### PR TITLE
refactor(visConfig): changed VisConfig field `Kind` to `Qri` 

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -172,8 +172,8 @@ func CompareVisConfigs(a, b *VisConfig) error {
 	} else if a != nil && b == nil {
 		return fmt.Errorf("nil: <not nil> != <nil>")
 	}
-	if a.Kind != b.Kind {
-		return fmt.Errorf("Kind: %s != %s", a.Kind, b.Kind)
+	if a.Qri != b.Qri {
+		return fmt.Errorf("Qri: %s != %s", a.Qri, b.Qri)
 	}
 	if a.Format != b.Format {
 		return fmt.Errorf("Format: %s != %s", a.Format, b.Format)

--- a/compare_test.go
+++ b/compare_test.go
@@ -134,10 +134,10 @@ func TestCompareVisConfigs(t *testing.T) {
 		err  string
 	}{
 		{nil, nil, ""},
-		{&VisConfig{Kind: "a", Format: "b", Visualizations: []interface{}{1, 2, 3}}, &VisConfig{Kind: "a", Format: "b", Visualizations: []interface{}{1, 2, 3}}, ""},
+		{&VisConfig{Qri: "a", Format: "b", Visualizations: []interface{}{1, 2, 3}}, &VisConfig{Qri: "a", Format: "b", Visualizations: []interface{}{1, 2, 3}}, ""},
 		{&VisConfig{}, nil, "nil: <not nil> != <nil>"},
 		{nil, &VisConfig{}, "nil: <nil> != <not nil>"},
-		{&VisConfig{Kind: "a"}, &VisConfig{Kind: "b"}, "Kind: a != b"},
+		{&VisConfig{Qri: "a"}, &VisConfig{Qri: "b"}, "Qri: a != b"},
 		{&VisConfig{Format: "a"}, &VisConfig{Format: "b"}, "Format: a != b"},
 		// {&VisConfig{DataPath: "a"}, &VisConfig{DataPath: "b"}, "DataPath: a != b"},
 		{&VisConfig{Visualizations: []interface{}{"hey", "sup"}}, &VisConfig{Visualizations: "test"}, "Visualizations not equal"},

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -23,7 +23,7 @@ func TestDatasetAssign(t *testing.T) {
 		{&Dataset{DataPath: "foo"}},
 		{&Dataset{PreviousPath: "stuff"}},
 		{&Dataset{Meta: &Meta{Title: "foo"}}},
-		{&Dataset{VisConfig: &VisConfig{Kind: KindVisConfig}}},
+		{&Dataset{VisConfig: &VisConfig{Qri: KindVisConfig}}},
 	}
 
 	for i, c := range cases {
@@ -50,7 +50,7 @@ func TestDatasetAssign(t *testing.T) {
 		AbstractTransform: &Transform{Data: "I'm abstract transform data?"},
 		Structure:         &Structure{Format: CSVDataFormat},
 		Commit:            &Commit{Title: "dy.no.mite."},
-		VisConfig:         &VisConfig{Kind: KindVisConfig},
+		VisConfig:         &VisConfig{Qri: KindVisConfig},
 	}
 	mads.Assign(madsa)
 

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -143,9 +143,9 @@ func TestCreateDataset(t *testing.T) {
 	}{
 		{"testdata/bad/invalid_reference.json", "testdata/cities.csv", "", "", 0, "error loading dataset commit: error loading commit file: datastore: key not found"},
 		{"testdata/bad/invalid.json", "testdata/cities.csv", "", "", 0, "commit is required"},
-		{"testdata/cities.json", "testdata/cities.csv", "cities.csv", "/map/QmRAuWroJY1C2bCd4s1yPDVRHUfqB3d36Y9HCGnVRE3suN", 7, ""},
-		{"testdata/complete.json", "testdata/complete.csv", "complete.csv", "/map/QmSfLdn1Q3i1hoJDK1whx1D4d1N2MSFZhjT33YHBRDsZP5", 15, ""},
-		{"testdata/cities_no_commit_title.json", "testdata/cities.csv", "cities.csv", "/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD", 17, ""},
+		{"testdata/cities.json", "testdata/cities.csv", "cities.csv", "/map/QmebrWmmBt2GmfYAT69vioaMb1Rp2aTfQm1jac7KEWHKNa", 7, ""},
+		{"testdata/complete.json", "testdata/complete.csv", "complete.csv", "/map/Qmehg2driQVjsGpf44p37EekpbLVXcu8kigP59j1ob24fD", 15, ""},
+		{"testdata/cities_no_commit_title.json", "testdata/cities.csv", "cities.csv", "/map/QmWF1hfiHiDs2wQp2WCmG1Xbj8rhby5REwFbqg4AXBsxA3", 17, ""},
 		// {"testdata/complete.json", "testdata/complete.csv", "complete.csv", "/map/QmQ2CuZ8dbKqjyaKvoQwynXgqnxPKTywojNVJ2Jpj2yb6c", 14, ""},
 		// {"testdata/cities_no_commit_title.json", "testdata/cities.csv", "cities.csv", "/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD", 16, ""},
 	}

--- a/dsfs/testdata/complete.json
+++ b/dsfs/testdata/complete.json
@@ -120,7 +120,7 @@
   },
   "visconfig":{
     "format": "foo",
-    "kind": "vc:0",
+    "qri": "vc:0",
     "visualizations": {
       "type": "bar",
       "colors": {

--- a/dsfs/vis_config_test.go
+++ b/dsfs/vis_config_test.go
@@ -9,7 +9,7 @@ import (
 
 var VisConfig1 = &dataset.VisConfig{
 	Format: "foo",
-	Kind:   dataset.KindVisConfig,
+	Qri:    dataset.KindVisConfig,
 	Visualizations: map[string]interface{}{
 		"type": "bar",
 		"colors": map[string]interface{}{

--- a/testdata/visconfigs/visconfig1.json
+++ b/testdata/visconfigs/visconfig1.json
@@ -1,6 +1,6 @@
 {
   "format": "foo",
-  "kind": "vc:0",
+  "qri": "vc:0",
   "visualizations": {
   	"type": "bar",
   	"colors": {

--- a/testdata/visconfigs/visconfig2.json
+++ b/testdata/visconfigs/visconfig2.json
@@ -1,5 +1,5 @@
 {
   "format": "bar",
-  "kind": "vc:0",
+  "qri": "vc:0",
   "visualizations": ["foo", "bar"]
 }

--- a/testdata/visconfigs/visconfig3.json
+++ b/testdata/visconfigs/visconfig3.json
@@ -1,5 +1,5 @@
 {
   "format": "bar",
-  "kind": "vc:0",
+  "qri": "vc:0",
   "visualizations": 10
 }

--- a/vis_config.go
+++ b/vis_config.go
@@ -10,8 +10,8 @@ import (
 type VisConfig struct {
 	// private storage for reference to this object
 	path datastore.Key
-	// Kind should always be "qri:vc:0"
-	Kind Kind
+	// Qri should always be "vc:0"
+	Qri Kind
 	// Format designates the visualization configuration syntax
 	Format string
 	// Visualizations lists concrete configuration details. Top level must always
@@ -55,8 +55,8 @@ func (v *VisConfig) Assign(visConfigs ...*VisConfig) {
 		if vs.path.String() != "" {
 			v.path = vs.path
 		}
-		if vs.Kind != "" {
-			v.Kind = vs.Kind
+		if vs.Qri != "" {
+			v.Qri = vs.Qri
 		}
 		if vs.Format != "" {
 			v.Format = vs.Format
@@ -75,7 +75,7 @@ func (v *VisConfig) Assign(visConfigs ...*VisConfig) {
 type _visconfig struct {
 	// DataPath       string      `json:"datapath,omitempty"`
 	Format         string      `json:"format,omitempty"`
-	Kind           Kind        `json:"kind,omitempty"`
+	Qri            Kind        `json:"qri,omitempty"`
 	Visualizations interface{} `json:"visualizations,omitempty"`
 }
 
@@ -104,7 +104,7 @@ func (v *VisConfig) UnmarshalJSON(data []byte) error {
 	*v = VisConfig{
 		// DataPath:       _v.DataPath,
 		Format:         _v.Format,
-		Kind:           _v.Kind,
+		Qri:            _v.Qri,
 		Visualizations: _v.Visualizations,
 	}
 	return nil
@@ -130,7 +130,7 @@ func UnmarshalVisConfig(v interface{}) (*VisConfig, error) {
 // MarshalJSONObject always marshals to a json Object, even if VisConfig is empty or a reference
 func (v *VisConfig) MarshalJSONObject() ([]byte, error) {
 	data := map[string]interface{}{}
-	data["kind"] = KindVisConfig
+	data["qri"] = KindVisConfig
 
 	if v.Format != "" {
 		data["format"] = v.Format

--- a/vis_config_test.go
+++ b/vis_config_test.go
@@ -10,7 +10,7 @@ import (
 
 var VisConfig1 = &VisConfig{
 	Format: "foo",
-	Kind:   KindVisConfig,
+	Qri:    KindVisConfig,
 	Visualizations: map[string]interface{}{
 		"type": "bar",
 		"colors": map[string]interface{}{
@@ -22,13 +22,13 @@ var VisConfig1 = &VisConfig{
 
 var VisConfig2 = &VisConfig{
 	Format:         "bar",
-	Kind:           KindVisConfig,
+	Qri:            KindVisConfig,
 	Visualizations: []interface{}{"foo", "bar"},
 }
 
 var VisConfig3 = &VisConfig{
 	Format:         "bar",
-	Kind:           KindVisConfig,
+	Qri:            KindVisConfig,
 	Visualizations: float64(10),
 }
 
@@ -43,27 +43,27 @@ func TestVisConfigAssign(t *testing.T) {
 		{&VisConfig{}, VisConfig1, VisConfig1, ""},
 		{&VisConfig{
 			Format:         "bar",
-			Kind:           KindVisConfig,
+			Qri:            KindVisConfig,
 			Visualizations: float64(10),
 		},
 			VisConfig2, VisConfig2, ""},
 		{&VisConfig{
 			Format:         "bar",
-			Kind:           KindVisConfig,
+			Qri:            KindVisConfig,
 			Visualizations: float64(10),
 		},
 			VisConfig2, VisConfig3, "Visualizations not equal"},
 		{&VisConfig{
 			path:           datastore.NewKey("foo"),
 			Format:         "foo",
-			Kind:           KindVisConfig,
+			Qri:            KindVisConfig,
 			Visualizations: float64(10),
 		},
 			&VisConfig{path: datastore.NewKey("bar"), Format: "bar"},
 			&VisConfig{
 				path:           datastore.NewKey("foo"),
 				Format:         "bar",
-				Kind:           KindVisConfig,
+				Qri:            KindVisConfig,
 				Visualizations: float64(10),
 			}, ""},
 	}
@@ -82,7 +82,7 @@ func TestVisConfigIsEmpty(t *testing.T) {
 		vc       *VisConfig
 		expected bool
 	}{
-		{&VisConfig{Kind: KindVisConfig}, true},
+		{&VisConfig{Qri: KindVisConfig}, true},
 		// {&VisConfig{DataPath: "foo"}, false},
 		{&VisConfig{Visualizations: "bar"}, false},
 		{&VisConfig{}, true},
@@ -151,10 +151,10 @@ func TestVisConfigMarshalJSON(t *testing.T) {
 		out []byte
 		err string
 	}{
-		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
-		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+		{&VisConfig{}, []byte(`{"qri":"vc:0"}`), ""},
+		{&VisConfig{Qri: KindVisConfig}, []byte(`{"qri":"vc:0"}`), ""},
+		{&VisConfig{Format: "foo", Qri: KindVisConfig}, []byte(`{"format":"foo","qri":"vc:0"}`), ""},
+		{VisConfig1, []byte(`{"format":"foo","qri":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
 		{&VisConfig{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`"/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"`), ""},
 		{&VisConfig{path: datastore.NewKey("/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD")}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), ""},
 	}
@@ -189,11 +189,11 @@ func TestVisConfigMarshalJSON(t *testing.T) {
 // 		out []byte
 // 		err string
 // 	}{
-// 		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
-// 		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
-// 		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
-// 		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
-// 		{&VisConfig{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`{"kind":"vc:0"}`), ""},
+// 		{&VisConfig{}, []byte(`{"qri":"vc:0"}`), ""},
+// 		{&VisConfig{Qri: KindVisConfig}, []byte(`{"qri":"vc:0"}`), ""},
+// 		{&VisConfig{Format: "foo", Qri: KindVisConfig}, []byte(`{"format":"foo","qri":"vc:0"}`), ""},
+// 		{VisConfig1, []byte(`{"format":"foo","qri":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+// 		{&VisConfig{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`{"qri":"vc:0"}`), ""},
 // 	}
 
 // 	for i, c := range cases {
@@ -226,10 +226,10 @@ func TestVisConfigMarshalJSONObject(t *testing.T) {
 		out []byte
 		err string
 	}{
-		{&VisConfig{}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Kind: KindVisConfig}, []byte(`{"kind":"vc:0"}`), ""},
-		{&VisConfig{Format: "foo", Kind: KindVisConfig}, []byte(`{"format":"foo","kind":"vc:0"}`), ""},
-		{VisConfig1, []byte(`{"format":"foo","kind":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+		{&VisConfig{}, []byte(`{"qri":"vc:0"}`), ""},
+		{&VisConfig{Qri: KindVisConfig}, []byte(`{"qri":"vc:0"}`), ""},
+		{&VisConfig{Format: "foo", Qri: KindVisConfig}, []byte(`{"format":"foo","qri":"vc:0"}`), ""},
+		{VisConfig1, []byte(`{"format":"foo","qri":"vc:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
 	}
 
 	for i, c := range cases {
@@ -249,7 +249,7 @@ func TestVisConfigMarshalJSONObject(t *testing.T) {
 }
 
 func TestUnmarshalVisConfig(t *testing.T) {
-	vc := VisConfig{Kind: KindVisConfig, Format: "foo"}
+	vc := VisConfig{Qri: KindVisConfig, Format: "foo"}
 	cases := []struct {
 		value interface{}
 		out   *VisConfig
@@ -257,7 +257,7 @@ func TestUnmarshalVisConfig(t *testing.T) {
 	}{
 		{vc, &vc, ""},
 		{&vc, &vc, ""},
-		{[]byte("{\"kind\":\"vc:0\"}"), &VisConfig{Kind: KindVisConfig}, ""},
+		{[]byte("{\"qri\":\"vc:0\"}"), &VisConfig{Qri: KindVisConfig}, ""},
 		{5, nil, "couldn't parse VisConfig, value is invalid type"},
 	}
 


### PR DESCRIPTION
Following the pattern established by other structures in Dataset (Structure, Meta, etc), the `Kind` field has been changed to `Qri`

closes #65