### PR TITLE
refactor: expose `MarshalJSONObject()` methods for dataset subcomponents

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -104,6 +104,11 @@ func (cm *Commit) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (cm *Commit) MarshalJSONObject() ([]byte, error) {
+	return []byte("todo..."), nil
+}
+
 // internal struct for json unmarshaling
 type _commitMsg Commit
 

--- a/commit.go
+++ b/commit.go
@@ -87,7 +87,11 @@ func (cm *Commit) MarshalJSON() ([]byte, error) {
 	if cm.path.String() != "" && cm.IsEmpty() {
 		return cm.path.MarshalJSON()
 	}
+	return cm.MarshalJSONObject()
+}
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (cm *Commit) MarshalJSONObject() ([]byte, error) {
 	kind := cm.Qri
 	if kind == "" {
 		kind = KindCommit
@@ -102,11 +106,6 @@ func (cm *Commit) MarshalJSON() ([]byte, error) {
 		Title:     cm.Title,
 	}
 	return json.Marshal(m)
-}
-
-// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
-func (cm *Commit) MarshalJSONObject() ([]byte, error) {
-	return []byte("todo..."), nil
 }
 
 // internal struct for json unmarshaling

--- a/commit_test.go
+++ b/commit_test.go
@@ -132,6 +132,34 @@ func TestCommitMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestCommitMarshalJSONObject(t *testing.T) {
+	ts := time.Date(2001, 01, 01, 01, 01, 01, 0, time.UTC)
+	cases := []struct {
+		in  *Commit
+		out []byte
+		err error
+	}{
+		{&Commit{Title: "title", Timestamp: ts}, []byte(`{"qri":"cm:0","timestamp":"2001-01-01T01:01:01Z","title":"title"}`), nil},
+		{&Commit{Author: &User{ID: "foo"}, Timestamp: ts}, []byte(`{"author":{"id":"foo"},"qri":"cm:0","timestamp":"2001-01-01T01:01:01Z","title":""}`), nil},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSON()
+		if err != c.err {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		check := &map[string]interface{}{}
+		err = json.Unmarshal(got, check)
+		if err != nil {
+			t.Errorf("case %d error: failed to unmarshal to object: %s", err.Error())
+			continue
+		}
+
+	}
+
+}
+
 func TestCommitUnmarshalJSON(t *testing.T) {
 	cases := []struct {
 		data   string

--- a/structure.go
+++ b/structure.go
@@ -138,6 +138,11 @@ func (s Structure) MarshalJSON() (data []byte, err error) {
 	})
 }
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (s Structure) MarshalJSONObject() ([]byte, error) {
+	return []byte("todo..."), nil
+}
+
 // UnmarshalJSON satisfies the json.Unmarshaler interface
 func (s *Structure) UnmarshalJSON(data []byte) (err error) {
 	var (

--- a/structure.go
+++ b/structure.go
@@ -114,6 +114,11 @@ func (s Structure) MarshalJSON() (data []byte, err error) {
 		return s.path.MarshalJSON()
 	}
 
+	return s.MarshalJSONObject()
+}
+
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (s Structure) MarshalJSONObject() ([]byte, error) {
 	kind := s.Qri
 	if kind == "" {
 		kind = KindStructure
@@ -136,11 +141,6 @@ func (s Structure) MarshalJSON() (data []byte, err error) {
 		Qri:          kind,
 		Schema:       s.Schema,
 	})
-}
-
-// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
-func (s Structure) MarshalJSONObject() ([]byte, error) {
-	return []byte("todo..."), nil
 }
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface

--- a/structure_test.go
+++ b/structure_test.go
@@ -214,6 +214,33 @@ func TestStructureMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestStructureMarshalJSONObject(t *testing.T) {
+	cases := []struct {
+		in  *Structure
+		out []byte
+		err error
+	}{
+		{&Structure{Format: CSVDataFormat}, []byte(`{"errCount":0,"format":"csv","qri":"st:0"}`), nil},
+		{&Structure{Format: CSVDataFormat, Qri: KindStructure}, []byte(`{"errCount":0,"format":"csv","qri":"st:0"}`), nil},
+		{AirportCodesStructure, []byte(`{"errCount":5,"format":"csv","formatConfig":{"headerRow":true},"qri":"st:0","schema":{"items":{"items":[{"title":"ident","type":"string"},{"title":"type","type":"string"},{"title":"name","type":"string"},{"title":"latitude_deg","type":"string"},{"title":"longitude_deg","type":"string"},{"title":"elevation_ft","type":"string"},{"title":"continent","type":"string"},{"title":"iso_country","type":"string"},{"title":"iso_region","type":"string"},{"title":"municipality","type":"string"},{"title":"gps_code","type":"string"},{"title":"iata_code","type":"string"},{"title":"local_code","type":"string"}],"type":"array"},"type":"array"}}`), nil},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSONObject()
+		if err != c.err {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		// now try to unmarshal to map string interface
+		check := &map[string]interface{}{}
+		err = json.Unmarshal(got, check)
+		if err != nil {
+			t.Errorf("case %d error: failed to unmarshal to object: %s", err.Error())
+			continue
+		}
+	}
+}
+
 func TestUnmarshalStructure(t *testing.T) {
 	sta := Structure{Qri: KindStructure, Format: CSVDataFormat}
 	cases := []struct {

--- a/transform.go
+++ b/transform.go
@@ -131,7 +131,11 @@ func (q Transform) MarshalJSON() ([]byte, error) {
 	if q.path.String() != "" && q.IsEmpty() {
 		return q.path.MarshalJSON()
 	}
+	return q.MarshalJSONObject()
+}
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (q Transform) MarshalJSONObject() ([]byte, error) {
 	kind := q.Qri
 	if kind == "" {
 		kind = KindTransform
@@ -146,11 +150,6 @@ func (q Transform) MarshalJSON() ([]byte, error) {
 		Structure:  q.Structure,
 		Syntax:     q.Syntax,
 	})
-}
-
-// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
-func (q Transform) MarshalJSONObject() ([]byte, error) {
-	return []byte("todo..."), nil
 }
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface

--- a/transform.go
+++ b/transform.go
@@ -148,6 +148,11 @@ func (q Transform) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (q Transform) MarshalJSONObject() ([]byte, error) {
+	return []byte("todo..."), nil
+}
+
 // UnmarshalJSON satisfies the json.Unmarshaler interface
 func (q *Transform) UnmarshalJSON(data []byte) error {
 	var s string

--- a/transform_test.go
+++ b/transform_test.go
@@ -104,7 +104,7 @@ func TestTransformUnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestTransformMarshalJSON(t *testing.T) {
+func TestTransformMarshalJSONObject(t *testing.T) {
 	cases := []struct {
 		q   *Transform
 		out string

--- a/transform_test.go
+++ b/transform_test.go
@@ -137,6 +137,32 @@ func TestTransformMarshalJSON(t *testing.T) {
 	}
 }
 
+func TestTransformMarshalJSON(t *testing.T) {
+	cases := []struct {
+		q   *Transform
+		out string
+		err error
+	}{
+		{&Transform{}, `{"qri":"tf:0"}`, nil},
+		{&Transform{Syntax: "sql", Data: "select a from b"}, `{"data":"select a from b","qri":"tf:0","syntax":"sql"}`, nil},
+	}
+
+	for i, c := range cases {
+		data, err := json.Marshal(c.q)
+		if err != c.err {
+			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err)
+			continue
+		}
+		check := &map[string]interface{}{}
+		err = json.Unmarshal(data, check)
+		if err != nil {
+			t.Errorf("case %d error: failed to unmarshal to object: %s", err.Error())
+			continue
+		}
+	}
+
+}
+
 func TestTransformIsEmpty(t *testing.T) {
 	cases := []struct {
 		tf       *Transform

--- a/vis_config.go
+++ b/vis_config.go
@@ -85,7 +85,11 @@ func (v *VisConfig) MarshalJSON() ([]byte, error) {
 	if v.path.String() != "" && v.IsEmpty() {
 		return v.path.MarshalJSON()
 	}
+	return v.MarshalJSONObject()
+}
 
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
 	kind := v.Kind
 	if kind == "" {
 		kind = KindVisConfig
@@ -97,11 +101,6 @@ func (v *VisConfig) MarshalJSON() ([]byte, error) {
 		Kind:           kind,
 		Visualizations: v.Visualizations,
 	})
-}
-
-// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
-func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
-	return []byte("todo..."), nil
 }
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface

--- a/vis_config.go
+++ b/vis_config.go
@@ -1,141 +1,146 @@
 package dataset
 
 import (
-  "encoding/json"
-  "fmt"
-  "github.com/ipfs/go-datastore"
+	"encoding/json"
+	"fmt"
+	"github.com/ipfs/go-datastore"
 )
 
 // VisConfig stores configuration data related to representing a dataset as a visualization
 type VisConfig struct {
-  // private storage for reference to this object
-  path datastore.Key
-  // Kind should always be "qri:vc:0"
-  Kind Kind
-  // Format designates the visualization configuration syntax
-  Format string
-  // Visualizations lists concrete configuration details. Top level must always
-  // be a slice, even when only one visualization is present. The top level is left as an empty
-  // interface to allow custom go structures later on, but we should initially require this to be
-  // a []map[string]interface{}, with a type assertion that fails if it's anything else. That check
-  // should happen in dsfs.CreateDataset
-  Visualizations interface{}
-  // DataPath is the least worked out part, but I'm imagining we should
-  // borrow some of our thinking from dataset.Transformation to place here, with the
-  // goal of being able to specify all details necessary to generate visualizations
-  // from some sort of executable code designated by this hash?
-  // DataPath string
+	// private storage for reference to this object
+	path datastore.Key
+	// Kind should always be "qri:vc:0"
+	Kind Kind
+	// Format designates the visualization configuration syntax
+	Format string
+	// Visualizations lists concrete configuration details. Top level must always
+	// be a slice, even when only one visualization is present. The top level is left as an empty
+	// interface to allow custom go structures later on, but we should initially require this to be
+	// a []map[string]interface{}, with a type assertion that fails if it's anything else. That check
+	// should happen in dsfs.CreateDataset
+	Visualizations interface{}
+	// DataPath is the least worked out part, but I'm imagining we should
+	// borrow some of our thinking from dataset.Transformation to place here, with the
+	// goal of being able to specify all details necessary to generate visualizations
+	// from some sort of executable code designated by this hash?
+	// DataPath string
 }
 
 // Path gives the internal path reference for this structure
 func (v *VisConfig) Path() datastore.Key {
-  return v.path
+	return v.path
 }
 
 // NewVisConfigRef creates an empty struct with it's
 // internal path set
 func NewVisConfigRef(path datastore.Key) *VisConfig {
-  return &VisConfig{path: path}
+	return &VisConfig{path: path}
 }
 
 // IsEmpty checks to see if VisConfig has any fields other than the internal path
 func (v *VisConfig) IsEmpty() bool {
-  return v.Format == "" && v.Visualizations == nil
-  // v.Format == "" && v.DataPath == "" && v.Visualizations == nil
+	return v.Format == "" && v.Visualizations == nil
+	// v.Format == "" && v.DataPath == "" && v.Visualizations == nil
 }
 
 // Assign collapses all properties of a group of structures on to one
 // this is directly inspired by Javascript's Object.assign
 func (v *VisConfig) Assign(visConfigs ...*VisConfig) {
-  for _, vs := range visConfigs {
-    if vs == nil {
-      continue
-    }
+	for _, vs := range visConfigs {
+		if vs == nil {
+			continue
+		}
 
-    if vs.path.String() != "" {
-      v.path = vs.path
-    }
-    if vs.Kind != "" {
-      v.Kind = vs.Kind
-    }
-    if vs.Format != "" {
-      v.Format = vs.Format
-    }
-    // if vs.DataPath != "" {
-    //   v.DataPath = vs.DataPath
-    // }
-    if vs.Visualizations != nil {
-      v.Visualizations = vs.Visualizations
-    }
-  }
+		if vs.path.String() != "" {
+			v.path = vs.path
+		}
+		if vs.Kind != "" {
+			v.Kind = vs.Kind
+		}
+		if vs.Format != "" {
+			v.Format = vs.Format
+		}
+		// if vs.DataPath != "" {
+		//   v.DataPath = vs.DataPath
+		// }
+		if vs.Visualizations != nil {
+			v.Visualizations = vs.Visualizations
+		}
+	}
 }
 
 // _visconfig is a private struct for marshaling into & out of.
 // fields must remain sorted in lexographical order
 type _visconfig struct {
-  // DataPath       string      `json:"datapath,omitempty"`
-  Format         string      `json:"format,omitempty"`
-  Kind           Kind        `json:"kind,omitempty"`
-  Visualizations interface{} `json:"visualizations,omitempty"`
+	// DataPath       string      `json:"datapath,omitempty"`
+	Format         string      `json:"format,omitempty"`
+	Kind           Kind        `json:"kind,omitempty"`
+	Visualizations interface{} `json:"visualizations,omitempty"`
 }
 
 // MarshalJSON satisfies the json.Marshaler interface
 func (v *VisConfig) MarshalJSON() ([]byte, error) {
-  // if we're dealing with an empty object that has a path specified, marshal to a string instead
-  if v.path.String() != "" && v.IsEmpty() {
-    return v.path.MarshalJSON()
-  }
+	// if we're dealing with an empty object that has a path specified, marshal to a string instead
+	if v.path.String() != "" && v.IsEmpty() {
+		return v.path.MarshalJSON()
+	}
 
-  kind := v.Kind
-  if kind == "" {
-    kind = KindVisConfig
-  }
+	kind := v.Kind
+	if kind == "" {
+		kind = KindVisConfig
+	}
 
-  return json.Marshal(&_visconfig{
-    // DataPath:       v.DataPath,
-    Format:         v.Format,
-    Kind:           kind,
-    Visualizations: v.Visualizations,
-  })
+	return json.Marshal(&_visconfig{
+		// DataPath:       v.DataPath,
+		Format:         v.Format,
+		Kind:           kind,
+		Visualizations: v.Visualizations,
+	})
+}
+
+// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
+func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
+	return []byte("todo..."), nil
 }
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface
 func (v *VisConfig) UnmarshalJSON(data []byte) error {
-  var s string
-  if err := json.Unmarshal(data, &s); err == nil {
-    *v = VisConfig{path: datastore.NewKey(s)}
-    return nil
-  }
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*v = VisConfig{path: datastore.NewKey(s)}
+		return nil
+	}
 
-  _v := &_visconfig{}
-  if err := json.Unmarshal(data, _v); err != nil {
-    return err
-  }
+	_v := &_visconfig{}
+	if err := json.Unmarshal(data, _v); err != nil {
+		return err
+	}
 
-  *v = VisConfig{
-    // DataPath:       _v.DataPath,
-    Format:         _v.Format,
-    Kind:           _v.Kind,
-    Visualizations: _v.Visualizations,
-  }
-  return nil
+	*v = VisConfig{
+		// DataPath:       _v.DataPath,
+		Format:         _v.Format,
+		Kind:           _v.Kind,
+		Visualizations: _v.Visualizations,
+	}
+	return nil
 }
 
 // UnmarshalVisConfig tries to extract a resource type from an empty
 // interface. Pairs nicely with datastore.Get() from github.com/ipfs/go-datastore
 func UnmarshalVisConfig(v interface{}) (*VisConfig, error) {
-  switch q := v.(type) {
-  case *VisConfig:
-    return q, nil
-  case VisConfig:
-    return &q, nil
-  case []byte:
-    visConfig := &VisConfig{}
-    err := json.Unmarshal(q, visConfig)
-    return visConfig, err
-  default:
-    return nil, fmt.Errorf("couldn't parse VisConfig, value is invalid type")
-  }
+	switch q := v.(type) {
+	case *VisConfig:
+		return q, nil
+	case VisConfig:
+		return &q, nil
+	case []byte:
+		visConfig := &VisConfig{}
+		err := json.Unmarshal(q, visConfig)
+		return visConfig, err
+	default:
+		return nil, fmt.Errorf("couldn't parse VisConfig, value is invalid type")
+	}
 }
 
 // MarshalJSONObject always marshals to a json Object, even if VisConfig is empty or a reference

--- a/vis_config.go
+++ b/vis_config.go
@@ -88,21 +88,6 @@ func (v *VisConfig) MarshalJSON() ([]byte, error) {
 	return v.MarshalJSONObject()
 }
 
-// MarshalJSONObject always marshals to a json Object, even if meta is empty or a reference
-func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
-	kind := v.Kind
-	if kind == "" {
-		kind = KindVisConfig
-	}
-
-	return json.Marshal(&_visconfig{
-		// DataPath:       v.DataPath,
-		Format:         v.Format,
-		Kind:           kind,
-		Visualizations: v.Visualizations,
-	})
-}
-
 // UnmarshalJSON satisfies the json.Unmarshaler interface
 func (v *VisConfig) UnmarshalJSON(data []byte) error {
 	var s string
@@ -144,15 +129,15 @@ func UnmarshalVisConfig(v interface{}) (*VisConfig, error) {
 
 // MarshalJSONObject always marshals to a json Object, even if VisConfig is empty or a reference
 func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
-  data := map[string]interface{}{}
-  data["kind"] = KindVisConfig
+	data := map[string]interface{}{}
+	data["kind"] = KindVisConfig
 
-  if v.Format != "" {
-    data["format"] = v.Format
-  }
-  if v.Visualizations != nil {
-    data["visualizations"] = v.Visualizations
-  }
+	if v.Format != "" {
+		data["format"] = v.Format
+	}
+	if v.Visualizations != nil {
+		data["visualizations"] = v.Visualizations
+	}
 
-  return json.Marshal(data)
+	return json.Marshal(data)
 }

--- a/vis_config_test.go
+++ b/vis_config_test.go
@@ -183,42 +183,42 @@ func TestVisConfigMarshalJSON(t *testing.T) {
 	}
 }
 
-func TestVisConfigMarshalJSONObject(t *testing.T) {
-	cases := []struct {
-		in  *VisConfig
-		out []byte
-		err string
-	}{
-		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
-		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
-		{&VisConfig{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`{"kind":"vc:0"}`), ""},
-	}
+// func TestVisConfigMarshalJSONObject(t *testing.T) {
+// 	cases := []struct {
+// 		in  *VisConfig
+// 		out []byte
+// 		err string
+// 	}{
+// 		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
+// 		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
+// 		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
+// 		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+// 		{&VisConfig{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`{"kind":"vc:0"}`), ""},
+// 	}
 
-	for i, c := range cases {
-		got, err := c.in.MarshalJSONObject()
-		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
-			continue
-		}
+// 	for i, c := range cases {
+// 		got, err := c.in.MarshalJSONObject()
+// 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+// 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+// 			continue
+// 		}
 
-		if string(c.out) != string(got) {
-			t.Errorf("case %d, %s != %s", i, string(c.out), string(got))
-			continue
-		}
-	}
+// 		if string(c.out) != string(got) {
+// 			t.Errorf("case %d, %s != %s", i, string(c.out), string(got))
+// 			continue
+// 		}
+// 	}
 
-	vcbytes, err := json.Marshal(&VisConfig{path: datastore.NewKey("/path/to/VisConfig")})
-	if err != nil {
-		t.Errorf("unexpected string marshal error: %s", err.Error())
-		return
-	}
+// 	vcbytes, err := json.Marshal(&VisConfig{path: datastore.NewKey("/path/to/VisConfig")})
+// 	if err != nil {
+// 		t.Errorf("unexpected string marshal error: %s", err.Error())
+// 		return
+// 	}
 
-	if !bytes.Equal(vcbytes, []byte("\"/path/to/VisConfig\"")) {
-		t.Errorf("marshal strbyte interface byte mismatch: %s != %s", string(vcbytes), "\"/path/to/VisConfig\"")
-	}
-}
+// 	if !bytes.Equal(vcbytes, []byte("\"/path/to/VisConfig\"")) {
+// 		t.Errorf("marshal strbyte interface byte mismatch: %s != %s", string(vcbytes), "\"/path/to/VisConfig\"")
+// 	}
+// }
 
 func TestVisConfigMarshalJSONObject(t *testing.T) {
 	cases := []struct {

--- a/vis_config_test.go
+++ b/vis_config_test.go
@@ -220,6 +220,34 @@ func TestVisConfigMarshalJSONObject(t *testing.T) {
 	}
 }
 
+func TestVisConfigMarshalJSONObject(t *testing.T) {
+	cases := []struct {
+		in  *VisConfig
+		out []byte
+		err string
+	}{
+		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
+		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
+		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
+		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSON()
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		check := &map[string]interface{}{}
+		err = json.Unmarshal(got, check)
+		if err != nil {
+			t.Errorf("case %d error: failed to unmarshal to object: %s", err.Error())
+			continue
+		}
+
+	}
+}
+
 func TestUnmarshalVisConfig(t *testing.T) {
 	vc := VisConfig{Kind: KindVisConfig, Format: "foo"}
 	cases := []struct {


### PR DESCRIPTION
closes #67 / see for more details