### PR TITLE
refactor(dataset.Metadata): move all human-interest metadata into it's own struct

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -8,11 +8,11 @@ import (
 	"github.com/ipfs/go-datastore"
 )
 
-// CommitMsg encapsulates information about changes to a dataset in
-// relation to other entries in a given history. CommitMsg is intended
+// Commit encapsulates information about changes to a dataset in
+// relation to other entries in a given history. Commit is intended
 // to be directly analogous to the concept of a Commit Message in the
 // git version control system
-type CommitMsg struct {
+type Commit struct {
 	path    datastore.Key
 	Author  *User  `json:"author,omitempty"`
 	Kind    Kind   `json:"kind,omitempty"`
@@ -22,25 +22,25 @@ type CommitMsg struct {
 	Title     string    `json:"title"`
 }
 
-// NewCommitMsgRef creates an empty struct with it's
+// NewCommitRef creates an empty struct with it's
 // internal path set
-func NewCommitMsgRef(path datastore.Key) *CommitMsg {
-	return &CommitMsg{path: path}
+func NewCommitRef(path datastore.Key) *Commit {
+	return &Commit{path: path}
 }
 
 // IsEmpty checks to see if any fields are filled out
-func (cm *CommitMsg) IsEmpty() bool {
+func (cm *Commit) IsEmpty() bool {
 	return cm.Message == "" && cm.Author == nil
 }
 
 // Path returns the internal path of this commitMsg
-func (cm *CommitMsg) Path() datastore.Key {
+func (cm *Commit) Path() datastore.Key {
 	return cm.path
 }
 
-// Assign collapses all properties of a set of CommitMsg onto one.
+// Assign collapses all properties of a set of Commit onto one.
 // this is directly inspired by Javascript's Object.assign
-func (cm *CommitMsg) Assign(msgs ...*CommitMsg) {
+func (cm *Commit) Assign(msgs ...*Commit) {
 	for _, m := range msgs {
 		if m == nil {
 			continue
@@ -67,17 +67,17 @@ func (cm *CommitMsg) Assign(msgs ...*CommitMsg) {
 	}
 }
 
-// MarshalJSON implements the json.Marshaler interface for CommitMsg
-// Empty CommitMsg instances with a non-empty path marshal to their path value
-// otherwise, CommitMsg marshals to an object
-func (cm *CommitMsg) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaler interface for Commit
+// Empty Commit instances with a non-empty path marshal to their path value
+// otherwise, Commit marshals to an object
+func (cm *Commit) MarshalJSON() ([]byte, error) {
 	if cm.path.String() != "" && cm.IsEmpty() {
 		return cm.path.MarshalJSON()
 	}
 
 	kind := cm.Kind
 	if kind == "" {
-		kind = KindCommitMsg
+		kind = KindCommit
 	}
 
 	m := &_commitMsg{
@@ -91,14 +91,14 @@ func (cm *CommitMsg) MarshalJSON() ([]byte, error) {
 }
 
 // internal struct for json unmarshaling
-type _commitMsg CommitMsg
+type _commitMsg Commit
 
-// UnmarshalJSON implements json.Unmarshaller for CommitMsg
-func (cm *CommitMsg) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements json.Unmarshaller for Commit
+func (cm *Commit) UnmarshalJSON(data []byte) error {
 	// first check to see if this is a valid path ref
 	var path string
 	if err := json.Unmarshal(data, &path); err == nil {
-		*cm = CommitMsg{path: datastore.NewKey(path)}
+		*cm = Commit{path: datastore.NewKey(path)}
 		return nil
 	}
 
@@ -107,20 +107,20 @@ func (cm *CommitMsg) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("error unmarshling dataset: %s", err.Error())
 	}
 
-	*cm = CommitMsg(m)
+	*cm = Commit(m)
 	return nil
 }
 
-// UnmarshalCommitMsg tries to extract a dataset type from an empty
+// UnmarshalCommit tries to extract a dataset type from an empty
 // interface. Pairs nicely with datastore.Get() from github.com/ipfs/go-datastore
-func UnmarshalCommitMsg(v interface{}) (*CommitMsg, error) {
+func UnmarshalCommit(v interface{}) (*Commit, error) {
 	switch r := v.(type) {
-	case *CommitMsg:
+	case *Commit:
 		return r, nil
-	case CommitMsg:
+	case Commit:
 		return &r, nil
 	case []byte:
-		cm := &CommitMsg{}
+		cm := &Commit{}
 		err := json.Unmarshal(r, cm)
 		return cm, err
 	default:

--- a/commit.go
+++ b/commit.go
@@ -3,6 +3,7 @@ package dataset
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 )
@@ -16,7 +17,9 @@ type CommitMsg struct {
 	Author  *User  `json:"author,omitempty"`
 	Kind    Kind   `json:"kind,omitempty"`
 	Message string `json:"message,omitempty"`
-	Title   string `json:"title"`
+	// Time this dataset was created. Required. Datasets are immutable, so no "updated"
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Title     string    `json:"title"`
 }
 
 // NewCommitMsgRef creates an empty struct with it's
@@ -52,6 +55,9 @@ func (cm *CommitMsg) Assign(msgs ...*CommitMsg) {
 		if m.Title != "" {
 			cm.Title = m.Title
 		}
+		if !m.Timestamp.IsZero() {
+			cm.Timestamp = m.Timestamp
+		}
 		if m.Message != "" {
 			cm.Message = m.Message
 		}
@@ -75,10 +81,11 @@ func (cm *CommitMsg) MarshalJSON() ([]byte, error) {
 	}
 
 	m := &_commitMsg{
-		Author:  cm.Author,
-		Kind:    kind,
-		Message: cm.Message,
-		Title:   cm.Title,
+		Author:    cm.Author,
+		Kind:      kind,
+		Message:   cm.Message,
+		Timestamp: cm.Timestamp,
+		Title:     cm.Title,
 	}
 	return json.Marshal(m)
 }

--- a/commit_test.go
+++ b/commit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 )
@@ -20,13 +21,15 @@ func TestCommitMsg(t *testing.T) {
 }
 
 func TestCommitMsgAssign(t *testing.T) {
+	t1 := time.Now()
 	doug := &User{ID: "doug_id", Email: "doug@example.com"}
 	expect := &CommitMsg{
-		path:    datastore.NewKey("a"),
-		Kind:    KindCommitMsg,
-		Author:  doug,
-		Title:   "expect title",
-		Message: "expect message",
+		path:      datastore.NewKey("a"),
+		Kind:      KindCommitMsg,
+		Author:    doug,
+		Timestamp: t1,
+		Title:     "expect title",
+		Message:   "expect message",
 	}
 	got := &CommitMsg{
 		Author:  &User{ID: "maha_id", Email: "maha@example.com"},
@@ -39,8 +42,9 @@ func TestCommitMsgAssign(t *testing.T) {
 		Kind:   KindCommitMsg,
 		Title:  "expect title",
 	}, &CommitMsg{
-		path:    datastore.NewKey("a"),
-		Message: "expect message",
+		path:      datastore.NewKey("a"),
+		Timestamp: t1,
+		Message:   "expect message",
 	})
 
 	if err := CompareCommitMsgs(expect, got); err != nil {
@@ -60,13 +64,14 @@ func TestCommitMsgAssign(t *testing.T) {
 }
 
 func TestCommitMsgMarshalJSON(t *testing.T) {
+	ts := time.Date(2001, 01, 01, 01, 01, 01, 0, time.UTC)
 	cases := []struct {
 		in  *CommitMsg
 		out []byte
 		err error
 	}{
-		{&CommitMsg{Title: "title"}, []byte(`{"kind":"qri:cm:0","title":"title"}`), nil},
-		{&CommitMsg{Author: &User{ID: "foo"}}, []byte(`{"author":{"id":"foo"},"kind":"qri:cm:0","title":""}`), nil},
+		{&CommitMsg{Title: "title", Timestamp: ts}, []byte(`{"kind":"qri:cm:0","timestamp":"2001-01-01T01:01:01Z","title":"title"}`), nil},
+		{&CommitMsg{Author: &User{ID: "foo"}, Timestamp: ts}, []byte(`{"author":{"id":"foo"},"kind":"qri:cm:0","timestamp":"2001-01-01T01:01:01Z","title":""}`), nil},
 	}
 
 	for i, c := range cases {

--- a/compare.go
+++ b/compare.go
@@ -45,7 +45,7 @@ func CompareDatasets(a, b *Dataset) error {
 	if err := CompareTransforms(a.AbstractTransform, b.AbstractTransform); err != nil {
 		return fmt.Errorf("AbstractTransform: %s", err.Error())
 	}
-	if err := CompareCommitMsgs(a.Commit, b.Commit); err != nil {
+	if err := CompareCommits(a.Commit, b.Commit); err != nil {
 		return fmt.Errorf("Commit: %s", err.Error())
 	}
 
@@ -219,9 +219,9 @@ func CompareFields(a, b *Field) error {
 	return nil
 }
 
-// CompareCommitMsgs checks if all fields of a CommitMsg are equal,
+// CompareCommits checks if all fields of a Commit are equal,
 // returning an error on the first, nil if equal
-func CompareCommitMsgs(a, b *CommitMsg) error {
+func CompareCommits(a, b *Commit) error {
 	if a == nil && b == nil {
 		return nil
 	} else if a == nil && b != nil {

--- a/compare.go
+++ b/compare.go
@@ -22,44 +22,74 @@ func CompareDatasets(a, b *Dataset) error {
 	if a.Kind.String() != b.Kind.String() {
 		return fmt.Errorf("Kind: %s != %s", a.Kind, b.Kind)
 	}
-	if !a.Timestamp.Equal(b.Timestamp) {
-		return fmt.Errorf("Timestamp: %s != %s", a.Timestamp, b.Timestamp)
+
+	if a.PreviousPath != b.PreviousPath {
+		return fmt.Errorf("PreviousPath: %s != %s", a.PreviousPath, b.PreviousPath)
 	}
-	if a.Length != b.Length {
-		return fmt.Errorf("Length: %d != %d", a.Length, b.Length)
+	if a.DataPath != b.DataPath {
+		return fmt.Errorf("DataPath: %s != %s", a.DataPath, b.DataPath)
 	}
-	if a.Rows != b.Rows {
-		return fmt.Errorf("Rows: %d != %d", a.Rows, b.Rows)
+
+	if err := CompareMetadatas(a.Metadata, b.Metadata); err != nil {
+		return fmt.Errorf("Metadata: %s", err.Error())
+	}
+	if err := CompareStructures(a.Structure, b.Structure); err != nil {
+		return fmt.Errorf("Structure: %s", err.Error())
+	}
+	if err := CompareDatasets(a.Abstract, b.Abstract); err != nil {
+		return fmt.Errorf("Abstract: %s", err.Error())
+	}
+	if err := CompareTransforms(a.Transform, b.Transform); err != nil {
+		return fmt.Errorf("Transform: %s", err.Error())
+	}
+	if err := CompareTransforms(a.AbstractTransform, b.AbstractTransform); err != nil {
+		return fmt.Errorf("AbstractTransform: %s", err.Error())
+	}
+	if err := CompareCommitMsgs(a.Commit, b.Commit); err != nil {
+		return fmt.Errorf("Commit: %s", err.Error())
+	}
+
+	return nil
+}
+
+// CompareMetadatas checks if all fields of a metadata struct are equal,
+// returning an error on the first, nil if equal
+func CompareMetadatas(a, b *Metadata) error {
+	if a == nil && b == nil {
+		return nil
+	}
+	if a == nil && b != nil {
+		return fmt.Errorf("nil: <nil> != <not nil>")
+	} else if a != nil && b == nil {
+		return fmt.Errorf("nil: <not nil> != <nil>")
+	}
+
+	if !a.Path().Equal(b.Path()) {
+		return fmt.Errorf("Path: %s != %s", a.Path(), b.Path())
+	}
+	if a.Kind.String() != b.Kind.String() {
+		return fmt.Errorf("Kind: %s != %s", a.Kind, b.Kind)
 	}
 	if a.Title != b.Title {
 		return fmt.Errorf("Title: %s != %s", a.Title, b.Title)
 	}
-	if a.AccessURL != b.AccessURL {
-		return fmt.Errorf("AccessURL: %s != %s", a.AccessURL, b.AccessURL)
+	if a.AccessPath != b.AccessPath {
+		return fmt.Errorf("AccessPath: %s != %s", a.AccessPath, b.AccessPath)
 	}
-	if a.DownloadURL != b.DownloadURL {
-		return fmt.Errorf("DownloadURL: %s != %s", a.DownloadURL, b.DownloadURL)
+	if a.DownloadPath != b.DownloadPath {
+		return fmt.Errorf("DownloadPath: %s != %s", a.DownloadPath, b.DownloadPath)
 	}
 	if a.AccrualPeriodicity != b.AccrualPeriodicity {
 		return fmt.Errorf("AccrualPeriodicity: %s != %s", a.AccrualPeriodicity, b.AccrualPeriodicity)
 	}
-	if a.Readme != b.Readme {
-		return fmt.Errorf("Readme: %s != %s", a.Readme, b.Readme)
-	}
-	if a.Author != b.Author {
-		return fmt.Errorf("Author: %s != %s", a.Author, b.Author)
-	}
-	if a.Image != b.Image {
-		return fmt.Errorf("Image: %s != %s", a.Image, b.Image)
+	if a.ReadmePath != b.ReadmePath {
+		return fmt.Errorf("ReadmePath: %s != %s", a.ReadmePath, b.ReadmePath)
 	}
 	if a.Description != b.Description {
 		return fmt.Errorf("Description: %s != %s", a.Description, b.Description)
 	}
-	if a.Homepage != b.Homepage {
-		return fmt.Errorf("Homepage: %s != %s", a.Homepage, b.Homepage)
-	}
-	if a.IconImage != b.IconImage {
-		return fmt.Errorf("IconImage: %s != %s", a.IconImage, b.IconImage)
+	if a.HomePath != b.HomePath {
+		return fmt.Errorf("HomePath: %s != %s", a.HomePath, b.HomePath)
 	}
 	if a.Identifier != b.Identifier {
 		return fmt.Errorf("Identifier: %s != %s", a.Identifier, b.Identifier)
@@ -82,38 +112,11 @@ func CompareDatasets(a, b *Dataset) error {
 	if err := CompareStringSlices(a.Theme, b.Theme); err != nil {
 		return fmt.Errorf("Theme: %s", err.Error())
 	}
-	if a.QueryString != b.QueryString {
-		return fmt.Errorf("QueryString: %s != %s", a.QueryString, b.QueryString)
-	}
 
 	// TODO - currently we're ignoring abitrary metadata differences
 	// if err := compare.MapStringInterface(a.Meta(), b.Meta()); err != nil {
 	// 	return fmt.Errorf("meta: %s", err.Error())
 	// }
-
-	if !a.Previous.Equal(b.Previous) {
-		return fmt.Errorf("Previous: %s != %s", a.Previous, b.Previous)
-	}
-	if a.Data != b.Data {
-		return fmt.Errorf("Data: %s != %s", a.Data, b.Data)
-	}
-
-	if err := CompareStructures(a.Structure, b.Structure); err != nil {
-		return fmt.Errorf("Structure: %s", err.Error())
-	}
-	if err := CompareDatasets(a.Abstract, b.Abstract); err != nil {
-		return fmt.Errorf("Abstract: %s", err.Error())
-	}
-	if err := CompareTransforms(a.Transform, b.Transform); err != nil {
-		return fmt.Errorf("Transform: %s", err.Error())
-	}
-	if err := CompareTransforms(a.AbstractTransform, b.AbstractTransform); err != nil {
-		return fmt.Errorf("AbstractTransform: %s", err.Error())
-	}
-	if err := CompareCommitMsgs(a.Commit, b.Commit); err != nil {
-		return fmt.Errorf("Commit: %s", err.Error())
-	}
-
 	return nil
 }
 
@@ -134,6 +137,12 @@ func CompareStructures(a, b *Structure) error {
 	if a.Format != b.Format {
 		return fmt.Errorf("Format: %s != %s", a.Format, b.Format)
 	}
+	if a.Length != b.Length {
+		return fmt.Errorf("Length: %d != %d", a.Length, b.Length)
+	}
+	if a.Rows != b.Rows {
+		return fmt.Errorf("Rows: %d != %d", a.Rows, b.Rows)
+	}
 	if a.Encoding != b.Encoding {
 		return fmt.Errorf("Encoding: %s != %s", a.Encoding, b.Encoding)
 	}
@@ -153,9 +162,10 @@ func CompareStructures(a, b *Structure) error {
 func CompareSchemas(a, b *Schema) error {
 	if a == nil && b == nil {
 		return nil
-	}
-	if a != nil && b == nil || a == nil && b != nil {
-		return fmt.Errorf("nil: %s != %s", a, b)
+	} else if a == nil && b != nil {
+		return fmt.Errorf("nil: <nil> != <not nil>")
+	} else if a != nil && b == nil {
+		return fmt.Errorf("nil: <not nil> != <nil>")
 	}
 
 	if err := CompareStringSlices(a.PrimaryKey, b.PrimaryKey); err != nil {
@@ -186,8 +196,10 @@ func CompareSchemas(a, b *Schema) error {
 func CompareFields(a, b *Field) error {
 	if a == nil && b == nil {
 		return nil
-	} else if a == nil && b != nil || a != nil && b == nil {
-		return fmt.Errorf("nil: %s != %s", a, b)
+	} else if a == nil && b != nil {
+		return fmt.Errorf("nil: <nil> != <not nil>")
+	} else if a != nil && b == nil {
+		return fmt.Errorf("nil: <not nil> != <nil>")
 	}
 
 	if a.Name != b.Name {
@@ -212,16 +224,21 @@ func CompareFields(a, b *Field) error {
 func CompareCommitMsgs(a, b *CommitMsg) error {
 	if a == nil && b == nil {
 		return nil
-	} else if a == nil && b != nil || a != nil && b == nil {
-		return fmt.Errorf("nil: %s != %s", a, b)
+	} else if a == nil && b != nil {
+		return fmt.Errorf("nil: <nil> != <not nil>")
+	} else if a != nil && b == nil {
+		return fmt.Errorf("nil: <not nil> != <nil>")
 	}
+
 	if a.Kind != b.Kind {
 		return fmt.Errorf("Kind: %s != %s", a.Kind, b.Kind)
 	}
 	if a.Title != b.Title {
 		return fmt.Errorf("Title: %s != %s", a.Title, b.Title)
 	}
-
+	if !a.Timestamp.Equal(b.Timestamp) {
+		return fmt.Errorf("Timestamp: %s != %s", a.Timestamp, b.Timestamp)
+	}
 	if a.Message != b.Message {
 		return fmt.Errorf("Message: %s != %s", a.Message, b.Message)
 	}

--- a/compare_test.go
+++ b/compare_test.go
@@ -17,41 +17,49 @@ func TestCompareDatasets(t *testing.T) {
 		{AirportCodes, AirportCodes, ""},
 		{NewDatasetRef(datastore.NewKey("a")), NewDatasetRef(datastore.NewKey("b")), "Path: /a != /b"},
 		{&Dataset{Kind: "a"}, &Dataset{Kind: "b"}, "Kind: a != b"},
-		{
-			&Dataset{Timestamp: time.Date(2001, 01, 01, 01, 0, 0, 0, time.UTC)},
-			&Dataset{Timestamp: time.Date(2002, 01, 01, 01, 0, 0, 0, time.UTC)},
-			"Timestamp: 2001-01-01 01:00:00 +0000 UTC != 2002-01-01 01:00:00 +0000 UTC",
-		},
-		{&Dataset{Length: 0}, &Dataset{Length: 1}, "Length: 0 != 1"},
-		{&Dataset{Rows: 0}, &Dataset{Rows: 1}, "Rows: 0 != 1"},
-		{&Dataset{Title: "a"}, &Dataset{Title: "b"}, "Title: a != b"},
-		{&Dataset{AccessURL: "a"}, &Dataset{AccessURL: "b"}, "AccessURL: a != b"},
-		{&Dataset{DownloadURL: "a"}, &Dataset{DownloadURL: "b"}, "DownloadURL: a != b"},
-		{&Dataset{AccrualPeriodicity: "a"}, &Dataset{AccrualPeriodicity: "b"}, "AccrualPeriodicity: a != b"},
-		{&Dataset{Readme: "a"}, &Dataset{Readme: "b"}, "Readme: a != b"},
-		{&Dataset{Author: nil}, &Dataset{Author: &User{}}, "Author: %!s(*dataset.User=<nil>) != &{  }"},
-		{&Dataset{Image: "a"}, &Dataset{Image: "b"}, "Image: a != b"},
-		{&Dataset{Description: "a"}, &Dataset{Description: "b"}, "Description: a != b"},
-		{&Dataset{Homepage: "a"}, &Dataset{Homepage: "b"}, "Homepage: a != b"},
-		{&Dataset{IconImage: "a"}, &Dataset{IconImage: "b"}, "IconImage: a != b"},
-		{&Dataset{Identifier: "a"}, &Dataset{Identifier: "b"}, "Identifier: a != b"},
-		// TODO
-		// {&Dataset{License: &License{}}, &Dataset{Version: "b"}, "Version: a != b"},
-		{&Dataset{Version: "a"}, &Dataset{Version: "b"}, "Version: a != b"},
-		{&Dataset{Keywords: []string{"a"}}, &Dataset{Keywords: []string{"b"}}, "Keywords: element 0: a != b"},
-		{&Dataset{Language: []string{"a"}}, &Dataset{Language: []string{"b"}}, "Language: element 0: a != b"},
-		{&Dataset{Theme: []string{"a"}}, &Dataset{Theme: []string{"b"}}, "Theme: element 0: a != b"},
-		{&Dataset{QueryString: "a"}, &Dataset{QueryString: "b"}, "QueryString: a != b"},
-		{&Dataset{Previous: datastore.NewKey("a")}, &Dataset{Previous: datastore.NewKey("b")}, "Previous: /a != /b"},
-		{&Dataset{Data: "a"}, &Dataset{Data: "b"}, "Data: a != b"},
+		{&Dataset{PreviousPath: "a"}, &Dataset{PreviousPath: "b"}, "PreviousPath: a != b"},
+		{&Dataset{DataPath: "a"}, &Dataset{DataPath: "b"}, "DataPath: a != b"},
 		{&Dataset{}, &Dataset{Structure: &Structure{}}, "Structure: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Transform: &Transform{}}, "Transform: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{AbstractTransform: &Transform{}}, "AbstractTransform: nil: <nil> != <not nil>"},
-		{&Dataset{}, &Dataset{Commit: &CommitMsg{}}, "Commit: nil: %!s(*dataset.CommitMsg=<nil>) != &{{} %!s(*dataset.User=<nil>)   }"},
+		{&Dataset{}, &Dataset{Commit: &CommitMsg{}}, "Commit: nil: <nil> != <not nil>"},
 	}
 
 	for i, c := range cases {
 		err := CompareDatasets(c.a, c.b)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+		}
+	}
+}
+
+func TestCompareMetadatas(t *testing.T) {
+	cases := []struct {
+		a, b *Metadata
+		err  string
+	}{
+		{nil, nil, ""},
+		{AirportCodes.Metadata, AirportCodes.Metadata, ""},
+		{NewMetadataRef(datastore.NewKey("a")), NewMetadataRef(datastore.NewKey("b")), "Path: /a != /b"},
+		{&Metadata{Kind: "a"}, &Metadata{Kind: "b"}, "Kind: a != b"},
+		{&Metadata{Title: "a"}, &Metadata{Title: "b"}, "Title: a != b"},
+		{&Metadata{AccessPath: "a"}, &Metadata{AccessPath: "b"}, "AccessPath: a != b"},
+		{&Metadata{DownloadPath: "a"}, &Metadata{DownloadPath: "b"}, "DownloadPath: a != b"},
+		{&Metadata{AccrualPeriodicity: "a"}, &Metadata{AccrualPeriodicity: "b"}, "AccrualPeriodicity: a != b"},
+		{&Metadata{ReadmePath: "a"}, &Metadata{ReadmePath: "b"}, "ReadmePath: a != b"},
+		{&Metadata{Description: "a"}, &Metadata{Description: "b"}, "Description: a != b"},
+		{&Metadata{HomePath: "a"}, &Metadata{HomePath: "b"}, "HomePath: a != b"},
+		{&Metadata{Identifier: "a"}, &Metadata{Identifier: "b"}, "Identifier: a != b"},
+		// TODO
+		// {&Metadata{License: &License{}}, &Metadata{Version: "b"}, "Version: a != b"},
+		{&Metadata{Version: "a"}, &Metadata{Version: "b"}, "Version: a != b"},
+		{&Metadata{Keywords: []string{"a"}}, &Metadata{Keywords: []string{"b"}}, "Keywords: element 0: a != b"},
+		{&Metadata{Language: []string{"a"}}, &Metadata{Language: []string{"b"}}, "Language: element 0: a != b"},
+		{&Metadata{Theme: []string{"a"}}, &Metadata{Theme: []string{"b"}}, "Theme: element 0: a != b"},
+	}
+
+	for i, c := range cases {
+		err := CompareMetadatas(c.a, c.b)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 		}
@@ -68,10 +76,12 @@ func TestCompareStructures(t *testing.T) {
 		{nil, AirportCodes.Structure, "nil: <nil> != <not nil>"},
 		{AirportCodes.Structure, nil, "nil: <not nil> != <nil>"},
 		{&Structure{Kind: "a"}, &Structure{Kind: "b"}, "Kind: a != b"},
+		{&Structure{Length: 0}, &Structure{Length: 1}, "Length: 0 != 1"},
+		{&Structure{Rows: 0}, &Structure{Rows: 1}, "Rows: 0 != 1"},
 		{&Structure{Format: CSVDataFormat}, &Structure{Format: UnknownDataFormat}, "Format: csv != "},
 		{&Structure{Encoding: "a"}, &Structure{Encoding: "b"}, "Encoding: a != b"},
 		{&Structure{Compression: compression.None}, &Structure{Compression: compression.Tar}, "Compression:  != tar"},
-		{&Structure{}, &Structure{Schema: &Schema{}}, "Schema: nil: %!s(*dataset.Schema=<nil>) != &{[] []}"},
+		{&Structure{}, &Structure{Schema: &Schema{}}, "Schema: nil: <nil> != <not nil>"},
 	}
 
 	for i, c := range cases {
@@ -89,7 +99,8 @@ func TestCompareSchemas(t *testing.T) {
 	}{
 		{nil, nil, ""},
 		{AirportCodes.Structure.Schema, AirportCodes.Structure.Schema, ""},
-		{nil, &Schema{}, "nil: %!s(*dataset.Schema=<nil>) != &{[] []}"},
+		{&Schema{}, nil, "nil: <not nil> != <nil>"},
+		{nil, &Schema{}, "nil: <nil> != <not nil>"},
 		{&Schema{PrimaryKey: FieldKey{"a"}}, &Schema{PrimaryKey: FieldKey{"b"}}, "PrimaryKey: element 0: a != b"},
 		{&Schema{}, &Schema{Fields: []*Field{}}, "Fields: [] != []"},
 		{&Schema{}, &Schema{Fields: []*Field{&Field{Name: "a"}}}, "Fields: [] != [%!s(*dataset.Field=&{a 0 <nil>  <nil>  })]"},
@@ -120,7 +131,8 @@ func TestCompareFields(t *testing.T) {
 	}{
 		{nil, nil, ""},
 		{f, f, ""},
-		{nil, f, "nil: %!s(*dataset.Field=<nil>) != &{a string foo fmt %!s(*dataset.FieldConstraints=<nil>) a a}"},
+		{nil, f, "nil: <nil> != <not nil>"},
+		{f, nil, "nil: <not nil> != <nil>"},
 	}
 
 	for i, c := range cases {
@@ -146,8 +158,14 @@ func TestCompareCommitMsgs(t *testing.T) {
 	}{
 		{nil, nil, ""},
 		{c1, c1, ""},
+		{c1, nil, "nil: <not nil> != <nil>"},
+		{nil, c1, "nil: <nil> != <not nil>"},
 		{&CommitMsg{}, &CommitMsg{}, ""},
-		{nil, c1, "nil: %!s(*dataset.CommitMsg=<nil>) != &{{/foo} %!s(*dataset.User=&{foo  }) qri:cm:0 message foo}"},
+		{
+			&CommitMsg{Timestamp: time.Date(2001, 01, 01, 01, 0, 0, 0, time.UTC)},
+			&CommitMsg{Timestamp: time.Date(2002, 01, 01, 01, 0, 0, 0, time.UTC)},
+			"Timestamp: 2001-01-01 01:00:00 +0000 UTC != 2002-01-01 01:00:00 +0000 UTC",
+		},
 		{&CommitMsg{Title: "a"}, &CommitMsg{Title: "b"}, "Title: a != b"},
 		{&CommitMsg{Message: "a"}, &CommitMsg{Message: "b"}, "Message: a != b"},
 		{&CommitMsg{Kind: "a"}, &CommitMsg{Kind: "b"}, "Kind: a != b"},

--- a/compare_test.go
+++ b/compare_test.go
@@ -22,7 +22,7 @@ func TestCompareDatasets(t *testing.T) {
 		{&Dataset{}, &Dataset{Structure: &Structure{}}, "Structure: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Transform: &Transform{}}, "Transform: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{AbstractTransform: &Transform{}}, "AbstractTransform: nil: <nil> != <not nil>"},
-		{&Dataset{}, &Dataset{Commit: &CommitMsg{}}, "Commit: nil: <nil> != <not nil>"},
+		{&Dataset{}, &Dataset{Commit: &Commit{}}, "Commit: nil: <nil> != <not nil>"},
 	}
 
 	for i, c := range cases {
@@ -143,36 +143,36 @@ func TestCompareFields(t *testing.T) {
 	}
 }
 
-func TestCompareCommitMsgs(t *testing.T) {
-	c1 := &CommitMsg{
+func TestCompareCommits(t *testing.T) {
+	c1 := &Commit{
 		path:    datastore.NewKey("/foo"),
 		Title:   "foo",
 		Message: "message",
-		Kind:    KindCommitMsg,
+		Kind:    KindCommit,
 		Author:  &User{ID: "foo"},
 	}
 
 	cases := []struct {
-		a, b *CommitMsg
+		a, b *Commit
 		err  string
 	}{
 		{nil, nil, ""},
 		{c1, c1, ""},
 		{c1, nil, "nil: <not nil> != <nil>"},
 		{nil, c1, "nil: <nil> != <not nil>"},
-		{&CommitMsg{}, &CommitMsg{}, ""},
+		{&Commit{}, &Commit{}, ""},
 		{
-			&CommitMsg{Timestamp: time.Date(2001, 01, 01, 01, 0, 0, 0, time.UTC)},
-			&CommitMsg{Timestamp: time.Date(2002, 01, 01, 01, 0, 0, 0, time.UTC)},
+			&Commit{Timestamp: time.Date(2001, 01, 01, 01, 0, 0, 0, time.UTC)},
+			&Commit{Timestamp: time.Date(2002, 01, 01, 01, 0, 0, 0, time.UTC)},
 			"Timestamp: 2001-01-01 01:00:00 +0000 UTC != 2002-01-01 01:00:00 +0000 UTC",
 		},
-		{&CommitMsg{Title: "a"}, &CommitMsg{Title: "b"}, "Title: a != b"},
-		{&CommitMsg{Message: "a"}, &CommitMsg{Message: "b"}, "Message: a != b"},
-		{&CommitMsg{Kind: "a"}, &CommitMsg{Kind: "b"}, "Kind: a != b"},
+		{&Commit{Title: "a"}, &Commit{Title: "b"}, "Title: a != b"},
+		{&Commit{Message: "a"}, &Commit{Message: "b"}, "Message: a != b"},
+		{&Commit{Kind: "a"}, &Commit{Kind: "b"}, "Kind: a != b"},
 	}
 
 	for i, c := range cases {
-		err := CompareCommitMsgs(c.a, c.b)
+		err := CompareCommits(c.a, c.b)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error: expected: '%s', got: '%s'", i, c.err, err)
 		}

--- a/dataset.go
+++ b/dataset.go
@@ -3,7 +3,6 @@ package dataset
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/ipfs/go-datastore"
 )
@@ -15,7 +14,7 @@ import (
 // * Though software Dataset metadata is interoperable with the DCAT, Project Open Data,
 //   Open Knowledge Foundation DataPackage and JSON-LD specifications,
 //   with the one major exception that content-addressed hashes are acceptable in place of urls.
-// * Datasets have a "Previous" field that forms historical DAGs
+// * Datasets have a "PreviousPath" field that forms historical DAGs
 // * Datasets contain a "commit" object that describes changes over time
 // * Dataset Commits can and should be author attributed via keypair signing
 // * Datasets "Transformations" provide determinstic records of the process used to
@@ -26,77 +25,37 @@ import (
 type Dataset struct {
 	// private storage for reference to this object
 	path datastore.Key
-	// Kind is required, must be qri:ds:[version]
-	Kind Kind `json:"kind"`
-	// Time this dataset was created. Required. Datasets are immutable, so no "updated"
-	Timestamp time.Time `json:"timestamp,omitempty"`
-	// Length is the length of the data object in bytes.
-	// must always match & be present
-	Length int `json:"length,omitempty"`
-	// number of rows in the dataset.
-	// required and must match underlying dataset.
-	Rows int `json:"rows"`
-	// Title of this dataset
-	Title string `json:"title,omitempty"`
-	// Url to access the dataset
-	AccessURL string `json:"accessUrl,omitempty"`
-	// Url that should / must lead directly to the data itself
-	DownloadURL string `json:"downloadUrl,omitempty"`
-	// The frequency with which dataset changes. Must be an ISO 8601 repeating duration
-	AccrualPeriodicity string `json:"accrualPeriodicity,omitempty"`
-	// path to readme
-	Readme string `json:"readme,omitempty"`
-	// Author
-	Author    *User       `json:"author,omitempty"`
-	Citations []*Citation `json:"citations"`
-	Image     string      `json:"image,omitempty"`
-	// Description follows the DCAT sense of the word, it should be around a paragraph of
-	// human-readable text
-	Description string `json:"description,omitempty"`
-	Homepage    string `json:"homepage,omitempty"`
-	IconImage   string `json:"iconImage,omitempty"`
-	// Identifier is for *other* data catalog specifications. Identifier should not be used
-	// or relied on to be unique, because this package does not enforce any of these rules.
-	Identifier string `json:"identifier,omitempty"`
-	// License will automatically parse to & from a string value if provided as a raw string
-	License *License `json:"license,omitempty"`
-	// SemVersion this dataset?
-	Version string `json:"version,omitempty"`
-	// String of Keywords
-	Keywords []string `json:"keywords,omitempty"`
-	// Contribute
-	Contributors []*User `json:"contributors,omitempty"`
-	// Languages this dataset is written in
-	Language []string `json:"language,omitempty"`
-	// Theme
-	Theme []string `json:"theme,omitempty"`
-	// QueryString is the user-inputted string of an SQL transform
-	QueryString string `json:"queryString,omitempty"`
-	// meta holds additional arbitrarty metadata not covered by the spec
-	// when encoding & decoding json values here will be hoisted into the
-	// Dataset object
-	meta map[string]interface{}
 
-	// Structure of this dataset
-	Structure *Structure `json:"structure"`
 	// Abstract is the abstract form of this dataset
 	Abstract *Dataset `json:"abstract,omitempty"`
-	// Transform is a path to the transformation that generated this resource
-	Transform *Transform `json:"transform,omitempty"`
 	// AbstractTransform is a reference to the general form of the transformation
 	// that resulted in this dataset
 	AbstractTransform *Transform `json:"abstractTransform,omitempty"`
 	// Commit contains author & change message information
-	Commit *CommitMsg `json:"commit"`
-	// Previous connects datasets to form a historical DAG
-	Previous datastore.Key `json:"previous,omitempty"`
-	// Data is the path to the hash of raw data as it resolves on the network.
-	Data string `json:"data,omitempty"`
+	Commit *CommitMsg `json:"commit,omitempty"`
+	// DataPath is the path to the hash of raw data as it resolves on the network.
+	DataPath string `json:"dataPath,omitempty"`
+	// Kind is required, must be qri:ds:[version]
+	Kind Kind `json:"kind"`
+	// Meta contains all human-readable metadata about this dataset
+	Metadata *Metadata `json:"metadata,omitempty"`
+	// PreviousPath connects datasets to form a historical DAG
+	PreviousPath string `json:"previousPath,omitempty"`
+	// Structure of this dataset
+	Structure *Structure `json:"structure"`
+	// Transform is a path to the transformation that generated this resource
+	Transform *Transform `json:"transform,omitempty"`
 }
 
 // IsEmpty checks to see if dataset has any fields other than the internal path
 func (ds *Dataset) IsEmpty() bool {
-	return ds.Title == "" && ds.Description == "" && ds.Structure == nil && ds.Timestamp.IsZero() && ds.Previous.String() == ""
+	return ds.Abstract == nil &&
+		ds.AbstractTransform == nil &&
+		ds.Commit == nil &&
+		ds.DataPath == "" &&
+		ds.Metadata == nil &&
+		ds.PreviousPath == "" &&
+		ds.Transform == nil
 }
 
 // Path gives the internal path reference for this dataset
@@ -122,14 +81,6 @@ func Abstract(ds *Dataset) *Dataset {
 	return abs
 }
 
-// Meta gives access to additional metadata not covered by dataset metadata
-func (ds *Dataset) Meta() map[string]interface{} {
-	if ds.meta == nil {
-		ds.meta = map[string]interface{}{}
-	}
-	return ds.meta
-}
-
 // Assign collapses all properties of a group of datasets onto one.
 // this is directly inspired by Javascript's Object.assign
 func (ds *Dataset) Assign(datasets ...*Dataset) {
@@ -141,10 +92,6 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 		if d.path.String() != "" {
 			ds.path = d.path
 		}
-		if !d.Timestamp.IsZero() {
-			ds.Timestamp = d.Timestamp
-		}
-
 		if ds.Structure == nil && d.Structure != nil {
 			ds.Structure = d.Structure
 		} else if ds.Structure != nil {
@@ -175,76 +122,13 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 			ds.Commit.Assign(d.Commit)
 		}
 
-		if d.Data != "" {
-			ds.Data = d.Data
+		if d.DataPath != "" {
+			ds.DataPath = d.DataPath
 		}
-		if d.Length != 0 {
-			ds.Length = d.Length
-		}
-		if d.Previous.String() != "" {
-			ds.Previous = d.Previous
+		if d.PreviousPath != "" {
+			ds.PreviousPath = d.PreviousPath
 		}
 		ds.Commit.Assign(d.Commit)
-		if d.Title != "" {
-			ds.Title = d.Title
-		}
-		if d.AccessURL != "" {
-			ds.AccessURL = d.AccessURL
-		}
-		if d.DownloadURL != "" {
-			ds.DownloadURL = d.DownloadURL
-		}
-		if d.Readme != "" {
-			ds.Readme = d.Readme
-		}
-		if d.Author != nil {
-			ds.Author = d.Author
-		}
-		if d.AccrualPeriodicity != "" {
-			ds.AccrualPeriodicity = d.AccrualPeriodicity
-		}
-		if d.Citations != nil {
-			ds.Citations = d.Citations
-		}
-		if d.Image != "" {
-			ds.Image = d.Image
-		}
-		if d.Description != "" {
-			ds.Description = d.Description
-		}
-		if d.Homepage != "" {
-			ds.Homepage = d.Homepage
-		}
-		if d.IconImage != "" {
-			ds.IconImage = d.IconImage
-		}
-		if d.Identifier != "" {
-			ds.Identifier = d.Identifier
-		}
-		if d.License != nil {
-			ds.License = d.License
-		}
-		if d.Version != "" {
-			ds.Version = d.Version
-		}
-		if d.Keywords != nil {
-			ds.Keywords = d.Keywords
-		}
-		if d.Contributors != nil {
-			ds.Contributors = d.Contributors
-		}
-		if d.Language != nil {
-			ds.Language = d.Language
-		}
-		if d.Theme != nil {
-			ds.Theme = d.Theme
-		}
-		if d.QueryString != "" {
-			ds.QueryString = d.QueryString
-		}
-		if d.meta != nil {
-			ds.meta = d.meta
-		}
 	}
 }
 
@@ -256,93 +140,11 @@ func (ds *Dataset) MarshalJSON() ([]byte, error) {
 	if ds.path.String() != "" && ds.IsEmpty() {
 		return ds.path.MarshalJSON()
 	}
-
-	data := ds.Meta()
-	if ds.AbstractTransform != nil {
-		data["abstractTransform"] = ds.AbstractTransform
-	}
-	if ds.Abstract != nil {
-		data["abstract"] = ds.Abstract
-	}
-	if ds.AccessURL != "" {
-		data["accessUrl"] = ds.AccessURL
-	}
-	if ds.Author != nil {
-		data["author"] = ds.Author
-	}
-	if ds.Citations != nil {
-		data["citations"] = ds.Citations
-	}
-	if ds.Contributors != nil {
-		data["contributors"] = ds.Contributors
-	}
-	if ds.Data != "" {
-		data["data"] = ds.Data
-	}
-	if ds.Description != "" {
-		data["description"] = ds.Description
-	}
-	if ds.DownloadURL != "" {
-		data["downloadUrl"] = ds.DownloadURL
-	}
-	if ds.Homepage != "" {
-		data["homepage"] = ds.Homepage
-	}
-	if ds.IconImage != "" {
-		data["iconImage"] = ds.IconImage
-	}
-	if ds.Identifier != "" {
-		data["identifier"] = ds.Identifier
-	}
-	if ds.Image != "" {
-		data["image"] = ds.Image
-	}
-	if ds.Keywords != nil {
-		data["keywords"] = ds.Keywords
-	}
-	data["kind"] = KindDataset
-	if ds.Language != nil {
-		data["language"] = ds.Language
-	}
-	if ds.Length != 0 {
-		data["length"] = ds.Length
-	}
-	if ds.License != nil {
-		data["license"] = ds.License
-	}
-	if ds.Previous.String() != "" {
-		data["previous"] = ds.Previous
-	}
-	if ds.Commit != nil {
-		data["commit"] = ds.Commit
-	}
-	if ds.Transform != nil {
-		data["transform"] = ds.Transform
-	}
-	if ds.QueryString != "" {
-		data["queryString"] = ds.QueryString
-	}
-	if ds.Readme != "" {
-		data["readme"] = ds.Readme
-	}
-	data["structure"] = ds.Structure
-	if ds.Theme != nil {
-		data["theme"] = ds.Theme
-	}
-	if !ds.Timestamp.IsZero() {
-		data["timestamp"] = ds.Timestamp
-	}
-	if ds.Title != "" {
-		data["title"] = ds.Title
-	}
-	if ds.AccrualPeriodicity != "" {
-		data["accrualPeriodicity"] = ds.AccrualPeriodicity
-	}
-	if ds.Version != "" {
-		data["version"] = ds.Version
+	if ds.Kind == "" {
+		ds.Kind = KindDataset
 	}
 
-	return json.Marshal(data)
+	return json.Marshal(_dataset(*ds))
 }
 
 // internal struct for json unmarshaling
@@ -363,47 +165,17 @@ func (ds *Dataset) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("error unmarshling dataset: %s", err.Error())
 	}
 
-	meta := map[string]interface{}{}
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return fmt.Errorf("error unmarshaling dataset metadata: %s", err, err)
+	*ds = Dataset{
+		Abstract:          d.Abstract,
+		AbstractTransform: d.AbstractTransform,
+		Commit:            d.Commit,
+		DataPath:          d.DataPath,
+		Kind:              d.Kind,
+		Metadata:          d.Metadata,
+		PreviousPath:      d.PreviousPath,
+		Structure:         d.Structure,
+		Transform:         d.Transform,
 	}
-
-	for _, f := range []string{
-		"abstractTransform",
-		"abstract",
-		"accessUrl",
-		"accrualPeriodicity",
-		"author",
-		"citations",
-		"commit",
-		"contributors",
-		"data",
-		"description",
-		"downloadUrl",
-		"homepage",
-		"iconImage",
-		"identifier",
-		"image",
-		"keywords",
-		"kind",
-		"language",
-		"length",
-		"license",
-		"previous",
-		"transform",
-		"queryString",
-		"readme",
-		"structure",
-		"theme",
-		"timestamp",
-		"title",
-		"version",
-	} {
-		delete(meta, f)
-	}
-
-	d.meta = meta
-	*ds = Dataset(d)
 	return nil
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -52,6 +52,7 @@ func (ds *Dataset) IsEmpty() bool {
 	return ds.Abstract == nil &&
 		ds.AbstractTransform == nil &&
 		ds.Commit == nil &&
+		ds.Structure == nil &&
 		ds.DataPath == "" &&
 		ds.Metadata == nil &&
 		ds.PreviousPath == "" &&
@@ -97,25 +98,26 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 		} else if ds.Structure != nil {
 			ds.Structure.Assign(d.Structure)
 		}
-
+		if ds.Metadata == nil && d.Metadata != nil {
+			ds.Metadata = d.Metadata
+		} else if ds.Metadata != nil {
+			ds.Metadata.Assign(d.Metadata)
+		}
 		if ds.Abstract == nil && d.Abstract != nil {
 			ds.Abstract = d.Abstract
 		} else if ds.Abstract != nil {
 			ds.Abstract.Assign(d.Abstract)
 		}
-
 		if ds.Transform == nil && d.Transform != nil {
 			ds.Transform = d.Transform
 		} else if ds.Transform != nil {
 			ds.Transform.Assign(d.Transform)
 		}
-
 		if ds.AbstractTransform == nil && d.AbstractTransform != nil {
 			ds.AbstractTransform = d.AbstractTransform
 		} else if ds.AbstractTransform != nil {
 			ds.AbstractTransform.Assign(d.AbstractTransform)
 		}
-
 		if ds.Commit == nil && d.Commit != nil {
 			ds.Commit = d.Commit
 		} else if ds.Commit != nil {

--- a/dataset.go
+++ b/dataset.go
@@ -32,7 +32,7 @@ type Dataset struct {
 	// that resulted in this dataset
 	AbstractTransform *Transform `json:"abstractTransform,omitempty"`
 	// Commit contains author & change message information
-	Commit *CommitMsg `json:"commit,omitempty"`
+	Commit *Commit `json:"commit,omitempty"`
 	// DataPath is the path to the hash of raw data as it resolves on the network.
 	DataPath string `json:"dataPath,omitempty"`
 	// Kind is required, must be qri:ds:[version]

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -19,7 +19,7 @@ func TestDatasetAssign(t *testing.T) {
 		// {&Dataset{Abstract: &Dataset{Title: "I'm an abstract dataset"}}},
 		{&Dataset{Transform: &Transform{Data: "I'm transform data!"}}},
 		{&Dataset{AbstractTransform: &Transform{Data: "I'm abstract transform data?"}}},
-		{&Dataset{Commit: &CommitMsg{Title: "foo"}}},
+		{&Dataset{Commit: &Commit{Title: "foo"}}},
 		{&Dataset{DataPath: "foo"}},
 		{&Dataset{PreviousPath: "stuff"}},
 	}
@@ -39,14 +39,14 @@ func TestDatasetAssign(t *testing.T) {
 		Transform:         &Transform{},
 		AbstractTransform: &Transform{},
 		Structure:         &Structure{},
-		Commit:            &CommitMsg{},
+		Commit:            &Commit{},
 	}
 	madsa := &Dataset{
 		Abstract:          &Dataset{Structure: &Structure{}},
 		Transform:         &Transform{Data: "I'm transform data!"},
 		AbstractTransform: &Transform{Data: "I'm abstract transform data?"},
 		Structure:         &Structure{Format: CSVDataFormat},
-		Commit:            &CommitMsg{Title: "dy.no.mite."},
+		Commit:            &Commit{Title: "dy.no.mite."},
 	}
 	mads.Assign(madsa)
 

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -22,6 +22,7 @@ func TestDatasetAssign(t *testing.T) {
 		{&Dataset{Commit: &Commit{Title: "foo"}}},
 		{&Dataset{DataPath: "foo"}},
 		{&Dataset{PreviousPath: "stuff"}},
+		{&Dataset{Metadata: &Metadata{Title: "foo"}}},
 	}
 
 	for i, c := range cases {
@@ -144,6 +145,28 @@ func TestDatasetUnmarshalJSON(t *testing.T) {
 	if strds.path.String() != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strds.path)
 		return
+	}
+}
+
+func TestDatasetIsEmpty(t *testing.T) {
+	cases := []struct {
+		ds *Dataset
+	}{
+		{&Dataset{Abstract: &Dataset{}}},
+		{&Dataset{AbstractTransform: &Transform{}}},
+		{&Dataset{Commit: &Commit{}}},
+		{&Dataset{DataPath: "foo"}},
+		{&Dataset{Metadata: &Metadata{}}},
+		{&Dataset{PreviousPath: "nope"}},
+		{&Dataset{Structure: &Structure{}}},
+		{&Dataset{Transform: &Transform{}}},
+	}
+
+	for i, c := range cases {
+		if c.ds.IsEmpty() == true {
+			t.Errorf("case %d improperly reported dataset as empty", i)
+			continue
+		}
 	}
 }
 

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -5,10 +5,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/qri-io/dataset/datatypes"
 )
 
 func TestDatasetAssign(t *testing.T) {
@@ -17,34 +15,13 @@ func TestDatasetAssign(t *testing.T) {
 		in *Dataset
 	}{
 		{&Dataset{path: datastore.NewKey("/a")}},
-		{&Dataset{Timestamp: time.Now()}},
 		{&Dataset{Structure: &Structure{Format: CSVDataFormat}}},
-		{&Dataset{Abstract: &Dataset{Title: "I'm an abstract dataset"}}},
+		// {&Dataset{Abstract: &Dataset{Title: "I'm an abstract dataset"}}},
 		{&Dataset{Transform: &Transform{Data: "I'm transform data!"}}},
 		{&Dataset{AbstractTransform: &Transform{Data: "I'm abstract transform data?"}}},
 		{&Dataset{Commit: &CommitMsg{Title: "foo"}}},
-		{&Dataset{Data: "foo"}},
-		{&Dataset{Length: 2503}},
-		{&Dataset{AccessURL: "foo"}},
-		{&Dataset{DownloadURL: "foo"}},
-		{&Dataset{Readme: "foo"}},
-		{&Dataset{Author: &User{Email: "foo"}}},
-		{&Dataset{AccrualPeriodicity: "1W"}},
-		{&Dataset{Citations: []*Citation{&Citation{Email: "foo"}}}},
-		{&Dataset{Image: "foo"}},
-		{&Dataset{Description: "foo"}},
-		{&Dataset{Homepage: "foo"}},
-		{&Dataset{IconImage: "foo"}},
-		{&Dataset{Identifier: "foo"}},
-		{&Dataset{License: &License{Type: "foo"}}},
-		{&Dataset{Version: "foo"}},
-		{&Dataset{Keywords: []string{"foo"}}},
-		{&Dataset{Contributors: []*User{&User{Email: "foo"}}}},
-		{&Dataset{Language: []string{"stuff"}}},
-		{&Dataset{Theme: []string{"stuff"}}},
-		{&Dataset{QueryString: "stuff"}},
-		{&Dataset{Previous: datastore.NewKey("stuff")}},
-		{&Dataset{meta: map[string]interface{}{"foo": "bar"}}},
+		{&Dataset{DataPath: "foo"}},
+		{&Dataset{PreviousPath: "stuff"}},
 	}
 
 	for i, c := range cases {
@@ -65,7 +42,7 @@ func TestDatasetAssign(t *testing.T) {
 		Commit:            &CommitMsg{},
 	}
 	madsa := &Dataset{
-		Abstract:          &Dataset{Title: "I'm an abstract dataset"},
+		Abstract:          &Dataset{Structure: &Structure{}},
 		Transform:         &Transform{Data: "I'm transform data!"},
 		AbstractTransform: &Transform{Data: "I'm abstract transform data?"},
 		Structure:         &Structure{Format: CSVDataFormat},
@@ -76,63 +53,6 @@ func TestDatasetAssign(t *testing.T) {
 	if err := CompareDatasets(mads, madsa); err != nil {
 		t.Errorf("error testing assigning to existing substructs: %s", err.Error())
 		return
-	}
-
-	expect := &Dataset{
-		Title:       "Final Title",
-		Description: "Final Description",
-		AccessURL:   "AccessURL",
-		Structure: &Structure{
-			Schema: &Schema{
-				Fields: []*Field{
-					{Type: datatypes.String, Name: "foo"},
-					{Type: datatypes.Integer, Name: "bar"},
-					{Description: "bat"},
-				},
-			},
-		},
-	}
-	got := &Dataset{
-		Title:       "Overwrite Me",
-		Description: "Nope",
-		Structure: &Structure{
-			Schema: &Schema{
-				Fields: []*Field{
-					{Type: datatypes.String},
-					{Type: datatypes.Integer},
-				},
-			},
-		},
-	}
-
-	got.Assign(&Dataset{
-		Title:       "Final Title",
-		Description: "Final Description",
-		AccessURL:   "AccessURL",
-		Structure: &Structure{
-			Schema: &Schema{
-				Fields: []*Field{
-					{Name: "foo"},
-					{Name: "bar"},
-					{Description: "bat"},
-				},
-			},
-		},
-	})
-
-	if err := CompareDatasets(expect, got); err != nil {
-		t.Error(err)
-	}
-
-	got.Assign(nil, nil)
-	if err := CompareDatasets(expect, got); err != nil {
-		t.Error(err)
-	}
-
-	emptyDs := &Dataset{}
-	emptyDs.Assign(expect)
-	if err := CompareDatasets(expect, emptyDs); err != nil {
-		t.Error(err)
 	}
 }
 
@@ -259,7 +179,7 @@ func TestAbstract(t *testing.T) {
 }
 
 func TestUnmarshalDataset(t *testing.T) {
-	dsa := Dataset{Kind: KindDataset, Title: "foo"}
+	dsa := Dataset{Kind: KindDataset}
 	cases := []struct {
 		value interface{}
 		out   *Dataset

--- a/dsfs/commit_msg.go
+++ b/dsfs/commit_msg.go
@@ -8,20 +8,20 @@ import (
 	"github.com/qri-io/dataset"
 )
 
-// SaveCommitMsg writes a commit message to a cafs
-func SaveCommitMsg(store cafs.Filestore, s *dataset.CommitMsg, pin bool) (path datastore.Key, err error) {
-	file, err := JSONFile(PackageFileCommitMsg.String(), s)
+// SaveCommit writes a commit message to a cafs
+func SaveCommit(store cafs.Filestore, s *dataset.Commit, pin bool) (path datastore.Key, err error) {
+	file, err := JSONFile(PackageFileCommit.String(), s)
 	if err != nil {
 		return datastore.NewKey(""), fmt.Errorf("error saving json commit file: %s", err.Error())
 	}
 	return store.Put(file, pin)
 }
 
-// LoadCommitMsg loads a commit from a given path in a store
-func LoadCommitMsg(store cafs.Filestore, path datastore.Key) (st *dataset.CommitMsg, err error) {
+// LoadCommit loads a commit from a given path in a store
+func LoadCommit(store cafs.Filestore, path datastore.Key) (st *dataset.Commit, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading commit file: %s", err.Error())
 	}
-	return dataset.UnmarshalCommitMsg(data)
+	return dataset.UnmarshalCommit(data)
 }

--- a/dsfs/commit_msg_test.go
+++ b/dsfs/commit_msg_test.go
@@ -8,25 +8,25 @@ import (
 	"github.com/qri-io/cafs/memfs"
 )
 
-func TestSaveCommitMsg(t *testing.T) {
+func TestSaveCommit(t *testing.T) {
 	store := memfs.NewMapstore()
-	path, err := SaveCommitMsg(store, AirportCodesCommitMsg, true)
+	path, err := SaveCommit(store, AirportCodesCommit, true)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
 	}
-	cmt, err := LoadCommitMsg(store, path)
+	cmt, err := LoadCommit(store, path)
 	if err != nil {
 		t.Errorf("error loading saved commit message: %s", err.Error())
 		return
 	}
 
-	if err := dataset.CompareCommitMsgs(AirportCodesCommitMsg, cmt); err != nil {
+	if err := dataset.CompareCommits(AirportCodesCommit, cmt); err != nil {
 		t.Errorf("saved message mismatch: %s", err.Error())
 		return
 	}
 
-	// _, err = SaveCommitMsg(store, &dataset.Dataset{}, false)
+	// _, err = SaveCommit(store, &dataset.Dataset{}, false)
 	// if err == nil {
 	// 	t.Errorf("expected saving nil message to error")
 	// 	return
@@ -38,18 +38,18 @@ func TestSaveCommitMsg(t *testing.T) {
 	// }
 }
 
-func TestLoadCommitMsg(t *testing.T) {
+func TestLoadCommit(t *testing.T) {
 	store := memfs.NewMapstore()
-	a, err := SaveCommitMsg(store, AirportCodesCommitMsg, true)
+	a, err := SaveCommit(store, AirportCodesCommit, true)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
 	}
-	if _, err := LoadCommitMsg(store, a); err != nil {
+	if _, err := LoadCommit(store, a); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	_, err = LoadCommitMsg(store, datastore.NewKey("/bad/path"))
+	_, err = LoadCommit(store, datastore.NewKey("/bad/path"))
 	if err == nil {
 		t.Errorf("expected loading a bad path to error. got nil")
 		return

--- a/dsfs/data.go
+++ b/dsfs/data.go
@@ -12,7 +12,7 @@ import (
 
 // LoadData loads the data this dataset points to from the store
 func LoadData(store cafs.Filestore, ds *dataset.Dataset) (cafs.File, error) {
-	return store.Get(datastore.NewKey(ds.Data))
+	return store.Get(datastore.NewKey(ds.DataPath))
 }
 
 // LoadRows loads a slice of raw bytes inside a limit/offset row range

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -5,42 +5,11 @@ import (
 	"fmt"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/cafs/memfs"
 	"github.com/qri-io/dataset"
 )
-
-// PrepareDataset modifies a dataset in preparation for adding to a dsfs
-// assumes the given dataset is valid
-// func PrepareDataset(store cafs.Filestore, ds *dataset.Dataset) error {
-
-// 	// generate abstract form of dataset
-// 	ds.Abstract = dataset.Abstract(ds)
-
-// 	if ds.AbstractTransform != nil {
-// 		// convert abstract transform to abstract references
-// 		for name, ref := range ds.AbstractTransform.Resources {
-// 			// data, _ := ref.MarshalJSON()
-// 			// fmt.Println(string(data))
-// 			if ref.Abstract != nil {
-// 				ds.AbstractTransform.Resources[name] = ref.Abstract
-// 			} else {
-
-// 				absf, err := JSONFile(PackageFileAbstract.String(), dataset.Abstract(ref))
-// 				if err != nil {
-// 					return err
-// 				}
-// 				path, err := store.Put(absf, true)
-// 				if err != nil {
-// 					return err
-// 				}
-// 				ds.AbstractTransform.Resources[name] = dataset.NewDatasetRef(path)
-// 			}
-// 		}
-// 	}
-
-// 	return nil
-// }
 
 // LoadDataset reads a dataset from a cafs and dereferences structure, transform, and commitMsg if they exist,
 // returning a fully-hydrated dataset
@@ -139,6 +108,108 @@ func DerefDatasetCommitMsg(store cafs.Filestore, ds *dataset.Dataset) error {
 	}
 	return nil
 }
+
+// CreateDatasetParams defines parmeters for the CreateDataset function
+type CreateDatasetParams struct {
+	// Store is where we're going to
+	Store cafs.Filestore
+	//
+	Dataset  *dataset.Dataset
+	DataFile cafs.File
+	PrivKey  crypto.PrivKey
+}
+
+// CreateDataset is the canonical method for getting a dataset pointer & it's data into a store
+// func CreateDataset(p *CreateDatasetParams) (path datastore.Key, err error) {
+// 	// TODO - need a better strategy for huge files
+// 	data, err := ioutil.ReadAll(rdr)
+// 	if err != nil {
+// 		return fmt.Errorf("error reading file: %s", err.Error())
+// 	}
+
+// 	if err = PrepareDataset(p.Store, p.Dataset, p.DataFile); err != nil {
+// 		return
+// 	}
+
+// 	// Ensure that dataset is well-formed
+// 	// format, err := detect.ExtensionDataFormat(filename)
+// 	// if err != nil {
+// 	// 	return fmt.Errorf("error detecting format extension: %s", err.Error())
+// 	// }
+// 	// if err = validate.DataFormat(format, bytes.NewReader(data)); err != nil {
+// 	// 	return fmt.Errorf("invalid data format: %s", err.Error())
+// 	// }
+
+// 	// TODO - check for errors in dataset and warn user if errors exist
+
+// 	datakey, err := store.Put(memfs.NewMemfileBytes("data."+st.Format.String(), data), false)
+// 	if err != nil {
+// 		return fmt.Errorf("error putting data file in store: %s", err.Error())
+// 	}
+
+// 	ds.Timestamp = time.Now().In(time.UTC)
+// 	if ds.Title == "" {
+// 		ds.Title = name
+// 	}
+// 	ds.Data = datakey.String()
+
+// 	if err := validate.Dataset(ds); err != nil {
+// 		return err
+// 	}
+
+// 	dskey, err := SaveDataset(store, ds, true)
+// 	if err != nil {
+// 		return fmt.Errorf("error saving dataset: %s", err.Error())
+// 	}
+// }
+
+// prepareDataset modifies a dataset in preparation for adding to a dsfs
+// func PrepareDataset(store cafs.Filestore, ds *dataset.Dataset, data cafs.File) error {
+
+// 	st, err := detect.FromReader(data.FileName(), data)
+// 	if err != nil {
+// 		return fmt.Errorf("error determining dataset schema: %s", err.Error())
+// 	}
+// 	if ds.Structure == nil {
+// 		ds.Structure = &dataset.Structure{}
+// 	}
+// 	ds.Structure.Assign(st, ds.Structure)
+
+// 	// Ensure that dataset contains valid field names
+// 	if err = validate.Structure(st); err != nil {
+// 		return fmt.Errorf("invalid structure: %s", err.Error())
+// 	}
+// 	if err := validate.DataFormat(st.Format, bytes.NewReader(data)); err != nil {
+// 		return fmt.Errorf("invalid data format: %s", err.Error())
+// 	}
+
+// 	// generate abstract form of dataset
+// 	ds.Abstract = dataset.Abstract(ds)
+
+// 	if ds.AbstractTransform != nil {
+// 		// convert abstract transform to abstract references
+// 		for name, ref := range ds.AbstractTransform.Resources {
+// 			// data, _ := ref.MarshalJSON()
+// 			// fmt.Println(string(data))
+// 			if ref.Abstract != nil {
+// 				ds.AbstractTransform.Resources[name] = ref.Abstract
+// 			} else {
+
+// 				absf, err := JSONFile(PackageFileAbstract.String(), dataset.Abstract(ref))
+// 				if err != nil {
+// 					return err
+// 				}
+// 				path, err := store.Put(absf, true)
+// 				if err != nil {
+// 					return err
+// 				}
+// 				ds.AbstractTransform.Resources[name] = dataset.NewDatasetRef(path)
+// 			}
+// 		}
+// 	}
+
+// 	return nil
+// }
 
 // SaveDataset writes a dataset to a cafs, replacing subcomponents of a dataset with hash references
 // during the write process. Directory structure is according to PackageFile naming conventions

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -40,21 +40,25 @@ func TestLoadDataset(t *testing.T) {
 		{dataset.NewDatasetRef(datastore.NewKey("/bad/path")),
 			"error loading dataset: error getting file bytes: datastore: key not found"},
 		{&dataset.Dataset{
-			Title:     "bad structure",
+			Metadata: dataset.NewMetadataRef(datastore.NewKey("/bad/path")),
+		}, "error loading dataset metadata: error loading metadata file: datastore: key not found"},
+		{&dataset.Dataset{
 			Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path")),
 		}, "error loading dataset structure: error loading structure file: datastore: key not found"},
 		{&dataset.Dataset{
-			Title:     "bad structure",
+			Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path")),
+		}, "error loading dataset structure: error loading structure file: datastore: key not found"},
+		{&dataset.Dataset{
 			Transform: dataset.NewTransformRef(datastore.NewKey("/bad/path")),
 		}, "error loading dataset transform: error loading transform raw data: datastore: key not found"},
 		{&dataset.Dataset{
-			Title:  "bad structure",
-			Commit: dataset.NewCommitMsgRef(datastore.NewKey("/bad/path")),
+			Commit: dataset.NewCommitRef(datastore.NewKey("/bad/path")),
 		}, "error loading dataset commit: error loading commit file: datastore: key not found"},
 	}
 
 	for i, c := range cases {
 		path := c.ds.Path()
+		t.Log(i, c.ds.IsEmpty())
 		if !c.ds.IsEmpty() {
 			dsf, err := JSONFile(PackageFileDataset.String(), c.ds)
 			if err != nil {
@@ -93,8 +97,8 @@ func TestSaveDataset(t *testing.T) {
 		repoEntries int
 		err         string
 	}{
-		{"testdata/cities.json", datastore.NewKey("/map/QmQDJiMKBXGJTXDJm4KQ6ddzggQhYi4PPHj2F6bqJCKwvv"), 2, ""},
-		{"testdata/complete.json", datastore.NewKey("/map/Qmdp2mMbLqhZCAdtHtVqA8GjRaxgdvPWyUEjVU1yCqcgyw"), 8, ""},
+		{"testdata/cities.json", datastore.NewKey("/map/QmVMxEijcYvGFofARruPV4Du5cYWUfsCquiEkQA18aeE1n"), 3, ""},
+		{"testdata/complete.json", datastore.NewKey("/map/QmcYUtYGu6mobvoarbxgs7opaXgtMsNbbAFXbWEpuZNKqv"), 10, ""},
 	}
 
 	for i, c := range cases {
@@ -163,6 +167,13 @@ func TestSaveDataset(t *testing.T) {
 			}
 			// Abstract transforms aren't loaded
 			ds.AbstractTransform = dataset.NewTransformRef(ref.AbstractTransform.Path())
+		}
+		if ref.Metadata != nil {
+			if !ref.Metadata.IsEmpty() {
+				t.Errorf("expected stored dataset.Metadata to be a reference")
+			}
+			// Abstract transforms aren't loaded
+			ds.Metadata.Assign(dataset.NewMetadataRef(ref.Metadata.Path()))
 		}
 		if ref.Structure != nil {
 			if !ref.Structure.IsEmpty() {

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -10,23 +10,6 @@ import (
 	"github.com/qri-io/dataset"
 )
 
-// func TestPrepareDataset(t *testing.T) {
-// 	store := memfs.NewMapstore()
-
-// 	cases := []struct {
-// 		in, out *dataset.Dataset
-// 		err     string
-// 	}{}
-
-// 	for i, c := range cases {
-// 		err := PrepareDataset(store, ds)
-// 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-// 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
-// 			continue
-// 		}
-// 	}
-// }
-
 func TestLoadDataset(t *testing.T) {
 	store := memfs.NewMapstore()
 
@@ -207,3 +190,20 @@ func TestSaveDataset(t *testing.T) {
 		}
 	}
 }
+
+// func TestPrepareDataset(t *testing.T) {
+// 	store := memfs.NewMapstore()
+
+// 	cases := []struct {
+// 		in, out *dataset.Dataset
+// 		err     string
+// 	}{}
+
+// 	for i, c := range cases {
+// 		err := PrepareDataset(store, ds)
+// 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+// 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+// 			continue
+// 		}
+// 	}
+// }

--- a/dsfs/metadata.go
+++ b/dsfs/metadata.go
@@ -1,0 +1,27 @@
+package dsfs
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/qri-io/cafs"
+	"github.com/qri-io/dataset"
+)
+
+// SaveMetadata saves a query's metadata to a given store
+func SaveMetadata(store cafs.Filestore, s *dataset.Metadata, pin bool) (path datastore.Key, err error) {
+	file, err := JSONFile(PackageFileMetadata.String(), s)
+	if err != nil {
+		return datastore.NewKey(""), fmt.Errorf("error saving json metadata file: %s", err.Error())
+	}
+	return store.Put(file, pin)
+}
+
+// LoadMetadata loads a metadata from a given path in a store
+func LoadMetadata(store cafs.Filestore, path datastore.Key) (md *dataset.Metadata, err error) {
+	data, err := fileBytes(store.Get(path))
+	if err != nil {
+		return nil, fmt.Errorf("error loading metadata file: %s", err.Error())
+	}
+	return dataset.UnmarshalMetadata(data)
+}

--- a/dsfs/metadata_test.go
+++ b/dsfs/metadata_test.go
@@ -1,0 +1,21 @@
+package dsfs
+
+import (
+	"testing"
+
+	"github.com/qri-io/cafs/memfs"
+)
+
+func TestLoadMetadata(t *testing.T) {
+	store := memfs.NewMapstore()
+	a, err := SaveMetadata(store, AirportCodes.Metadata, true)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	if _, err := LoadMetadata(store, a); err != nil {
+		t.Errorf(err.Error())
+	}
+	// TODO - other tests & stuff
+}

--- a/dsfs/package.go
+++ b/dsfs/package.go
@@ -23,15 +23,17 @@ const (
 	// that went into creating a dataset
 	// TODO - I think this can be removed now that Transform exists
 	PackageFileResources
-	// PackageFileCommitMsg is isolates the user-entered
+	// PackageFileCommit isolates the user-entered
 	// documentation of the changes to this dataset's history
-	PackageFileCommitMsg
+	PackageFileCommit
 	// PackageFileTransform isloates the concrete transform that
 	// generated this dataset
 	PackageFileTransform
 	// PackageFileAbstractTransform is the abstract version of
 	// the operation performed to create this dataset
 	PackageFileAbstractTransform
+	// PackageFileMetadata encapsulates human-readable metadata
+	PackageFileMetadata
 )
 
 // filenames maps PackageFile to their filename counterparts
@@ -42,8 +44,9 @@ var filenames = map[PackageFile]string{
 	PackageFileAbstract:          "abstract.json",
 	PackageFileAbstractTransform: "abstract_transform.json",
 	PackageFileResources:         "resources",
-	PackageFileCommitMsg:         "commit.json",
+	PackageFileCommit:            "commit.json",
 	PackageFileTransform:         "transform.json",
+	PackageFileMetadata:          "metadata.json",
 }
 
 // String implements the io.Stringer interface for PackageFile

--- a/dsfs/structure.go
+++ b/dsfs/structure.go
@@ -10,7 +10,6 @@ import (
 
 // SaveStructure saves a query's structure to a given store
 func SaveStructure(store cafs.Filestore, s *dataset.Structure, pin bool) (path datastore.Key, err error) {
-	s.Kind = dataset.KindStructure
 	file, err := JSONFile(PackageFileStructure.String(), s)
 	if err != nil {
 		return datastore.NewKey(""), fmt.Errorf("error saving json structure file: %s", err.Error())

--- a/dsfs/testdata/cities.json
+++ b/dsfs/testdata/cities.json
@@ -1,5 +1,8 @@
 {
-  "title": "example city data",
+  "metadata": {
+    "kind" : "qri:md:0",
+    "title": "example city data"
+  },
   "kind": "qri:ds:0",
   "structure": {
     "kind": "qri:st:0",

--- a/dsfs/testdata/complete.json
+++ b/dsfs/testdata/complete.json
@@ -1,9 +1,12 @@
 {
-  "title": "dataset with all submodels example",
   "kind": "qri:ds:0",
-  "commit" : {
-    "kind" : "qri:cm:0",
-    "message" : "I'm a commit"
+  "commit": {
+    "kind": "qri:cm:0",
+    "message": "I'm a commit"
+  },
+  "metadata": {
+    "kind": "qri:md:0",
+    "title": "dataset with all submodels example"
   },
   "transform": {
     "kind": "qri:tf:0",
@@ -34,7 +37,7 @@
   },
   "abstractTransform": {
     "kind": "qri:tf:0",
-    "data" : "select * from a",
+    "data": "select * from a",
     "structure": {
       "kind": "qri:st:0",
       "format": "csv",
@@ -54,8 +57,8 @@
         ]
       }
     },
-    "resources" : {
-      "a" : "/fake/path/to/abstract/dataset/"
+    "resources": {
+      "a": "/fake/path/to/abstract/dataset/"
     }
   },
   "abstract": {

--- a/dsfs/testdata_test.go
+++ b/dsfs/testdata_test.go
@@ -13,15 +13,17 @@ import (
 )
 
 var AirportCodes = &dataset.Dataset{
-	Title:    "Airport Codes",
-	Homepage: "http://www.ourairports.com/",
-	License: &dataset.License{
-		Type: "PDDL-1.0",
-	},
-	Citations: []*dataset.Citation{
-		{
-			Name: "Our Airports",
-			URL:  "http://ourairports.com/data/",
+	Metadata: &dataset.Metadata{
+		Title:    "Airport Codes",
+		HomePath: "http://www.ourairports.com/",
+		License: &dataset.License{
+			Type: "PDDL-1.0",
+		},
+		Citations: []*dataset.Citation{
+			{
+				Name: "Our Airports",
+				URL:  "http://ourairports.com/data/",
+			},
 		},
 	},
 	// File:   "data/airport-codes.csv",
@@ -29,8 +31,8 @@ var AirportCodes = &dataset.Dataset{
 	// Format: "text/csv",
 }
 
-var AirportCodesCommitMsg = &dataset.CommitMsg{
-	Kind:    dataset.KindCommitMsg,
+var AirportCodesCommit = &dataset.Commit{
+	Kind:    dataset.KindCommit,
 	Message: "initial commit",
 }
 
@@ -159,17 +161,21 @@ var AirportCodesStructureAgebraic = &dataset.Structure{
 }
 
 var ContinentCodes = &dataset.Dataset{
-	Title:       "Continent Codes",
-	Description: "list of continents with corresponding two letter codes",
-	License: &dataset.License{
-		Type: "odc-pddl",
-		URL:  "http://opendatacommons.org/licenses/pddl/",
-	},
-	Keywords: []string{
-		"Continents",
-		"Two letter code",
-		"Continent codes",
-		"Continent code list",
+	Kind: dataset.KindDataset,
+	Metadata: &dataset.Metadata{
+		Kind:        dataset.KindMetadata,
+		Title:       "Continent Codes",
+		Description: "list of continents with corresponding two letter codes",
+		License: &dataset.License{
+			Type: "odc-pddl",
+			URL:  "http://opendatacommons.org/licenses/pddl/",
+		},
+		Keywords: []string{
+			"Continents",
+			"Two letter code",
+			"Continent codes",
+			"Continent code list",
+		},
 	},
 }
 
@@ -190,7 +196,9 @@ var ContinentCodesStructure = &dataset.Structure{
 }
 
 var Hours = &dataset.Dataset{
-	Title: "hours",
+	Metadata: &dataset.Metadata{
+		Title: "hours",
+	},
 	// Data:   datastore.NewKey("/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"),
 }
 
@@ -236,7 +244,7 @@ func makeFilestore() (map[string]datastore.Key, cafs.Filestore, error) {
 			return datasets, nil, err
 		}
 
-		ds.Data = datakey.String()
+		ds.DataPath = datakey.String()
 		dskey, err := SaveDataset(fs, ds, true)
 		if err != nil {
 			return datasets, nil, err

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -32,7 +32,7 @@ func TestTransformLoadAbstract(t *testing.T) {
 
 func TestSaveTransform(t *testing.T) {
 	dsa := dataset.NewDatasetRef(datastore.NewKey("/path/to/dataset/a"))
-	dsa.Assign(&dataset.Dataset{Title: "now dataset isn't empty "})
+	dsa.Assign(&dataset.Dataset{Metadata: &dataset.Metadata{Title: "now dataset isn't empty"}})
 
 	store := memfs.NewMapstore()
 	q := &dataset.Transform{
@@ -90,7 +90,7 @@ func TestSaveTransform(t *testing.T) {
 
 func TestSaveAbstractTransform(t *testing.T) {
 	dsa := dataset.NewDatasetRef(datastore.NewKey("/path/to/dataset/a"))
-	dsa.Assign(&dataset.Dataset{Title: "now dataset isn't empty "})
+	dsa.Assign(&dataset.Dataset{Metadata: &dataset.Metadata{Title: "now dataset isn't empty "}})
 	dsa.Structure = &dataset.Structure{
 		Format: dataset.CSVDataFormat,
 		Schema: &dataset.Schema{

--- a/dsutil/dsutil_test.go
+++ b/dsutil/dsutil_test.go
@@ -106,7 +106,7 @@ func testStore() (cafs.Filestore, map[string]datastore.Key, error) {
 				},
 			},
 		},
-		Data: datakey.String(),
+		DataPath: datakey.String(),
 	}
 
 	dskey, err := dsfs.SaveDataset(fs, ds, true)

--- a/kind.go
+++ b/kind.go
@@ -15,6 +15,8 @@ const KindPrefix = "qri:"
 const (
 	// KindDataset is the current kind for datasets
 	KindDataset = Kind("qri:ds:0")
+	// KindMeta is the current kind for metadata
+	KindMetadata = Kind("qri:md:0")
 	// KindStructure is the current kind for dataset structures
 	KindStructure = Kind("qri:st:0")
 	// KindTransform is the current kind for dataset transforms

--- a/kind.go
+++ b/kind.go
@@ -21,8 +21,8 @@ const (
 	KindStructure = Kind("qri:st:0")
 	// KindTransform is the current kind for dataset transforms
 	KindTransform = Kind("qri:tf:0")
-	// KindCommitMsg is the current kind for dataset transforms
-	KindCommitMsg = Kind("qri:cm:0")
+	// KindCommit is the current kind for dataset transforms
+	KindCommit = Kind("qri:cm:0")
 )
 
 // Kind is a short identifier for all types of qri dataset objects

--- a/metadata.go
+++ b/metadata.go
@@ -92,6 +92,23 @@ func (md *Metadata) Meta() map[string]interface{} {
 	return md.meta
 }
 
+// UnmarshalMetadata tries to extract a metadata type from an empty
+// interface. Pairs nicely with datastore.Get() from github.com/ipfs/go-datastore
+func UnmarshalMetadata(v interface{}) (*Metadata, error) {
+	switch r := v.(type) {
+	case *Metadata:
+		return r, nil
+	case Metadata:
+		return &r, nil
+	case []byte:
+		metadata := &Metadata{}
+		err := json.Unmarshal(r, metadata)
+		return metadata, err
+	default:
+		return nil, fmt.Errorf("couldn't parse metadata, value is invalid type")
+	}
+}
+
 // Assign collapses all properties of a group of metadata structs onto one.
 // this is directly inspired by Javascript's Object.assign
 func (md *Metadata) Assign(metas ...*Metadata) {
@@ -102,6 +119,9 @@ func (md *Metadata) Assign(metas ...*Metadata) {
 
 		if m.path.String() != "" {
 			md.path = m.path
+		}
+		if m.Kind != "" {
+			md.Kind = m.Kind
 		}
 		if m.Title != "" {
 			md.Title = m.Title
@@ -242,14 +262,12 @@ func (md *Metadata) UnmarshalJSON(data []byte) error {
 	for _, f := range []string{
 		"accessPath",
 		"accrualPeriodicity",
-		"author",
 		"citations",
 		"contributors",
 		"data",
 		"description",
 		"downloadPath",
 		"homePath",
-		"iconImage",
 		"identifier",
 		"image",
 		"keyword",

--- a/metadata.go
+++ b/metadata.go
@@ -4,7 +4,272 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/ipfs/go-datastore"
 )
+
+// Meta contains all human-readable metadata about a dataset
+type Metadata struct {
+	// private storage for reference to this object
+	path datastore.Key
+	// meta holds additional arbitrarty metadata not covered by the spec
+	// when encoding & decoding json values here will be hoisted into the
+	// Dataset object
+	meta map[string]interface{}
+
+	// Url to access the dataset
+	AccessPath string `json:"accessPath,omitempty"`
+	// The frequency with which dataset changes. Must be an ISO 8601 repeating duration
+	AccrualPeriodicity string `json:"accrualPeriodicity,omitempty"`
+	// Citations is a slice of assets used to build this dataset
+	Citations []*Citation `json:"citations"`
+	// Contribute
+	Contributors []*User `json:"contributors,omitempty"`
+	// Description follows the DCAT sense of the word, it should be around a paragraph of
+	// human-readable text
+	Description string `json:"description,omitempty"`
+	// Url that should / must lead directly to the data itself
+	DownloadPath string `json:"downloadPath,omitempty"`
+	// HomePath is a path to a "home" resource, either a url or d.web path
+	HomePath string `json:"homePath,omitempty"`
+	// Identifier is for *other* data catalog specifications. Identifier should not be used
+	// or relied on to be unique, because this package does not enforce any of these rules.
+	Identifier string `json:"identifier,omitempty"`
+	// String of Keywords
+	Keywords []string `json:"keywords,omitempty"`
+	// Kind is required, must be qri:md:[version]
+	Kind Kind `json:"kind"`
+	// Languages this dataset is written in
+	Language []string `json:"language,omitempty"`
+	// License will automatically parse to & from a string value if provided as a raw string
+	License *License `json:"license,omitempty"`
+	// path to readmePath
+	ReadmePath string `json:"readmePath,omitempty"`
+	// Title of this dataset
+	Title string `json:"title,omitempty"`
+	// Theme
+	Theme []string `json:"theme,omitempty"`
+	// Version is the semantic version for this dataset
+	Version string `json:"version,omitempty"`
+}
+
+// IsEmpty checks to see if dataset has any fields other than the internal path
+func (md *Metadata) IsEmpty() bool {
+	return md.Title == "" &&
+		md.Description == "" &&
+		md.AccessPath == "" &&
+		md.AccrualPeriodicity == "" &&
+		md.Citations == nil &&
+		md.Contributors == nil &&
+		md.Description == "" &&
+		md.DownloadPath == "" &&
+		md.HomePath == "" &&
+		md.Identifier == "" &&
+		md.Keywords == nil &&
+		md.Language == nil &&
+		md.ReadmePath == "" &&
+		md.Title == "" &&
+		md.Theme == nil &&
+		md.Version == ""
+}
+
+// Path gives the internal path reference for this dataset
+func (md *Metadata) Path() datastore.Key {
+	return md.path
+}
+
+// NewMetadataRef creates a Metadata pointer with the internal
+// path property specified, and no other fields.
+func NewMetadataRef(path datastore.Key) *Metadata {
+	return &Metadata{path: path}
+}
+
+// Meta gives access to additional metadata not covered by dataset metadata
+func (md *Metadata) Meta() map[string]interface{} {
+	if md.meta == nil {
+		md.meta = map[string]interface{}{}
+	}
+	return md.meta
+}
+
+// Assign collapses all properties of a group of metadata structs onto one.
+// this is directly inspired by Javascript's Object.assign
+func (md *Metadata) Assign(metas ...*Metadata) {
+	for _, m := range metas {
+		if m == nil {
+			continue
+		}
+
+		if m.path.String() != "" {
+			md.path = m.path
+		}
+		if m.Title != "" {
+			md.Title = m.Title
+		}
+		if m.AccessPath != "" {
+			md.AccessPath = m.AccessPath
+		}
+		if m.DownloadPath != "" {
+			md.DownloadPath = m.DownloadPath
+		}
+		if m.ReadmePath != "" {
+			md.ReadmePath = m.ReadmePath
+		}
+		if m.AccrualPeriodicity != "" {
+			md.AccrualPeriodicity = m.AccrualPeriodicity
+		}
+		if m.Citations != nil {
+			md.Citations = m.Citations
+		}
+		if m.Description != "" {
+			md.Description = m.Description
+		}
+		if m.HomePath != "" {
+			md.HomePath = m.HomePath
+		}
+		if m.Identifier != "" {
+			md.Identifier = m.Identifier
+		}
+		if m.License != nil {
+			md.License = m.License
+		}
+		if m.Version != "" {
+			md.Version = m.Version
+		}
+		if m.Keywords != nil {
+			md.Keywords = m.Keywords
+		}
+		if m.Contributors != nil {
+			md.Contributors = m.Contributors
+		}
+		if m.Language != nil {
+			md.Language = m.Language
+		}
+		if m.Theme != nil {
+			md.Theme = m.Theme
+		}
+		if m.meta != nil {
+			md.meta = m.meta
+		}
+	}
+}
+
+// MarshalJSON uses a map to combine meta & standard fields.
+// Marshalling a map[string]interface{} automatically alpha-sorts the keys.
+func (md *Metadata) MarshalJSON() ([]byte, error) {
+	// if we're dealing with an empty object that has a path specified, marshal to a string instead
+	// TODO - check all fielmd
+	if md.path.String() != "" && md.IsEmpty() {
+		return md.path.MarshalJSON()
+	}
+
+	data := md.Meta()
+
+	data["kind"] = KindMetadata
+
+	if md.AccessPath != "" {
+		data["accessPath"] = md.AccessPath
+	}
+	if md.Citations != nil {
+		data["citations"] = md.Citations
+	}
+	if md.Contributors != nil {
+		data["contributors"] = md.Contributors
+	}
+	if md.Description != "" {
+		data["description"] = md.Description
+	}
+	if md.DownloadPath != "" {
+		data["downloadPath"] = md.DownloadPath
+	}
+	if md.HomePath != "" {
+		data["homePath"] = md.HomePath
+	}
+	if md.Identifier != "" {
+		data["identifier"] = md.Identifier
+	}
+	if md.Keywords != nil {
+		data["keywords"] = md.Keywords
+	}
+	if md.Language != nil {
+		data["language"] = md.Language
+	}
+	if md.License != nil {
+		data["license"] = md.License
+	}
+	if md.ReadmePath != "" {
+		data["readmePath"] = md.ReadmePath
+	}
+	if md.Theme != nil {
+		data["theme"] = md.Theme
+	}
+	if md.Title != "" {
+		data["title"] = md.Title
+	}
+	if md.AccrualPeriodicity != "" {
+		data["accrualPeriodicity"] = md.AccrualPeriodicity
+	}
+	if md.Version != "" {
+		data["version"] = md.Version
+	}
+
+	return json.Marshal(data)
+}
+
+// internal struct for json unmarshaling
+type _metadata Metadata
+
+// UnmarshalJSON implements json.Unmarshaller
+func (md *Metadata) UnmarshalJSON(data []byte) error {
+	// first check to see if this is a valid path ref
+	var path string
+	if err := json.Unmarshal(data, &path); err == nil {
+		*md = Metadata{path: datastore.NewKey(path)}
+		return nil
+	}
+
+	// TODO - I'm guessing what follows could be better
+	d := _metadata{}
+	if err := json.Unmarshal(data, &d); err != nil {
+		return fmt.Errorf("error unmarshling dataset: %s", err.Error())
+	}
+
+	meta := map[string]interface{}{}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return fmt.Errorf("error unmarshaling dataset metadata: %s", err, err)
+	}
+
+	for _, f := range []string{
+		"accessPath",
+		"accrualPeriodicity",
+		"author",
+		"citations",
+		"contributors",
+		"data",
+		"description",
+		"downloadPath",
+		"homePath",
+		"iconImage",
+		"identifier",
+		"image",
+		"keyword",
+		"kind",
+		"language",
+		"length",
+		"license",
+		"readmePath",
+		"theme",
+		"timestamp",
+		"title",
+		"version",
+	} {
+		delete(meta, f)
+	}
+
+	d.meta = meta
+	*md = Metadata(d)
+	return nil
+}
 
 // User is a placholder for talking about people, groups, organizations
 type User struct {

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,9 +1,170 @@
 package dataset
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-datastore"
 )
+
+func TestMetadataAssign(t *testing.T) {
+	// TODO - expand test to check all fields
+	cases := []struct {
+		in *Metadata
+	}{
+		{&Metadata{path: datastore.NewKey("/a")}},
+		{&Metadata{AccessPath: "foo"}},
+		{&Metadata{DownloadPath: "foo"}},
+		{&Metadata{ReadmePath: "foo"}},
+		{&Metadata{AccrualPeriodicity: "1W"}},
+		{&Metadata{Citations: []*Citation{&Citation{Email: "foo"}}}},
+		{&Metadata{Description: "foo"}},
+		{&Metadata{HomePath: "foo"}},
+		{&Metadata{Identifier: "foo"}},
+		{&Metadata{License: &License{Type: "foo"}}},
+		{&Metadata{Version: "foo"}},
+		{&Metadata{Keywords: []string{"foo"}}},
+		{&Metadata{Contributors: []*User{&User{Email: "foo"}}}},
+		{&Metadata{Language: []string{"stuff"}}},
+		{&Metadata{Theme: []string{"stuff"}}},
+		{&Metadata{meta: map[string]interface{}{"foo": "bar"}}},
+	}
+
+	for i, c := range cases {
+		got := &Metadata{}
+		got.Assign(c.in)
+		if err := CompareMetadatas(c.in, got); err != nil {
+			t.Errorf("case %d error: %s", i, err.Error())
+			continue
+		}
+	}
+
+	expect := &Metadata{
+		Title:       "Final Title",
+		Description: "Final Description",
+		AccessPath:  "AccessPath",
+	}
+	got := &Metadata{
+		Title:       "Overwrite Me",
+		Description: "Nope",
+	}
+
+	got.Assign(&Metadata{
+		Title:       "Final Title",
+		Description: "Final Description",
+		AccessPath:  "AccessPath",
+	})
+
+	if err := CompareMetadatas(expect, got); err != nil {
+		t.Error(err)
+	}
+
+	got.Assign(nil, nil)
+	if err := CompareMetadatas(expect, got); err != nil {
+		t.Error(err)
+	}
+
+	emptyDs := &Metadata{}
+	emptyDs.Assign(expect)
+	if err := CompareMetadatas(expect, emptyDs); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestMetadataMarshalJSON(t *testing.T) {
+	cases := []struct {
+		in  *Metadata
+		out []byte
+		err error
+	}{
+		{&Metadata{}, []byte(`{"kind":"qri:md:0"}`), nil},
+		{AirportCodes.Metadata, []byte(`{"citations":[{"name":"Our Airports","url":"http://ourairports.com/data/"}],"homePath":"http://www.ourairports.com/","kind":"qri:md:0","license":"PDDL-1.0","title":"Airport Codes"}`), nil},
+		{Hours.Metadata, []byte(`{"accessPath":"https://example.com/not/a/url","downloadPath":"https://example.com/not/a/url","kind":"qri:md:0","readmePath":"/ipfs/notahash","title":"hours"}`), nil},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSON()
+		if err != c.err {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if !bytes.Equal(c.out, got) {
+			t.Errorf("case %d error mismatch. %s != %s", i, string(c.out), string(got))
+			continue
+		}
+	}
+
+	data, err := ioutil.ReadFile("testdata/datasets/complete.json")
+	if err != nil {
+		t.Errorf("error reading dataset file: %s", err.Error())
+		return
+	}
+	ds := &Metadata{}
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Errorf("error unmarshaling json: %s", err.Error())
+		return
+	}
+	if _, err := ds.MarshalJSON(); err != nil {
+		t.Errorf("error marshaling back to json: %s", err.Error())
+		return
+	}
+
+	strbytes, err := json.Marshal(&Metadata{path: datastore.NewKey("/path/to/dataset")})
+	if err != nil {
+		t.Errorf("unexpected string marshal error: %s", err.Error())
+		return
+	}
+
+	if !bytes.Equal(strbytes, []byte("\"/path/to/dataset\"")) {
+		t.Errorf("marshal strbyte interface byte mismatch: %s != %s", string(strbytes), "\"/path/to/dataset\"")
+	}
+}
+
+func TestMetadataUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		FileName string
+		result   *Metadata
+		err      error
+	}{
+		{"testdata/metadata/airport-codes.json", AirportCodes.Metadata, nil},
+		{"testdata/metadata/continent-codes.json", ContinentCodes.Metadata, nil},
+		{"testdata/metadata/hours.json", Hours.Metadata, nil},
+	}
+
+	for i, c := range cases {
+		data, err := ioutil.ReadFile(c.FileName)
+		if err != nil {
+			t.Errorf("case %d couldn't read file: %s", i, err.Error())
+		}
+
+		ds := &Metadata{}
+		if err := json.Unmarshal(data, ds); err != c.err {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if err = CompareMetadatas(ds, c.result); err != nil {
+			t.Errorf("case %d resource comparison error: %s", i, err)
+			continue
+		}
+	}
+
+	strds := &Metadata{}
+	path := "/path/to/dataset"
+	if err := json.Unmarshal([]byte(`"`+path+`"`), strds); err != nil {
+		t.Errorf("unmarshal string path error: %s", err.Error())
+		return
+	}
+
+	if strds.path.String() != path {
+		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strds.path)
+		return
+	}
+}
 
 func TestLicense(t *testing.T) {
 

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -166,6 +166,32 @@ func TestMetadataUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMetadata(t *testing.T) {
+	dsa := Metadata{Kind: KindMetadata}
+	cases := []struct {
+		value interface{}
+		out   *Metadata
+		err   string
+	}{
+		{dsa, &dsa, ""},
+		{&dsa, &dsa, ""},
+		{[]byte("{\"kind\":\"qri:md:0\"}"), &Metadata{Kind: KindMetadata}, ""},
+		{5, nil, "couldn't parse metadata, value is invalid type"},
+	}
+
+	for i, c := range cases {
+		got, err := UnmarshalMetadata(c.value)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		if err := CompareMetadatas(c.out, got); err != nil {
+			t.Errorf("case %d metadata mismatch: %s", i, err.Error())
+			continue
+		}
+	}
+}
+
 func TestLicense(t *testing.T) {
 
 }

--- a/structure.go
+++ b/structure.go
@@ -19,6 +19,12 @@ type Structure struct {
 	path datastore.Key
 	// Kind should always be KindStructure
 	Kind `json:"kind"`
+	// Length is the length of the data object in bytes.
+	// must always match & be present
+	Length int `json:"length,omitempty"`
+	// number of rows in the dataset.
+	// required and must match underlying dataset.
+	Rows int `json:"rows"`
 	// Format specifies the format of the raw data MIME type
 	Format DataFormat `json:"format"`
 	// FormatConfig removes as much ambiguity as possible about how
@@ -146,13 +152,6 @@ func (s *Structure) UnmarshalJSON(data []byte) (err error) {
 		Kind:         _s.Kind,
 		Schema:       _s.Schema,
 	}
-
-	// TODO - question of weather we should not accept
-	// invalid structure defs at parse time. For now we'll take 'em.
-	// if err := d.Valid(); err != nil {
-	//   return err
-	// }
-
 	return nil
 }
 
@@ -171,6 +170,12 @@ func (s *Structure) Assign(structures ...*Structure) {
 
 		if st.path.String() != "" {
 			s.path = st.path
+		}
+		if st.Length != 0 {
+			s.Length = st.Length
+		}
+		if st.Rows != 0 {
+			s.Rows = st.Rows
 		}
 		if st.Format != UnknownDataFormat {
 			s.Format = st.Format

--- a/structure_test.go
+++ b/structure_test.go
@@ -64,6 +64,7 @@ func TestStructureAbstract(t *testing.T) {
 func TestStructureAssign(t *testing.T) {
 	expect := &Structure{
 		Format: CSVDataFormat,
+		Length: 2503,
 		Schema: &Schema{
 			Fields: []*Field{
 				{Type: datatypes.String, Name: "foo"},
@@ -83,6 +84,7 @@ func TestStructureAssign(t *testing.T) {
 	}
 
 	got.Assign(&Structure{
+		Length: 2503,
 		Schema: &Schema{
 			Fields: []*Field{
 				{Name: "foo"},

--- a/testdata/datasets/airport-codes.json
+++ b/testdata/datasets/airport-codes.json
@@ -1,8 +1,11 @@
 {
-  "title": "Airport Codes",
   "kind": "qri:ds:0",
-  "homepage": "http://www.ourairports.com/",
-  "license": "PDDL-1.0",
+  "metadata" : {
+    "kind" : "qri:md:0",
+    "homePath": "http://www.ourairports.com/",
+    "license": "PDDL-1.0",
+    "title": "Airport Codes"
+  },
   "commit": {
     "title": "initial commit"
   },

--- a/testdata/datasets/complete.json
+++ b/testdata/datasets/complete.json
@@ -1,28 +1,45 @@
 {
-  "title": "dataset with all submodels example",
-  "description" : "foo",
-  "accessUrl" : "foo",
-  "downloadUrl" : "foo",
-  "accrualPeriodicity" : "1W",
-  "version" : "0",
-  "readme" : "foo",
-  "queryString" : "foo",
-  "previous" : "foo",
   "kind": "qri:ds:0",
-  "identifier" : "foo",
-  "iconImage" : "foo",
-  "length" : 2503,
-  "image" : "foo",
-  "keywords" : ["a","b", "foo"],
-  "language" : ["english"],
-  "theme" : ["foo"],
-  "author" : {"email" : "foo"},
-  "data" : "foo",
-  "contributors" : [{"email" : "foo"}],
-  "timestamp" : "2017-12-21T04:13:22.534Z",
-  "commit" : {
-    "kind" : "qri:cm:0",
-    "message" : "I'm a commit"
+  "metadata": {
+    "title": "dataset with all submodels example",
+    "description": "foo",
+    "accessUrl": "foo",
+    "downloadUrl": "foo",
+    "accrualPeriodicity": "1W",
+    "version": "0",
+    "readme": "foo",
+    "queryString": "foo",
+    "previous": "foo",
+    "kind": "qri:md:0",
+    "identifier": "foo",
+    "iconImage": "foo",
+    "length": 2503,
+    "image": "foo",
+    "keywords": [
+      "a",
+      "b",
+      "foo"
+    ],
+    "language": [
+      "english"
+    ],
+    "theme": [
+      "foo"
+    ],
+    "author": {
+      "email": "foo"
+    },
+    "data": "foo",
+    "contributors": [
+      {
+        "email": "foo"
+      }
+    ]
+  },
+  "commit": {
+    "kind": "qri:cm:0",
+    "timestamp": "2017-12-21T04:13:22.534Z",
+    "message": "I'm a commit"
   },
   "transform": {
     "kind": "qri:tf:0",
@@ -53,7 +70,7 @@
   },
   "abstractTransform": {
     "kind": "qri:tf:0",
-    "data" : "select * from a",
+    "data": "select * from a",
     "structure": {
       "kind": "qri:st:0",
       "format": "csv",
@@ -73,8 +90,8 @@
         ]
       }
     },
-    "resources" : {
-      "a" : "/fake/path/to/abstract/dataset/"
+    "resources": {
+      "a": "/fake/path/to/abstract/dataset/"
     }
   },
   "abstract": {

--- a/testdata/datasets/continent-codes.json
+++ b/testdata/datasets/continent-codes.json
@@ -1,15 +1,18 @@
 {
-  "title": "Continent Codes",
   "kind": "qri:ds:0",
-  "description": "list of continents with corresponding two letter codes",
-  "license": {
-    "type": "odc-pddl",
-    "url": "http://opendatacommons.org/licenses/pddl/"
-  },
-  "keywords": [
-    "Continents",
-    "Two letter code",
-    "Continent codes",
-    "Continent code list"
-  ]
+  "metadata": {
+    "title": "Continent Codes",
+    "kind": "qri:md:0",
+    "description": "list of continents with corresponding two letter codes",
+    "license": {
+      "type": "odc-pddl",
+      "url": "http://opendatacommons.org/licenses/pddl/"
+    },
+    "keywords": [
+      "Continents",
+      "Two letter code",
+      "Continent codes",
+      "Continent code list"
+    ]
+  }
 }

--- a/testdata/datasets/hours.json
+++ b/testdata/datasets/hours.json
@@ -1,7 +1,11 @@
 {
-  "title" : "hours",
   "kind": "qri:ds:0",
-  "length": 0,
-  "data": "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
-  "transformEngineConfig": null
+  "metadata": {
+    "kind": "qri:md:0",
+    "title": "hours",
+    "accessPath": "https://example.com/not/a/url",
+    "downloadPath": "https://example.com/not/a/url",
+    "readmePath": "/ipfs/notahash"
+  },
+  "dataPath": "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"
 }

--- a/testdata/metadata/airport-codes.json
+++ b/testdata/metadata/airport-codes.json
@@ -1,0 +1,6 @@
+{
+  "kind": "qri:md:0",
+  "homePath": "http://www.ourairports.com/",
+  "license": "PDDL-1.0",
+  "title": "Airport Codes"
+}

--- a/testdata/metadata/continent-codes.json
+++ b/testdata/metadata/continent-codes.json
@@ -1,0 +1,15 @@
+{
+  "title": "Continent Codes",
+  "kind": "qri:md:0",
+  "description": "list of continents with corresponding two letter codes",
+  "license": {
+    "type": "odc-pddl",
+    "url": "http://opendatacommons.org/licenses/pddl/"
+  },
+  "keywords": [
+    "Continents",
+    "Two letter code",
+    "Continent codes",
+    "Continent code list"
+  ]
+}

--- a/testdata/metadata/hours.json
+++ b/testdata/metadata/hours.json
@@ -1,0 +1,7 @@
+{
+  "kind": "qri:md:0",
+  "title": "hours",
+  "accessPath": "https://example.com/not/a/url",
+  "downloadPath": "https://example.com/not/a/url",
+  "readmePath": "/ipfs/notahash"
+}

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -5,23 +5,23 @@ import (
 )
 
 var AirportCodes = &Dataset{
-	Kind:     KindDataset,
-	Title:    "Airport Codes",
-	Homepage: "http://www.ourairports.com/",
-	License: &License{
-		Type: "PDDL-1.0",
-	},
-	Citations: []*Citation{
-		{
-			Name: "Our Airports",
-			URL:  "http://ourairports.com/data/",
+	Kind: KindDataset,
+	Metadata: &Metadata{
+		Kind:     KindMetadata,
+		Title:    "Airport Codes",
+		HomePath: "http://www.ourairports.com/",
+		License: &License{
+			Type: "PDDL-1.0",
+		},
+		Citations: []*Citation{
+			{
+				Name: "Our Airports",
+				URL:  "http://ourairports.com/data/",
+			},
 		},
 	},
 	Commit:    &CommitMsg{Title: "initial commit"},
 	Structure: AirportCodesStructure,
-	// File:   "data/airport-codes.csv",
-	// Readme: "readme.md",
-	// Format: "text/csv",
 }
 
 var AirportCodesAbstract = &Dataset{
@@ -29,7 +29,7 @@ var AirportCodesAbstract = &Dataset{
 	Structure: AirportCodesStructureAbstract,
 }
 
-const AirportCodesJSON = `{"citations":[{"name":"Our Airports","url":"http://ourairports.com/data/"}],"commit":{"kind":"qri:cm:0","title":"initial commit"},"homepage":"http://www.ourairports.com/","kind":"qri:ds:0","license":"PDDL-1.0","structure":{"format":"csv","formatConfig":{"headerRow":true},"kind":"qri:st:0","schema":{"fields":[{"name":"ident","type":"string"},{"name":"type","type":"string"},{"name":"name","type":"string"},{"name":"latitude_deg","type":"float"},{"name":"longitude_deg","type":"float"},{"name":"elevation_ft","type":"integer"},{"name":"continent","type":"string"},{"name":"iso_country","type":"string"},{"name":"iso_region","type":"string"},{"name":"municipality","type":"string"},{"name":"gps_code","type":"string"},{"name":"iata_code","type":"string"},{"name":"local_code","type":"string"}]}},"title":"Airport Codes"}`
+const AirportCodesJSON = `{"commit":{"kind":"qri:cm:0","timestamp":"0001-01-01T00:00:00Z","title":"initial commit"},"kind":"qri:ds:0","metadata":{"citations":[{"name":"Our Airports","url":"http://ourairports.com/data/"}],"homePath":"http://www.ourairports.com/","kind":"qri:md:0","license":"PDDL-1.0","title":"Airport Codes"},"structure":{"format":"csv","formatConfig":{"headerRow":true},"kind":"qri:st:0","schema":{"fields":[{"name":"ident","type":"string"},{"name":"type","type":"string"},{"name":"name","type":"string"},{"name":"latitude_deg","type":"float"},{"name":"longitude_deg","type":"float"},{"name":"elevation_ft","type":"integer"},{"name":"continent","type":"string"},{"name":"iso_country","type":"string"},{"name":"iso_region","type":"string"},{"name":"municipality","type":"string"},{"name":"gps_code","type":"string"},{"name":"iata_code","type":"string"},{"name":"local_code","type":"string"}]}}}`
 
 var AirportCodesStructure = &Structure{
 	Format: CSVDataFormat,
@@ -157,18 +157,21 @@ var AirportCodesStructureAbstract = &Structure{
 }
 
 var ContinentCodes = &Dataset{
-	Title:       "Continent Codes",
-	Kind:        KindDataset,
-	Description: "list of continents with corresponding two letter codes",
-	License: &License{
-		Type: "odc-pddl",
-		URL:  "http://opendatacommons.org/licenses/pddl/",
-	},
-	Keywords: []string{
-		"Continents",
-		"Two letter code",
-		"Continent codes",
-		"Continent code list",
+	Kind: KindDataset,
+	Metadata: &Metadata{
+		Title:       "Continent Codes",
+		Kind:        KindMetadata,
+		Description: "list of continents with corresponding two letter codes",
+		License: &License{
+			Type: "odc-pddl",
+			URL:  "http://opendatacommons.org/licenses/pddl/",
+		},
+		Keywords: []string{
+			"Continents",
+			"Two letter code",
+			"Continent codes",
+			"Continent code list",
+		},
 	},
 }
 
@@ -189,9 +192,15 @@ var ContinentCodesStructure = &Structure{
 }
 
 var Hours = &Dataset{
-	Title: "hours",
-	Kind:  KindDataset,
-	Data:  "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
+	Kind: KindDataset,
+	Metadata: &Metadata{
+		Title:        "hours",
+		Kind:         KindMetadata,
+		AccessPath:   "https://example.com/not/a/url",
+		DownloadPath: "https://example.com/not/a/url",
+		ReadmePath:   "/ipfs/notahash",
+	},
+	DataPath: "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
 }
 
 var HoursStructure = &Structure{

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -20,7 +20,7 @@ var AirportCodes = &Dataset{
 			},
 		},
 	},
-	Commit:    &CommitMsg{Title: "initial commit"},
+	Commit:    &Commit{Title: "initial commit"},
 	Structure: AirportCodesStructure,
 }
 

--- a/validate/dataset.go
+++ b/validate/dataset.go
@@ -27,9 +27,9 @@ func Dataset(ds *dataset.Dataset) error {
 	return nil
 }
 
-// Commit checks that a dataset CommitMsg is valid for use
+// Commit checks that a dataset Commit is valid for use
 // returning the first error encountered, nil if valid
-func Commit(cm *dataset.CommitMsg) error {
+func Commit(cm *dataset.Commit) error {
 	if cm == nil {
 		return nil
 	}

--- a/validate/dataset_test.go
+++ b/validate/dataset_test.go
@@ -13,9 +13,9 @@ func TestDataset(t *testing.T) {
 		err string
 	}{
 		{nil, ""},
-		{&dataset.Dataset{Commit: &dataset.CommitMsg{}}, "commit: title is required"},
+		{&dataset.Dataset{Commit: &dataset.Commit{}}, "commit: title is required"},
 		{&dataset.Dataset{Structure: &dataset.Structure{}}, "structure: dataFormat is required"},
-		{&dataset.Dataset{Abstract: &dataset.Dataset{Title: "foo"}}, "abstract field is not an abstract dataset. Title: foo != "},
+		{&dataset.Dataset{Abstract: &dataset.Dataset{Metadata: &dataset.Metadata{}}}, "abstract field is not an abstract dataset. Metadata: nil: <not nil> != <nil>"},
 		{&dataset.Dataset{}, ""},
 	}
 
@@ -30,13 +30,13 @@ func TestDataset(t *testing.T) {
 
 func TestCommit(t *testing.T) {
 	cases := []struct {
-		cm  *dataset.CommitMsg
+		cm  *dataset.Commit
 		err string
 	}{
 		{nil, ""},
-		{&dataset.CommitMsg{}, "title is required"},
-		{&dataset.CommitMsg{Title: strings.Repeat("f", 150)}, "title is too long. 150 length exceeds 100 character limit"},
-		{&dataset.CommitMsg{Title: "message"}, ""},
+		{&dataset.Commit{}, "title is required"},
+		{&dataset.Commit{Title: strings.Repeat("f", 150)}, "title is too long. 150 length exceeds 100 character limit"},
+		{&dataset.Commit{Title: "message"}, ""},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
This refactor moves all user-added metadata into a new Metadata struct, allowing commits that don't alter metadata to de-duplicate via hash reference.

The byproduct of this is now Dataset is only a collection of references which on the face of it feels right. For some time our humble dataset package has been caught between being a child of git or a child of DCAT, it's now clear that it's a child of git. To me this elevates the need for interop procedures that allow datasets to be seamlessly expressed as DCAT & datapackages, so those'll get moved up the list.