### PR TITLE
fix(dsfs): added set of unexported load methods

### DIFF
--- a/dsfs/commit_msg.go
+++ b/dsfs/commit_msg.go
@@ -20,6 +20,11 @@ func SaveCommit(store cafs.Filestore, s *dataset.Commit, pin bool) (path datasto
 // LoadCommit loads a commit from a given path in a store
 func LoadCommit(store cafs.Filestore, path datastore.Key) (st *dataset.Commit, err error) {
 	path = PackageKeypath(store, path, PackageFileCommit)
+	return loadCommit(store, path)
+}
+
+// loadCommit assumes the provided path is valid
+func loadCommit(store cafs.Filestore, path datastore.Key) (st *dataset.Commit, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading commit file: %s", err.Error())

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -87,7 +87,7 @@ func DerefDataset(store cafs.Filestore, ds *dataset.Dataset) error {
 // should be a no-op if ds.Structure is nil or isn't a reference
 func DerefDatasetStructure(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.Structure != nil && ds.Structure.IsEmpty() && ds.Structure.Path().String() != "" {
-		st, err := LoadStructure(store, ds.Structure.Path())
+		st, err := loadStructure(store, ds.Structure.Path())
 		if err != nil {
 			return fmt.Errorf("error loading dataset structure: %s", err.Error())
 		}
@@ -102,7 +102,7 @@ func DerefDatasetStructure(store cafs.Filestore, ds *dataset.Dataset) error {
 // should be a no-op if ds.VisConfig is nil or isn't a reference
 func DerefDatasetVisConfig(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.VisConfig != nil && ds.VisConfig.IsEmpty() && ds.VisConfig.Path().String() != "" {
-		st, err := LoadVisConfig(store, ds.VisConfig.Path())
+		st, err := loadVisConfig(store, ds.VisConfig.Path())
 		if err != nil {
 			return fmt.Errorf("error loading dataset visconfig: %s", err.Error())
 		}
@@ -117,7 +117,7 @@ func DerefDatasetVisConfig(store cafs.Filestore, ds *dataset.Dataset) error {
 // should be a no-op if ds.Structure is nil or isn't a reference
 func DerefDatasetTransform(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.Transform != nil && ds.Transform.IsEmpty() && ds.Transform.Path().String() != "" {
-		t, err := LoadTransform(store, ds.Transform.Path())
+		t, err := loadTransform(store, ds.Transform.Path())
 		if err != nil {
 			return fmt.Errorf("error loading dataset transform: %s", err.Error())
 		}
@@ -132,7 +132,7 @@ func DerefDatasetTransform(store cafs.Filestore, ds *dataset.Dataset) error {
 // should be a no-op if ds.Structure is nil or isn't a reference
 func DerefDatasetMeta(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.Meta != nil && ds.Meta.IsEmpty() && ds.Meta.Path().String() != "" {
-		md, err := LoadMeta(store, ds.Meta.Path())
+		md, err := loadMeta(store, ds.Meta.Path())
 		if err != nil {
 			return fmt.Errorf("error loading dataset metadata: %s", err.Error())
 		}
@@ -147,7 +147,7 @@ func DerefDatasetMeta(store cafs.Filestore, ds *dataset.Dataset) error {
 // should be a no-op if ds.Structure is nil or isn't a reference
 func DerefDatasetCommit(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.Commit != nil && ds.Commit.IsEmpty() && ds.Commit.Path().String() != "" {
-		cm, err := LoadCommit(store, ds.Commit.Path())
+		cm, err := loadCommit(store, ds.Commit.Path())
 		if err != nil {
 			return fmt.Errorf("error loading dataset commit: %s", err.Error())
 		}

--- a/dsfs/meta.go
+++ b/dsfs/meta.go
@@ -20,6 +20,11 @@ func SaveMeta(store cafs.Filestore, s *dataset.Meta, pin bool) (path datastore.K
 // LoadMeta loads a metadata from a given path in a store
 func LoadMeta(store cafs.Filestore, path datastore.Key) (md *dataset.Meta, err error) {
 	path = PackageKeypath(store, path, PackageFileMeta)
+	return loadMeta(store, path)
+}
+
+// loadMeta assumes the provided path is valid
+func loadMeta(store cafs.Filestore, path datastore.Key) (md *dataset.Meta, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading metadata file: %s", err.Error())

--- a/dsfs/structure.go
+++ b/dsfs/structure.go
@@ -20,6 +20,11 @@ func SaveStructure(store cafs.Filestore, s *dataset.Structure, pin bool) (path d
 // LoadStructure loads a structure from a given path in a store
 func LoadStructure(store cafs.Filestore, path datastore.Key) (st *dataset.Structure, err error) {
 	path = PackageKeypath(store, path, PackageFileStructure)
+	return loadStructure(store, path)
+}
+
+// loadStructure assumes path is valid
+func loadStructure(store cafs.Filestore, path datastore.Key) (st *dataset.Structure, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading structure file: %s", err.Error())

--- a/dsfs/transform.go
+++ b/dsfs/transform.go
@@ -13,6 +13,11 @@ import (
 // LoadTransform loads a transform from a given path in a store
 func LoadTransform(store cafs.Filestore, path datastore.Key) (q *dataset.Transform, err error) {
 	path = PackageKeypath(store, path, PackageFileTransform)
+	return loadTransform(store, path)
+}
+
+// loadTransform assumes the provided path is correct
+func loadTransform(store cafs.Filestore, path datastore.Key) (q *dataset.Transform, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading transform raw data: %s", err.Error())

--- a/dsfs/vis_config.go
+++ b/dsfs/vis_config.go
@@ -20,6 +20,11 @@ func SaveVisConfig(store cafs.Filestore, v *dataset.VisConfig, pin bool) (path d
 // LoadVisConfig loads a visconfig from a given path in a store
 func LoadVisConfig(store cafs.Filestore, path datastore.Key) (st *dataset.VisConfig, err error) {
 	path = PackageKeypath(store, path, PackageFileVisConfig)
+	return loadVisConfig(store, path)
+}
+
+// loadVisConfig assumes the provided path is valid
+func loadVisConfig(store cafs.Filestore, path datastore.Key) (st *dataset.VisConfig, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		return nil, fmt.Errorf("error loading visconfig file: %s", err.Error())


### PR DESCRIPTION
Deref methods were using their exported Load counterparts for example `dsfs.DerefDatasetMetadata` was calling `dsfs.LoadMetadata`, which was causing `/meta.json` to be appended to valid hashes of the meta file. In this case hash of the metadata file was `QmFoo...`, but now `LoadMetadata` was adding `/meta.json` when what we want is just `QmFoo...`. 

So I've added a set of unexported methods that deref can use, sharing this code with their exported `Load` counterparts.