### PR TITLE
refactor(dataset.Abstract): replace AbstractStructure with Abstract

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -14,8 +14,9 @@ import (
 type CommitMsg struct {
 	path    datastore.Key
 	Author  *User  `json:"author,omitempty"`
-	Title   string `json:"title"`
+	Kind    Kind   `json:"kind,omitempty"`
 	Message string `json:"message,omitempty"`
+	Title   string `json:"title"`
 }
 
 // NewCommitMsgRef creates an empty struct with it's
@@ -54,6 +55,9 @@ func (cm *CommitMsg) Assign(msgs ...*CommitMsg) {
 		if m.Message != "" {
 			cm.Message = m.Message
 		}
+		if m.Kind.String() != "" {
+			cm.Kind = m.Kind
+		}
 	}
 }
 
@@ -66,8 +70,9 @@ func (cm *CommitMsg) MarshalJSON() ([]byte, error) {
 	}
 	m := &_commitMsg{
 		Author:  cm.Author,
-		Title:   cm.Title,
+		Kind:    cm.Kind,
 		Message: cm.Message,
+		Title:   cm.Title,
 	}
 	return json.Marshal(m)
 }

--- a/dataset.go
+++ b/dataset.go
@@ -35,8 +35,8 @@ type Dataset struct {
 
 	// Structure of this dataset
 	Structure *Structure `json:"structure"`
-	// AbstractStructure is the abstract form of the structure field
-	AbstractStructure *Structure `json:"abstractStructure,omitempty"`
+	// Abstract is the abstract form of this dataset
+	Abstract *Dataset `json:"abstract,omitempty"`
 	// Transform is a path to the transformation that generated this resource
 	Transform *Transform `json:"transform,omitempty"`
 	// AbstractTransform is a reference to the general form of the transformation
@@ -115,18 +115,10 @@ func NewDatasetRef(path datastore.Key) *Dataset {
 	return &Dataset{path: path}
 }
 
-// Meta gives access to additional metadata not covered by dataset metadata
-func (ds *Dataset) Meta() map[string]interface{} {
-	if ds.meta == nil {
-		ds.meta = map[string]interface{}{}
-	}
-	return ds.meta
-}
-
 // Abstract returns a copy of dataset with all
 // semantically-identifiable and concrete references replaced with
 // uniform values
-func (ds *Dataset) Abstract() *Dataset {
+func Abstract(ds *Dataset) *Dataset {
 	abs := &Dataset{Kind: ds.Kind}
 
 	if ds.Structure != nil {
@@ -136,6 +128,14 @@ func (ds *Dataset) Abstract() *Dataset {
 		}
 	}
 	return abs
+}
+
+// Meta gives access to additional metadata not covered by dataset metadata
+func (ds *Dataset) Meta() map[string]interface{} {
+	if ds.meta == nil {
+		ds.meta = map[string]interface{}{}
+	}
+	return ds.meta
 }
 
 // Assign collapses all properties of a group of datasets onto one.
@@ -159,10 +159,10 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 			ds.Structure.Assign(d.Structure)
 		}
 
-		if ds.AbstractStructure == nil && d.AbstractStructure != nil {
-			ds.AbstractStructure = d.AbstractStructure
-		} else if ds.AbstractStructure != nil {
-			ds.AbstractStructure.Assign(d.AbstractStructure)
+		if ds.Abstract == nil && d.Abstract != nil {
+			ds.Abstract = d.Abstract
+		} else if ds.Abstract != nil {
+			ds.Abstract.Assign(d.Abstract)
 		}
 
 		if d.Data != "" {
@@ -254,8 +254,8 @@ func (ds *Dataset) MarshalJSON() ([]byte, error) {
 	if ds.AbstractTransform != nil {
 		data["abstractTransform"] = ds.AbstractTransform
 	}
-	if ds.AbstractStructure != nil {
-		data["abstractStructure"] = ds.AbstractStructure
+	if ds.Abstract != nil {
+		data["abstract"] = ds.Abstract
 	}
 	if ds.AccessURL != "" {
 		data["accessUrl"] = ds.AccessURL
@@ -363,7 +363,7 @@ func (ds *Dataset) UnmarshalJSON(data []byte) error {
 
 	for _, f := range []string{
 		"abstractTransform",
-		"abstractStructure",
+		"abstract",
 		"accessUrl",
 		"accrualPeriodicity",
 		"author",

--- a/dataset.go
+++ b/dataset.go
@@ -293,7 +293,7 @@ func (ds *Dataset) MarshalJSON() ([]byte, error) {
 	if ds.Keywords != nil {
 		data["keywords"] = ds.Keywords
 	}
-	data["kind"] = DatasetKind
+	data["kind"] = KindDataset
 	if ds.Language != nil {
 		data["language"] = ds.Language
 	}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -146,7 +146,7 @@ func TestDatasetUnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestDatasetAbstract(t *testing.T) {
+func TestAbstract(t *testing.T) {
 	cases := []struct {
 		FileName string
 		result   *Dataset
@@ -168,7 +168,7 @@ func TestDatasetAbstract(t *testing.T) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 			continue
 		}
-		abs := ds.Abstract()
+		abs := Abstract(ds)
 
 		if err = CompareDatasets(abs, c.result); err != nil {
 			t.Errorf("case %d resource comparison error: %s", i, err)

--- a/dsfs/commit_msg.go
+++ b/dsfs/commit_msg.go
@@ -19,6 +19,7 @@ func LoadCommitMsg(store cafs.Filestore, path datastore.Key) (st *dataset.Commit
 
 // SaveCommitMsg writes a commit message to a cafs
 func SaveCommitMsg(store cafs.Filestore, s *dataset.CommitMsg, pin bool) (path datastore.Key, err error) {
+	s.Kind = dataset.KindCommitMsg
 	file, err := jsonFile(PackageFileCommitMsg.String(), s)
 	if err != nil {
 		return datastore.NewKey(""), fmt.Errorf("error saving json commit file: %s", err.Error())

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -168,6 +168,7 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 	}
 
 	if ds.Commit != nil {
+		ds.Commit.Kind = dataset.KindCommitMsg
 		cmdata, err := json.Marshal(ds.Commit)
 		if err != nil {
 			return datastore.NewKey(""), fmt.Errorf("error marshilng dataset commit message to json: %s", err.Error())
@@ -216,14 +217,6 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 				ds.Transform = dataset.NewTransformRef(ao.Path)
 			case PackageFileAbstractTransform.String():
 				ds.AbstractTransform = dataset.NewTransformRef(ao.Path)
-				// if ds.Transform != nil {
-				// 	if f, err := transformFile(ds.Transform); err != nil {
-				// 		done <- fmt.Errorf("error generating transform file: %s", err.Error())
-				// 	} else {
-				// 		fileTasks++
-				// 		adder.AddFile(f)
-				// 	}
-				// }
 			case PackageFileCommitMsg.String():
 				ds.Commit = dataset.NewCommitMsgRef(ao.Path)
 			default:

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -120,16 +120,25 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 	// TODO - this might not constitute a valid dataset. should we be
 	// validating datasets in here?
 	if ds.Transform == nil && ds.Structure == nil {
-		fileTasks++
 		dsdata, err := json.Marshal(ds)
 		if err != nil {
 			return datastore.NewKey(""), fmt.Errorf("error marshaling dataset to json: %s", err.Error())
 		}
+		fileTasks++
 		adder.AddFile(memfs.NewMemfileBytes(PackageFileDataset.String(), dsdata))
 		addedDataset = true
 	}
 
 	if ds.Transform != nil {
+		// all resources must be references
+		for key, r := range ds.Transform.Resources {
+			if r.Path().String() == "" {
+				return datastore.NewKey(""), fmt.Errorf("transform resource %s requires a path to save", key)
+			}
+			if !r.IsEmpty() {
+				ds.Transform.Resources[key] = dataset.NewDatasetRef(r.Path())
+			}
+		}
 		qdata, err := json.Marshal(ds.Transform)
 		if err != nil {
 			return datastore.NewKey(""), fmt.Errorf("error marshaling dataset transform to json: %s", err.Error())
@@ -139,6 +148,17 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 	}
 
 	if ds.AbstractTransform != nil {
+		// ensure all dataset references are abstract
+		for key, r := range ds.AbstractTransform.Resources {
+			// ds.AbstractTransform.Resources[key]
+			absdata, err := json.Marshal(dataset.Abstract(r))
+			if err != nil {
+				return datastore.NewKey(""), fmt.Errorf("error marshaling dataset abstract to json: %s", err.Error())
+			}
+
+			fileTasks++
+			adder.AddFile(memfs.NewMemfileBytes(fmt.Sprintf("%s_abst.json", key), absdata))
+		}
 		qdata, err := json.Marshal(ds.AbstractTransform)
 		if err != nil {
 			return datastore.NewKey(""), fmt.Errorf("error marshaling dataset abstract transform to json: %s", err.Error())
@@ -164,12 +184,12 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 		fileTasks++
 		adder.AddFile(memfs.NewMemfileBytes(PackageFileStructure.String(), stdata))
 
-		asdata, err := json.Marshal(ds.Structure.Abstract())
+		asdata, err := json.Marshal(dataset.Abstract(ds))
 		if err != nil {
-			return datastore.NewKey(""), fmt.Errorf("error marshaling dataset abstract structure to json: %s", err.Error())
+			return datastore.NewKey(""), fmt.Errorf("error marshaling dataset abstract to json: %s", err.Error())
 		}
 		fileTasks++
-		adder.AddFile(memfs.NewMemfileBytes(PackageFileAbstractStructure.String(), asdata))
+		adder.AddFile(memfs.NewMemfileBytes(PackageFileAbstract.String(), asdata))
 
 		data, err := store.Get(datastore.NewKey(ds.Data))
 		if err != nil {
@@ -190,23 +210,30 @@ func SaveDataset(store cafs.Filestore, ds *dataset.Dataset, pin bool) (datastore
 			switch ao.Name {
 			case PackageFileStructure.String():
 				ds.Structure = dataset.NewStructureRef(ao.Path)
-			case PackageFileAbstractStructure.String():
-				ds.AbstractStructure = dataset.NewStructureRef(ao.Path)
+			case PackageFileAbstract.String():
+				ds.Abstract = dataset.NewDatasetRef(ao.Path)
 			case PackageFileTransform.String():
 				ds.Transform = dataset.NewTransformRef(ao.Path)
 			case PackageFileAbstractTransform.String():
 				ds.AbstractTransform = dataset.NewTransformRef(ao.Path)
-				if ds.Transform != nil {
-					if f, err := transformFile(ds.Transform); err != nil {
-						done <- fmt.Errorf("error generating transform file: %s", err.Error())
-					} else {
-						fileTasks++
-						adder.AddFile(f)
-					}
-				}
+				// if ds.Transform != nil {
+				// 	if f, err := transformFile(ds.Transform); err != nil {
+				// 		done <- fmt.Errorf("error generating transform file: %s", err.Error())
+				// 	} else {
+				// 		fileTasks++
+				// 		adder.AddFile(f)
+				// 	}
+				// }
 			case PackageFileCommitMsg.String():
 				ds.Commit = dataset.NewCommitMsgRef(ao.Path)
-				// case "resources":
+			default:
+				if ds.AbstractTransform != nil {
+					for key := range ds.AbstractTransform.Resources {
+						if ao.Name == fmt.Sprintf("%s_abst.json", key) {
+							ds.AbstractTransform.Resources[key] = dataset.NewDatasetRef(ao.Path)
+						}
+					}
+				}
 			}
 
 			fileTasks--

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -2,7 +2,6 @@ package dsfs
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
@@ -43,10 +42,12 @@ func TestDatasetSave(t *testing.T) {
 				Fields: []*dataset.Field{},
 			},
 		},
-		AbstractStructure: &dataset.Structure{
-			Format: dataset.CSVDataFormat,
-			Schema: &dataset.Schema{
-				Fields: []*dataset.Field{},
+		Abstract: &dataset.Dataset{
+			Structure: &dataset.Structure{
+				Format: dataset.CSVDataFormat,
+				Schema: &dataset.Schema{
+					Fields: []*dataset.Field{},
+				},
 			},
 		},
 		Transform: &dataset.Transform{
@@ -82,15 +83,15 @@ func TestDatasetSave(t *testing.T) {
 		return
 	}
 
-	hash := "/map/QmQ42yS6gQ2LNywxKuwwyJnMGKeKtnkKXwn5j41V4AixyR"
+	hash := "/map/QmUHnEPuYbp2QtC8PmawZn6vKYyy5BqYMmiPACDB81WNQ5"
 	if hash != key.String() {
 		t.Errorf("key mismatch: %s != %s", hash, key.String())
 		return
 	}
 
-	expectedEntries := 5
+	expectedEntries := 7
 	if len(store.(memfs.MapStore)) != expectedEntries {
-		t.Error("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(memfs.MapStore)))
+		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(memfs.MapStore)))
 		return
 	}
 
@@ -106,9 +107,6 @@ func TestDatasetSave(t *testing.T) {
 		return
 	}
 
-	rd, _ := result.MarshalJSON()
-	fmt.Println(string(rd))
-
 	if !result.Transform.IsEmpty() {
 		t.Errorf("expected stored dataset.Transform to be a reference")
 	}
@@ -118,8 +116,8 @@ func TestDatasetSave(t *testing.T) {
 	if !result.Structure.IsEmpty() {
 		t.Errorf("expected stored dataset.Structure to be a reference")
 	}
-	if !result.AbstractStructure.IsEmpty() {
-		t.Errorf("expected stored dataset.AbstractStructure to be a reference")
+	if !result.Abstract.IsEmpty() {
+		t.Errorf("expected stored dataset.Abstract to be a reference")
 	}
 
 	qf, err := store.Get(result.Transform.Path())

--- a/dsfs/package.go
+++ b/dsfs/package.go
@@ -16,9 +16,9 @@ const (
 	// PackageFileStructure isolates this dataset's structure
 	// in it's own file
 	PackageFileStructure
-	// PackageFileAbstractStructure is the abstract verion of
+	// PackageFileAbstract is the abstract verion of
 	// structure
-	PackageFileAbstractStructure
+	PackageFileAbstract
 	// PackageFileResources lists the resource datasets
 	// that went into creating a dataset
 	// TODO - I think this can be removed now that Transform exists
@@ -39,7 +39,7 @@ var filenames = map[PackageFile]string{
 	PackageFileUnknown:           "",
 	PackageFileDataset:           "dataset.json",
 	PackageFileStructure:         "structure.json",
-	PackageFileAbstractStructure: "abstract_structure.json",
+	PackageFileAbstract:          "abstract.json",
 	PackageFileAbstractTransform: "abstract_transform.json",
 	PackageFileResources:         "resources",
 	PackageFileCommitMsg:         "commit.json",

--- a/dsfs/structure.go
+++ b/dsfs/structure.go
@@ -19,6 +19,7 @@ func LoadStructure(store cafs.Filestore, path datastore.Key) (st *dataset.Struct
 
 // SaveStructure saves a query's structure to a given store
 func SaveStructure(store cafs.Filestore, s *dataset.Structure, pin bool) (path datastore.Key, err error) {
+	s.Kind = dataset.KindStructure
 	file, err := jsonFile(PackageFileStructure.String(), s)
 	if err != nil {
 		return datastore.NewKey(""), fmt.Errorf("error saving json structure file: %s", err.Error())

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -25,7 +25,7 @@ func TestLoadTransform(t *testing.T) {
 	// TODO - other tests & stuff
 }
 
-func TestTransformLoadAbstractStructures(t *testing.T) {
+func TestTransformLoadAbstract(t *testing.T) {
 	// store := datastore.NewMapDatastore()
 	// TODO - finish dis test
 }

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -2,6 +2,7 @@ package dsfs
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
@@ -30,22 +31,19 @@ func TestTransformLoadAbstract(t *testing.T) {
 	// TODO - finish dis test
 }
 
-func TestTransformSave(t *testing.T) {
+func TestSaveTransform(t *testing.T) {
 	dsa := dataset.NewDatasetRef(datastore.NewKey("/path/to/dataset/a"))
 	dsa.Assign(&dataset.Dataset{Title: "now dataset isn't empty "})
 
 	store := memfs.NewMapstore()
 	q := &dataset.Transform{
-		Syntax:    "sweet syntax",
-		Structure: &dataset.Structure{Format: dataset.CSVDataFormat, Schema: &dataset.Schema{Fields: []*dataset.Field{{Name: "its_a_field"}}}},
-		// Abstract: &dataset.AbstractTransform{
-		// 	Syntax:    "sweet syntax",
-		// 	Statement: "select * from a",
-		// 	Structure: &dataset.Structure{Format: dataset.CSVDataFormat, Schema: &dataset.Schema{Fields: []*dataset.Field{{Name: "its_a_field"}}}},
-		// 	Structures: map[string]*dataset.Structure{
-		// 		"a": {Format: dataset.CSVDataFormat, Schema: &dataset.Schema{Fields: []*dataset.Field{{Name: "its_a_field"}}}},
-		// 	},
-		// },
+		Syntax: "sweet syntax",
+		Structure: &dataset.Structure{
+			Format: dataset.CSVDataFormat,
+			Schema: &dataset.Schema{
+				Fields: []*dataset.Field{{Name: "its_a_field"}},
+			},
+		},
 		Resources: map[string]*dataset.Dataset{
 			"a": dsa,
 		},
@@ -57,7 +55,7 @@ func TestTransformSave(t *testing.T) {
 		return
 	}
 
-	hash := "/map/QmaNayr7fAA9DyQ8q9nbfjECiYWGLNpdk2yk77uvxq6LLJ"
+	hash := "/map/QmTEv2cgNgqQZ4MiCmNqKJVj88kG3ZsnkY5GabgMifApXQ"
 	if hash != key.String() {
 		t.Errorf("key mismatch: %s != %s", hash, key.String())
 		return
@@ -81,9 +79,73 @@ func TestTransformSave(t *testing.T) {
 		return
 	}
 
-	// if !res.Abstract.IsEmpty() {
-	// 	t.Errorf("expected stored transform.Abstract to be a reference")
-	// }
+	if !res.Structure.IsEmpty() {
+		t.Errorf("expected stored transform.Structure to be a reference")
+	}
+	for name, ref := range res.Resources {
+		if !ref.IsEmpty() {
+			t.Errorf("expected stored transform reference '%s' to be empty", name)
+		}
+	}
+}
+
+func TestSaveAbstractTransform(t *testing.T) {
+	dsa := dataset.NewDatasetRef(datastore.NewKey("/path/to/dataset/a"))
+	dsa.Assign(&dataset.Dataset{Title: "now dataset isn't empty "})
+	dsa.Structure = &dataset.Structure{
+		Format: dataset.CSVDataFormat,
+		Schema: &dataset.Schema{
+			Fields: []*dataset.Field{{Name: "its_a_field"}},
+		},
+	}
+
+	store := memfs.NewMapstore()
+	q := &dataset.Transform{
+		Syntax: "sweet syntax",
+		Structure: &dataset.Structure{
+			Format: dataset.CSVDataFormat,
+			Schema: &dataset.Schema{
+				Fields: []*dataset.Field{{Name: "its_a_field"}},
+			},
+		},
+		Resources: map[string]*dataset.Dataset{
+			"a": dsa,
+		},
+	}
+
+	key, err := SaveAbstractTransform(store, q, true)
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	hash := "/map/QmWVQ6Nh1H1Nz44W6imwzSvn1hHcsjhchh21txgP73QMU7"
+	if hash != key.String() {
+		t.Errorf("key mismatch: %s != %s", hash, key.String())
+		return
+	}
+
+	expectedEntries := 3
+	if len(store.(memfs.MapStore)) != expectedEntries {
+		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(memfs.MapStore)))
+		return
+	}
+
+	f, err := store.Get(datastore.NewKey(hash))
+	if err != nil {
+		t.Errorf("error getting dataset file: %s", err.Error())
+		return
+	}
+
+	res := &dataset.Transform{}
+	if err := json.NewDecoder(f).Decode(res); err != nil {
+		t.Errorf("error decoding transform json: %s", err.Error())
+		return
+	}
+
+	data, _ := res.MarshalJSON()
+	fmt.Println(string(data))
+
 	if !res.Structure.IsEmpty() {
 		t.Errorf("expected stored transform.Structure to be a reference")
 	}

--- a/dsgraph/graph.go
+++ b/dsgraph/graph.go
@@ -9,6 +9,8 @@ var (
 	// NtDataset is a holistic reference to a dataset,
 	// aka the base hash of a dataset
 	NtDataset = NodeType("dataset")
+	// NtAbstDataset is the abstract form of a dataset
+	NtAbstDataset = NodeType("abst_dataset")
 	// NtMetadata is the dataset.json file in a dataset
 	NtMetadata = NodeType("metadata")
 	// NtCommit is the commit.json file in a dataset

--- a/kind.go
+++ b/kind.go
@@ -12,13 +12,21 @@ const CurrentSpecVersion = "0"
 // definition from other formats
 const KindPrefix = "qri:"
 
-// DatasetKind is the current kind for datasets
-const DatasetKind = Kind("qri:ds:0")
+const (
+	// KindDataset is the current kind for datasets
+	KindDataset = Kind("qri:ds:0")
+	// KindStructure is the current kind for dataset structures
+	KindStructure = Kind("qri:st:0")
+	// KindTransform is the current kind for dataset transforms
+	KindTransform = Kind("qri:tf:0")
+	// KindCommitMsg is the current kind for dataset transforms
+	KindCommitMsg = Kind("qri:cm:0")
+)
 
 // Kind is a short identifier for all types of qri dataset objects
 // Kind does three things:
 // 1. Distinguish qri datasets from other formats
-// 2. Distinguish different types (Dataset/Structure/Process)
+// 2. Distinguish different types (Dataset/Structure/Transform)
 // 3. Distinguish between versions of the dataset spec
 // Kind is a string in the format qri:ds:[version]
 type Kind string

--- a/structure.go
+++ b/structure.go
@@ -17,6 +17,8 @@ import (
 type Structure struct {
 	// private storage for reference to this object
 	path datastore.Key
+	// Kind should always be KindStructure
+	Kind
 	// Format specifies the format of the raw data MIME type
 	Format DataFormat `json:"format"`
 	// FormatConfig removes as much ambiguity as possible about how

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 var AirportCodes = &Dataset{
-	Kind:     DatasetKind,
+	Kind:     KindDataset,
 	Title:    "Airport Codes",
 	Homepage: "http://www.ourairports.com/",
 	License: &License{
@@ -25,7 +25,7 @@ var AirportCodes = &Dataset{
 }
 
 var AirportCodesAbstract = &Dataset{
-	Kind:      DatasetKind,
+	Kind:      KindDataset,
 	Structure: AirportCodesStructureAbstract,
 }
 
@@ -157,7 +157,7 @@ var AirportCodesStructureAbstract = &Structure{
 
 var ContinentCodes = &Dataset{
 	Title:       "Continent Codes",
-	Kind:        DatasetKind,
+	Kind:        KindDataset,
 	Description: "list of continents with corresponding two letter codes",
 	License: &License{
 		Type: "odc-pddl",
@@ -189,7 +189,7 @@ var ContinentCodesStructure = &Structure{
 
 var Hours = &Dataset{
 	Title: "hours",
-	Kind:  DatasetKind,
+	Kind:  KindDataset,
 	// Data:   datastore.NewKey("/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"),
 }
 

--- a/transform.go
+++ b/transform.go
@@ -88,6 +88,9 @@ func (q *Transform) Assign(qs ...*Transform) {
 			}
 			q.Structure.Assign(q2.Structure)
 		}
+		if q2.Data != "" {
+			q.Data = q2.Data
+		}
 		if q2.Resources != nil {
 			if q.Resources == nil {
 				q.Resources = map[string]*Dataset{}

--- a/transform.go
+++ b/transform.go
@@ -18,7 +18,8 @@ import (
 type Transform struct {
 	// private storage for reference to this object
 	path datastore.Key
-
+	// Kind should always equal KindTransform
+	Kind `json:"kind,omitempty"`
 	// Syntax this transform was written in
 	Syntax string `json:"syntax,omitempty"`
 	// AppVersion is an identifier for the application and version number that produced the result
@@ -104,6 +105,7 @@ type _transform struct {
 	AppVersion string                 `json:"appVersion,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
 	Data       string                 `json:"data,omitempty"`
+	Kind       Kind                   `json:"kind,omitempty"`
 	Resources  map[string]*Dataset    `json:"resources,omitempty"`
 	Structure  *Structure             `json:"structure,omitempty"`
 	Syntax     string                 `json:"syntax,omitempty"`
@@ -120,6 +122,7 @@ func (q Transform) MarshalJSON() ([]byte, error) {
 		AppVersion: q.AppVersion,
 		Config:     q.Config,
 		Data:       q.Data,
+		Kind:       q.Kind,
 		Resources:  q.Resources,
 		Structure:  q.Structure,
 		Syntax:     q.Syntax,
@@ -143,6 +146,7 @@ func (q *Transform) UnmarshalJSON(data []byte) error {
 		AppVersion: _q.AppVersion,
 		Config:     _q.Config,
 		Data:       _q.Data,
+		Kind:       _q.Kind,
 		Resources:  _q.Resources,
 		Structure:  _q.Structure,
 		Syntax:     _q.Syntax,


### PR DESCRIPTION
In what feels like a final piece of the white paper puzzle,
abstract interoperability comparison will now be done with
abstract datasets instead of raw abstract structures.
Datasets now keep an Abstract field, which is the result of
calling Abstract on the dataset itself.

Abstract datasets are currently just their structure, abstracted,
and a dataset kind identifier. This makes it a valid dataset,
gives us the capacity to break hashes on version changes (for all
the mistakes the spec undoubtly contains).

The real win here comes in generating abstract transforms from
concrete transforms, which is now just a process of calling
Abstract on the resources, and means that there's no need for
a structural difference between abstract & concrete transforms.
