### PR TITLE
feat(dsio.StructuredRowBuffer): added StructuredRowBuffer

### DIFF
--- a/dsfs/data.go
+++ b/dsfs/data.go
@@ -23,7 +23,7 @@ func LoadRows(store cafs.Filestore, ds *dataset.Dataset, limit, offset int) ([]b
 	}
 
 	added := 0
-	buf, err := dsio.NewBuffer(ds.Structure)
+	buf, err := dsio.NewStructuredBuffer(ds.Structure)
 	if err != nil {
 		return nil, fmt.Errorf("error loading dataset data: %s", err.Error())
 	}

--- a/dsfs/data_test.go
+++ b/dsfs/data_test.go
@@ -56,7 +56,8 @@ func TestLoadRows(t *testing.T) {
 		err           string
 	}{
 		// {"cities", 0, 0, "", ""},
-		{"cities", 2, 2, `chicago,300000,44.4,true
+		{"cities", 2, 2, `city,pop,avg_age,in_usa
+chicago,300000,44.4,true
 chatham,35000,65.25,true
 `, ""},
 		{"archive", 10, 0, `!OpenWayback-CDXJ 1.0

--- a/dsio/cdxj.go
+++ b/dsio/cdxj.go
@@ -25,8 +25,8 @@ func NewCDXJReader(st *dataset.Structure, r io.Reader) *CDXJReader {
 }
 
 // Structure gives this reader's structure
-func (r *CDXJReader) Structure() dataset.Structure {
-	return *r.st
+func (r *CDXJReader) Structure() *dataset.Structure {
+	return r.st
 }
 
 // ReadRow reads one CDXJ record from the reader
@@ -70,8 +70,8 @@ func NewCDXJWriter(st *dataset.Structure, w io.Writer) *CDXJWriter {
 }
 
 // Structure gives this writer's structure
-func (w *CDXJWriter) Structure() dataset.Structure {
-	return *w.st
+func (w *CDXJWriter) Structure() *dataset.Structure {
+	return w.st
 }
 
 // WriteRow writes one CDXJ record to the writer

--- a/dsio/cdxj_test.go
+++ b/dsio/cdxj_test.go
@@ -74,7 +74,7 @@ func TestCDXJWriter(t *testing.T) {
 		return
 	}
 	st := rw.Structure()
-	if err := dataset.CompareStructures(&st, cdxjStruct); err != nil {
+	if err := dataset.CompareStructures(st, cdxjStruct); err != nil {
 		t.Errorf("structure mismatch: %s", err.Error())
 		return
 	}

--- a/dsio/csv.go
+++ b/dsio/csv.go
@@ -22,8 +22,8 @@ func NewCSVReader(st *dataset.Structure, r io.Reader) *CSVReader {
 }
 
 // Structure gives this reader's structure
-func (r *CSVReader) Structure() dataset.Structure {
-	return *r.st
+func (r *CSVReader) Structure() *dataset.Structure {
+	return r.st
 }
 
 // ReadRow reads one CSV record from the reader
@@ -72,15 +72,24 @@ type CSVWriter struct {
 // NewCSVWriter creates a Writer from a structure and write destination
 func NewCSVWriter(st *dataset.Structure, w io.Writer) *CSVWriter {
 	writer := csv.NewWriter(w)
-	return &CSVWriter{
+	wr := &CSVWriter{
 		st: st,
 		w:  writer,
 	}
+
+	if CSVOpts, ok := st.FormatConfig.(*dataset.CSVOptions); ok {
+		if CSVOpts.HeaderRow {
+			// TODO - capture error
+			writer.Write(st.Schema.FieldNames())
+		}
+	}
+
+	return wr
 }
 
 // Structure gives this writer's structure
-func (w *CSVWriter) Structure() dataset.Structure {
-	return *w.st
+func (w *CSVWriter) Structure() *dataset.Structure {
+	return w.st
 }
 
 // WriteRow writes one CSV record to the writer

--- a/dsio/csv_test.go
+++ b/dsio/csv_test.go
@@ -2,12 +2,14 @@ package dsio
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/datatypes"
-	"testing"
 )
 
-const csvData = `a,b,c,d
+const csvData = `col_a,col_b,col_c,col_d
+a,b,c,d
 a,b,c,d
 a,b,c,d
 a,b,c,d
@@ -15,12 +17,15 @@ a,b,c,d`
 
 var csvStruct = &dataset.Structure{
 	Format: dataset.CSVDataFormat,
+	FormatConfig: &dataset.CSVOptions{
+		HeaderRow: true,
+	},
 	Schema: &dataset.Schema{
 		Fields: []*dataset.Field{
-			{Name: "a", Type: datatypes.String},
-			{Name: "b", Type: datatypes.String},
-			{Name: "c", Type: datatypes.String},
-			{Name: "d", Type: datatypes.String},
+			{Name: "col_a", Type: datatypes.String},
+			{Name: "col_b", Type: datatypes.String},
+			{Name: "col_c", Type: datatypes.String},
+			{Name: "col_d", Type: datatypes.String},
 		},
 	},
 }
@@ -71,7 +76,7 @@ func TestCSVWriter(t *testing.T) {
 		return
 	}
 	st := rw.Structure()
-	if err := dataset.CompareStructures(&st, csvStruct); err != nil {
+	if err := dataset.CompareStructures(st, csvStruct); err != nil {
 		t.Errorf("structure mismatch: %s", err.Error())
 		return
 	}
@@ -86,7 +91,6 @@ func TestCSVWriter(t *testing.T) {
 		t.Errorf("close reader error: %s", err.Error())
 		return
 	}
-
 	if bytes.Equal(buf.Bytes(), []byte(csvData)) {
 		t.Errorf("output mismatch. %s != %s", buf.String(), csvData)
 	}

--- a/dsio/dsio.go
+++ b/dsio/dsio.go
@@ -11,7 +11,7 @@ import (
 // RowWriter is a generalized interface for writing structured data
 type RowWriter interface {
 	// Structure gives the structure being written
-	Structure() dataset.Structure
+	Structure() *dataset.Structure
 	// WriteRow writes one row of structured data to the Writer
 	WriteRow(row [][]byte) error
 	// Close finalizes the writer, indicating all entries
@@ -22,7 +22,7 @@ type RowWriter interface {
 // RowReader is a generalized interface for reading Structured Data
 type RowReader interface {
 	// Structure gives the structure being read
-	Structure() dataset.Structure
+	Structure() *dataset.Structure
 	// ReadRow reads one row of structured data from the reader
 	ReadRow() ([][]byte, error)
 }
@@ -30,7 +30,7 @@ type RowReader interface {
 // RowReadWriter combines RowWriter and RowReader behaviors
 type RowReadWriter interface {
 	// Structure gives the structure being read and written
-	Structure() dataset.Structure
+	Structure() *dataset.Structure
 	// ReadRow reads one row of structured data from the reader
 	ReadRow() ([][]byte, error)
 	// WriteRow writes one row of structured data to the ReadWriter

--- a/dsio/json.go
+++ b/dsio/json.go
@@ -31,8 +31,8 @@ func NewJSONReader(st *dataset.Structure, r io.Reader) *JSONReader {
 }
 
 // Structure gives this writer's structure
-func (r *JSONReader) Structure() dataset.Structure {
-	return *r.st
+func (r *JSONReader) Structure() *dataset.Structure {
+	return r.st
 }
 
 // ReadRow reads one JSON record from the reader
@@ -112,6 +112,7 @@ LOOP:
 
 	// return sliced data
 	if starti < stopi {
+		// TODO - this should semantically advance past a comma or something...
 		return stopi + 1, data[starti:stopi], nil
 	}
 
@@ -142,8 +143,8 @@ func NewJSONWriter(st *dataset.Structure, w io.Writer) *JSONWriter {
 }
 
 // Structure gives this writer's structure
-func (w *JSONWriter) Structure() dataset.Structure {
-	return *w.st
+func (w *JSONWriter) Structure() *dataset.Structure {
+	return w.st
 }
 
 // WriteRow writes one JSON record to the writer

--- a/dsio/structured_buffer.go
+++ b/dsio/structured_buffer.go
@@ -2,26 +2,27 @@ package dsio
 
 import (
 	"bytes"
+
 	"github.com/qri-io/dataset"
 )
 
-// A Buffer mimics the behaviour of bytes.Buffer, but with structured Dataa
+// StructuredBuffer mimics the behaviour of bytes.Buffer, but with structured Dataa
 // Read and Write are replaced with ReadRow and WriteRow. It's worth noting
 // that different data formats have idisyncrcies that affect the behavior
-// of buffers and their output. For example, Buffer won't write things like
+// of buffers and their output. For example, StructuredBuffer won't write things like
 // CSV header rows or enclosing JSON arrays until after the writer's
 // Close method has been called.
-type Buffer struct {
+type StructuredBuffer struct {
 	structure *dataset.Structure
 	r         RowReader
 	w         RowWriter
 	buf       *bytes.Buffer
 }
 
-// NewBuffer allocates a buffer, buffers should always be created with
-// NewBuffer, which will error if the provided structure is invalid for
+// NewStructuredBuffer allocates a buffer, buffers should always be created with
+// NewStructuredBuffer, which will error if the provided structure is invalid for
 // reading / writing
-func NewBuffer(st *dataset.Structure) (*Buffer, error) {
+func NewStructuredBuffer(st *dataset.Structure) (*StructuredBuffer, error) {
 	buf := &bytes.Buffer{}
 	r, err := NewRowReader(st, buf)
 	if err != nil {
@@ -32,7 +33,7 @@ func NewBuffer(st *dataset.Structure) (*Buffer, error) {
 		return nil, err
 	}
 
-	return &Buffer{
+	return &StructuredBuffer{
 		structure: st,
 		r:         r,
 		w:         w,
@@ -41,27 +42,27 @@ func NewBuffer(st *dataset.Structure) (*Buffer, error) {
 }
 
 // Structure gives the underlying structure this buffer is using
-func (b *Buffer) Structure() dataset.Structure {
-	return *b.structure
+func (b *StructuredBuffer) Structure() *dataset.Structure {
+	return b.structure
 }
 
 // ReadRow reads one row from the buffer
-func (b *Buffer) ReadRow() ([][]byte, error) {
+func (b *StructuredBuffer) ReadRow() ([][]byte, error) {
 	return b.r.ReadRow()
 }
 
 // WriteRow writes one row to the buffer
-func (b *Buffer) WriteRow(row [][]byte) error {
+func (b *StructuredBuffer) WriteRow(row [][]byte) error {
 	return b.w.WriteRow(row)
 }
 
 // Close closes the writer portion of the buffer, which will affect
 // underlying contents.
-func (b *Buffer) Close() error {
+func (b *StructuredBuffer) Close() error {
 	return b.w.Close()
 }
 
 // Bytes gives the raw contents of the underlying buffer
-func (b *Buffer) Bytes() []byte {
+func (b *StructuredBuffer) Bytes() []byte {
 	return b.buf.Bytes()
 }

--- a/dsio/structured_buffer_test.go
+++ b/dsio/structured_buffer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/qri-io/dataset"
 )
 
-func TestBuffer(t *testing.T) {
+func TestStructuredBuffer(t *testing.T) {
 	datasets, err := makeTestData()
 	if err != nil {
 		t.Errorf("error creating filestore", err.Error())
@@ -29,9 +29,9 @@ func TestBuffer(t *testing.T) {
 		Schema: ds.Structure.Schema,
 	}
 
-	rbuf, err := NewBuffer(outst)
+	rbuf, err := NewStructuredBuffer(outst)
 	if err != nil {
-		t.Errorf("error allocating Buffer: %s", err.Error())
+		t.Errorf("error allocating StructuredBuffer: %s", err.Error())
 		return
 	}
 
@@ -52,7 +52,7 @@ func TestBuffer(t *testing.T) {
 	}
 
 	bst := rbuf.Structure()
-	if err := dataset.CompareStructures(outst, &bst); err != nil {
+	if err := dataset.CompareStructures(outst, bst); err != nil {
 		t.Errorf("buffer structure mismatch: %s", err.Error())
 		return
 	}

--- a/dsio/structured_row_buffer.go
+++ b/dsio/structured_row_buffer.go
@@ -1,0 +1,184 @@
+package dsio
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/datatypes"
+)
+
+// StructuredRowBuffer is the fully-featured version of StructuredBuffer
+type StructuredRowBuffer struct {
+	st   *dataset.Structure
+	rows [][][]byte
+	// buf    *StructuredBuffer
+	less   *func(i, j int) bool
+	unique bool
+	err    error
+}
+
+// StructuredRowBufferCfg encapsulates configuration for StructuredRowBuffer
+type StructuredRowBufferCfg struct {
+	// OrderBy
+	OrderBy     []*dataset.Field
+	OrderByDesc bool
+	// Unique silently rejects writing rows
+	// already present in the buffer
+	Unique bool
+	// TODO - FilterFunc
+	// FilterFunc func(row [][]byte) bool
+}
+
+// NewStructuredRowBuffer allocates a StructuredRowBuffer from a statement
+func NewStructuredRowBuffer(st *dataset.Structure, configs ...func(o *StructuredRowBufferCfg)) (*StructuredRowBuffer, error) {
+	cfg := &StructuredRowBufferCfg{}
+	for _, config := range configs {
+		config(cfg)
+	}
+
+	rb := &StructuredRowBuffer{
+		st:     st,
+		unique: cfg.Unique,
+	}
+	rb.less, rb.err = rb.makeLessFunc(st, cfg)
+
+	return rb, nil
+}
+
+// Structure gives the underlying structure this buffer is using
+func (rb *StructuredRowBuffer) Structure() *dataset.Structure {
+	return rb.st
+}
+
+// ReadRow reads one row from the buffer
+func (rb *StructuredRowBuffer) ReadRow() ([][]byte, error) {
+	return nil, fmt.Errorf("cannot read rows from a *StructuredRowBuffer, call Close() then Bytes() instead")
+}
+
+// WriteRow writes one row to the buffer
+func (rb *StructuredRowBuffer) WriteRow(row [][]byte) error {
+	if rb.unique && rb.HasRow(row) {
+		return nil
+	}
+	rb.rows = append(rb.rows, row)
+	return nil
+}
+
+// Close closes the writer portion of the buffer, which will affect
+// underlying contents.
+func (rb *StructuredRowBuffer) Close() error {
+	if rb.err != nil {
+		return rb.err
+	}
+	if rb.less != nil {
+		sort.Sort(rb)
+	}
+	return nil
+}
+
+// Bytes gives the raw contents of the underlying buffer
+func (rb *StructuredRowBuffer) Bytes() []byte {
+	buf, err := NewStructuredBuffer(rb.Structure())
+	if err != nil {
+		// shouldn't be possible
+		panic(err)
+	}
+	for _, row := range rb.rows {
+		if err := buf.WriteRow(row); err != nil {
+			return nil
+		}
+	}
+	if err := buf.Close(); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+// HasRow checks if a row is in the buffer or not
+func (rb *StructuredRowBuffer) HasRow(row [][]byte) bool {
+ROWS:
+	for _, r := range rb.rows {
+		if len(r) != len(row) {
+			return false
+		}
+		for i, cell := range row {
+			if !bytes.Equal(r[i], cell) {
+				continue ROWS
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// Len is the number of elements in the collection.
+func (rb *StructuredRowBuffer) Len() int {
+	return len(rb.rows)
+}
+
+// Less reports whether the element with
+// index i should sort before the element with index j.
+func (rb *StructuredRowBuffer) Less(i, j int) bool {
+	less := *rb.less
+	return less(i, j)
+}
+
+// Swap swaps the elements with indexes i and j.
+func (rb *StructuredRowBuffer) Swap(i, j int) {
+	rb.rows[i], rb.rows[j] = rb.rows[j], rb.rows[i]
+}
+
+func (rb *StructuredRowBuffer) makeLessFunc(st *dataset.Structure, cfg *StructuredRowBufferCfg) (*func(i, j int) bool, error) {
+	if len(cfg.OrderBy) == 0 {
+		return nil, nil
+	}
+
+	type order struct {
+		idx  int
+		desc bool
+		dt   datatypes.Type
+	}
+
+	if st.Schema == nil {
+		return nil, fmt.Errorf("structure has no schema")
+	}
+
+	orders := []order{}
+	for _, o := range cfg.OrderBy {
+		idx := -1
+		for i, f := range st.Schema.Fields {
+			if f == o || f.Name == o.Name {
+				idx = i
+				break
+			}
+		}
+
+		if idx < 0 {
+			return nil, fmt.Errorf("couldn't find sort field: %s", o.Name)
+		}
+
+		orders = append(orders, order{
+			idx:  idx,
+			desc: cfg.OrderByDesc,
+			dt:   st.Schema.Fields[idx].Type,
+		})
+	}
+
+	less := func(i, j int) bool {
+		for _, o := range orders {
+			l, err := datatypes.CompareTypeBytes(rb.rows[i][o.idx], rb.rows[j][o.idx], o.dt)
+			if err != nil {
+				continue
+			}
+			if (o.desc && l < 0) || l > 0 {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+
+	return &less, nil
+}

--- a/dsio/structured_row_buffer_test.go
+++ b/dsio/structured_row_buffer_test.go
@@ -1,0 +1,117 @@
+package dsio
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/qri-io/dataset"
+	dmp "github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func TestStructuredRowBuffer(t *testing.T) {
+	datasets, err := makeTestData()
+	if err != nil {
+		t.Errorf("error creating filestore", err.Error())
+		return
+	}
+
+	cases := []struct {
+		dsName     string
+		Cfg        func(cfg *StructuredRowBufferCfg)
+		resultPath string
+		// newErr     string
+	}{
+		{"movies", func(cfg *StructuredRowBufferCfg) {}, "testdata/movies.csv"},
+		{"movies", func(cfg *StructuredRowBufferCfg) {
+			cfg.OrderBy = []*dataset.Field{
+				&dataset.Field{Name: "movie_title"},
+			}
+		}, "testdata/movies_sorted_movie_title.csv"},
+	}
+
+	for i, c := range cases {
+		ds := datasets[c.dsName].ds
+		// if err != nil {
+		// 	t.Errorf("error creating dataset: %s", err.Error())
+		// 	return
+		// }
+
+		// outst := &dataset.Structure{
+		// 	Format: dataset.JSONDataFormat,
+		// 	FormatConfig: &dataset.JSONOptions{
+		// 		ArrayEntries: false,
+		// 	},
+		// 	Schema: ds.Structure.Schema,
+		// }
+
+		srbuf, err := NewStructuredRowBuffer(ds.Structure, c.Cfg)
+		if err != nil {
+			t.Errorf("case %d error allocating StructuredRowBuffer: %s", i, err.Error())
+			continue
+		}
+
+		rr, err := NewRowReader(ds.Structure, bytes.NewBuffer(datasets["movies"].data))
+		if err != nil {
+			t.Errorf("case %d error allocating RowReader: %s", i, err.Error())
+			continue
+		}
+
+		if err = EachRow(rr, func(i int, row [][]byte, err error) error {
+			if err != nil {
+				return err
+			}
+			return srbuf.WriteRow(row)
+		}); err != nil {
+			t.Errorf("error writing rows: %s", err.Error())
+			continue
+		}
+
+		srbufs := srbuf.Structure()
+		if err := dataset.CompareStructures(ds.Structure, srbufs); err != nil {
+			t.Errorf("case %d buffer structure mismatch: %s", i, err.Error())
+			continue
+		}
+
+		if err := srbuf.Close(); err != nil {
+			t.Errorf("case %d error closing buffer: %s", i, err.Error())
+			continue
+		}
+
+		if c.resultPath != "" {
+			expectBytes, err := ioutil.ReadFile(c.resultPath)
+			if err != nil {
+				t.Errorf("case %d error reading result data file: %s", i, err.Error())
+				continue
+			}
+			if !bytes.Equal(expectBytes, srbuf.Bytes()) {
+				dmp := dmp.New()
+				diffs := dmp.DiffMain(string(expectBytes), string(srbuf.Bytes()), true)
+				if len(diffs) == 0 {
+					t.Logf("case %d bytes were unequal but computed no difference between results")
+					continue
+				}
+
+				t.Errorf("case %d mismatch:\n%s", i, dmp.DiffPrettyText(diffs))
+				path := fmt.Sprintf("%sTestStructuredRowBuffer_case_%d_data.%s", os.TempDir(), i, ds.Structure.Format.String())
+				if err := ioutil.WriteFile(path, srbuf.Bytes(), os.ModePerm); err == nil {
+					t.Logf("result bytes written to: %s", path)
+				}
+			}
+		}
+
+	}
+
+	// out := []interface{}{}
+	// if err := json.Unmarshal(rbuf.Bytes(), &out); err != nil {
+	// 	t.Errorf("error unmarshaling encoded bytes: %s", err.Error())
+	// 	return
+	// }
+
+	// if _, err = json.Marshal(out); err != nil {
+	// 	t.Errorf("error marshaling json data: %s", err.Error())
+	// 	return
+	// }
+}

--- a/dsio/testdata/movies.json
+++ b/dsio/testdata/movies.json
@@ -8,7 +8,7 @@
     "schema": {
       "fields": [
         {
-          "name": "title",
+          "name": "movie_title",
           "type": "string"
         },
         {

--- a/dsio/testdata/movies_sorted_movie_title.csv
+++ b/dsio/testdata/movies_sorted_movie_title.csv
@@ -1,0 +1,20 @@
+movie_title,duration
+Avatar ,178
+Avengers: Age of Ultron ,141
+Batman v Superman: Dawn of Justice ,183
+Harry Potter and the Half-Blood Prince ,153
+John Carter ,132
+Man of Steel ,143
+Pirates of the Caribbean: At World's End ,169
+Pirates of the Caribbean: Dead Man's Chest ,151
+Pirates of the Caribbean: On Stranger Tides ,136
+Quantum of Solace ,106
+Spectre ,148
+Spider-Man 3 ,156
+Star Wars: Episode VII - The Force Awakens             ,
+Superman Returns ,169
+Tangled ,100
+The Avengers ,173
+The Chronicles of Narnia: Prince Caspian ,150
+The Dark Knight Rises ,164
+The Lone Ranger ,150

--- a/validate/data.go
+++ b/validate/data.go
@@ -81,7 +81,7 @@ func DataErrors(r dsio.RowReader, options ...func(*DataErrorsCfg)) (errors dsio.
 		vst.Schema.Fields = append(vst.Schema.Fields, &dataset.Field{Name: f.Name + "_error", Type: datatypes.String})
 	}
 
-	buf, err := dsio.NewBuffer(vst)
+	buf, err := dsio.NewStructuredBuffer(vst)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating a row buffer: %s", err.Error())
 	}


### PR DESCRIPTION
this commit extracts the basics of RowBuffer from the dataset_sql package
into the dsio package, allowing us to do things like sort data by fields
without having to move through the sql package.

BREAKING CHANGES:
* dsio.Buffer is now dsio.StructuredBuffer (for clarity)
* dsio.CSVWriter now writes a header line if the structure.FormatConfig
  indicates HeaderRow = true