### PR TITLE
 fix(dsio,dsfs): fix bugs in entry counts, json reader string error

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -307,9 +307,11 @@ func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pri
 	}
 
 	entries := 0
-	for err == nil {
+	for {
+		if _, err = rr.ReadValue(); err != nil {
+			break
+		}
 		entries++
-		_, err = rr.ReadValue()
 	}
 	if err.Error() != "EOF" {
 		return nil, "", fmt.Errorf("error reading values: %s", err.Error())

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -145,13 +145,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmebrWmmBt2GmfYAT69vioaMb1Rp2aTfQm1jac7KEWHKNa", 7, ""},
+			"/map/QmYHjqM9EFJhxW5u2W4CZ76kVFxF98pBkYvjBY9WpRYxa3", 7, ""},
 		{"complete",
-			"/map/Qmehg2driQVjsGpf44p37EekpbLVXcu8kigP59j1ob24fD", 15, ""},
+			"/map/QmZ98pNQKSR2mRP466K7eZLttU8fx4FPp4QEaDTMZ8BonD", 15, ""},
 		{"cities_no_commit_title",
-			"/map/QmY5TnPy9xWBpqqcqBfcCKChKgfmdS149WnaGDrbnVhWLa", 17, ""},
+			"/map/QmafoKFW7VVaUJszdwEidyQNmrcJ1oBdKhLt9Xnf2KLEFn", 17, ""},
 		{"craigslist",
-			"/map/QmeytVZwjuWxTBdyZ83F2FSAK2xrtvzYse8Y129d2cGJde", 21, ""},
+			"/map/QmRLpDXcrccTzNCwWXyyHRZCmSzDxPoMX91KtLW3szmmkX", 21, ""},
 	}
 
 	for _, c := range cases {
@@ -189,7 +189,6 @@ func TestCreateDataset(t *testing.T) {
 				continue
 			}
 
-			t.Log(tc.Expect)
 			if tc.Expect != nil {
 				if err := dataset.CompareDatasets(tc.Expect, ds); err != nil {
 					t.Errorf("%s: dataset comparison error: %s", tc.Name, err.Error())

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -15,7 +15,7 @@
   "qri": "ds:0",
   "structure": {
     "checksum": "QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
-    "entries": 6,
+    "entries": 5,
     "errCount": 1,
     "format": "csv",
     "formatConfig": {

--- a/dsfs/testdata/complete/expect.dataset.json
+++ b/dsfs/testdata/complete/expect.dataset.json
@@ -15,7 +15,7 @@
   "qri": "ds:0",
   "structure": {
     "checksum": "QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
-    "entries": 6,
+    "entries": 5,
     "errCount": 1,
     "format": "csv",
     "formatConfig": {

--- a/dsfs/testdata/craigslist/data.json
+++ b/dsfs/testdata/craigslist/data.json
@@ -1,18001 +1,18002 @@
 [
   {
-    "name": "Gorgeous 3 Bedroom in Prime Area! Amazing Deal! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-in-prime/6498995602.html", 
+    "name": "Gorgeous 3 Bedroom in Prime Area! Amazing Deal! | No Fee",
+    "data": "This is a really long string that'll screw with the bytes.Scanner of a reader. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis vulputate turpis sed convallis. Cras vel lorem rhoncus, volutpat mauris quis, malesuada mi. Etiam ultrices, velit non convallis sollicitudin, tellus mauris tempus turpis, laoreet semper quam felis quis tellus. Integer quam tellus, lobortis sit amet ligula sed, hendrerit placerat ex. Curabitur eu justo vitae sem auctor elementum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Etiam efficitur magna aliquet congue feugiat.In quis ultricies tortor. Nulla eget viverra sapien, a feugiat sem. Praesent cursus ultrices magna, eu pellentesque sem pharetra ut. Nulla ut gravida nunc. Integer laoreet ex id metus laoreet imperdiet. Donec dignissim elementum lacus, quis faucibus justo tincidunt ac. Duis sit amet urna ornare, hendrerit magna quis, congue nisl.Praesent eget urna mollis, ultricies metus ultricies, pharetra sapien. Proin blandit imperdiet enim vel dapibus. Cras ornare ultrices lorem a interdum. Proin at eros porta, scelerisque nunc non, mollis nulla. Maecenas pellentesque euismod hendrerit. Donec lobortis ullamcorper massa, vitae eleifend est condimentum quis. Aliquam luctus suscipit justo, ac rhoncus lorem luctus a. Curabitur vel nibh lectus. Integer lobortis scelerisque augue at rutrum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam suscipit porttitor neque quis ultricies. Donec vulputate tellus nibh, vel consectetur ex blandit nec. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Suspendisse commodo odio in tellus varius, sed congue erat ultricies.Etiam aliquam a ligula molestie maximus. In sagittis, urna at cursus malesuada, erat nunc bibendum mauris, ut elementum turpis felis eu tortor. Curabitur egestas diam et elementum pellentesque. Sed auctor pulvinar neque. Sed pellentesque tortor at dolor interdum fermentum. Morbi porttitor posuere auctor. Nam accumsan consequat magna, at venenatis nunc eleifend vitae. Ut ac scelerisque mi. Maecenas dictum tortor in erat aliquam tincidunt.Nullam iaculis nec diam vitae vehicula. Morbi lobortis urna ut nisl volutpat, nec ultricies sem gravida. Duis sed maximus tellus. Aliquam felis risus, faucibus porttitor est vel, suscipit commodo sapien. Fusce dictum velit in velit accumsan suscipit. Phasellus quis ex vitae augue viverra hendrerit. Ut vulputate risus ut tortor vulputate sagittis. Donec tincidunt libero vel neque efficitur condimentum. Mauris feugiat est vitae risus rutrum, in interdum sapien condimentum. Fusce tortor lectus, iaculis auctor bibendum eget, tempus quis justo.Quisque varius, massa vitae cursus efficitur, elit mauris molestie erat, nec tempus ipsum turpis vitae augue. Duis lacus velit, imperdiet non euismod in, venenatis in arcu. Sed pellentesque vulputate ipsum, ac fringilla est tristique eu. Praesent porttitor dignissim maximus. Quisque sodales, lectus eget imperdiet mollis, leo nibh faucibus mauris, quis scelerisque ex augue nec felis. Donec purus urna, placerat sit amet finibus ac, feugiat eget enim. Nam elementum id eros sed tincidunt.Fusce a convallis erat, ac suscipit enim. Nunc bibendum mi ornare, faucibus lorem nec, fermentum dolor. Cras ante dui, blandit et enim in, rutrum viverra mauris. Proin pretium nibh enim, et commodo ipsum condimentum consectetur. Vivamus tempor dignissim urna id tempus. Vivamus volutpat, libero vel sagittis vulputate, odio nisl vestibulum leo, eleifend molestie metus ligula id turpis. Quisque id quam gravida, feugiat sem in, cursus diam. Pellentesque quis metus sit amet ligula dignissim molestie a eu turpis. Phasellus quis rhoncus justo.Vestibulum eget velit eu libero pulvinar luctus quis ac felis. Donec ultrices ac risus efficitur eleifend. Nulla lobortis tellus hendrerit imperdiet finibus. Maecenas tincidunt volutpat sapien tristique pharetra. Vivamus efficitur ultrices semper. Vestibulum id ex enim. Sed eleifend pulvinar dui a fermentum. Curabitur tincidunt quam id tortor imperdiet pulvinar. Quisque nibh turpis, luctus non volutpat quis, hendrerit quis lectus. In facilisis mollis arcu, in ultricies arcu fringilla id. Nullam in neque tortor. Mauris ultrices felis quis consectetur imperdiet. Vestibulum eleifend eros eget hendrerit porta.Fusce suscipit nulla nec diam tempor viverra. Nullam vehicula, lectus non elementum pretium, mi ipsum mattis mauris, ac aliquet orci turpis at libero. Vestibulum imperdiet sapien eu felis consequat, sit amet porttitor enim ornare. Curabitur eu bibendum sem. Pellentesque congue ultricies hendrerit. Maecenas eget urna orci. Maecenas dignissim, dui sit amet volutpat molestie, metus enim interdum enim, eget gravida leo arcu id nisl. Aenean vitae euismod nisi. Nullam sed sapien ac metus porta tincidunt nec in tortor. Aliquam ultrices volutpat pretium. Vivamus et sagittis elit, eu vestibulum lacus. Aenean lacus enim, volutpat ac mauris et, ornare molestie ligula.Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nulla fringilla efficitur est at auctor. Etiam venenatis tempus lorem, at consectetur augue maximus in. Donec semper sem sit amet sapien congue interdum. Aenean consequat elementum sapien, porta volutpat mi hendrerit vitae. Ut sit amet maximus magna. Sed pulvinar nisl nulla, eu fermentum enim finibus in.Etiam sed luctus mauris. Vestibulum felis dui, ullamcorper non metus nec, ultricies viverra lacus. Proin quis iaculis lectus. Morbi quis nulla vel augue mattis faucibus quis sit amet arcu. Ut posuere vitae massa eu sagittis. Vivamus pellentesque orci tristique molestie luctus. Nullam et lacinia lorem. Sed vestibulum ut dui vitae tristique. Nullam eget quam ante. Pellentesque quis dolor ac mauris viverra fringilla bibendum eget odio. Cras consectetur posuere tempor. Nunc nec diam eget ante ullamcorper pellentesque nec eget libero. Vivamus pretium elit non ipsum rutrum dignissim.Suspendisse consequat, arcu a vestibulum tempus, eros sem luctus purus, ut laoreet purus nisi at nulla. Curabitur semper dui a consequat consectetur. Cras dignissim est sodales feugiat ullamcorper. Nam at convallis diam. Cras efficitur, felis vitae elementum egestas, nulla diam semper ex, at faucibus arcu neque sit amet mi. Duis justo magna, eleifend id pulvinar a, placerat at tortor. Pellentesque vitae tincidunt eros. Phasellus varius turpis id purus aliquet, id congue ipsum rutrum. Nulla ut erat ac purus interdum sollicitudin non ac felis. Maecenas egestas venenatis eros vel facilisis. In et tortor ante. Cras ullamcorper elit sit amet diam tempus vestibulum. Aliquam erat volutpat. Suspendisse quis laoreet ipsum, ut luctus augue.Vivamus quis placerat diam. Suspendisse ultricies non enim at ornare. Cras et quam vel libero ultrices congue id ut ante. Nam facilisis ipsum maximus, lacinia odio eu, semper orci. Duis ut elementum massa, non consectetur arcu. Nullam ligula mauris, viverra vehicula venenatis et, luctus quis nunc. Nam sit amet lobortis libero. Sed sed commodo velit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer et magna ac metus sollicitudin posuere. Nulla pulvinar sem id nisl posuere, vitae mattis ante gravida. Nulla quis tellus pellentesque quam blandit ultrices ullamcorper quis tortor. Sed libero velit, rhoncus sed arcu vel, blandit aliquet neque. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.Donec egestas blandit tincidunt. Sed aliquam turpis quam, sed condimentum nibh sodales a. Pellentesque finibus metus sit amet mattis dignissim. Nullam euismod odio non ullamcorper imperdiet. Proin quis viverra tortor. Nullam et bibendum lectus, nec facilisis nisl. Vestibulum pellentesque auctor ipsum quis euismod. Aliquam libero nisi, feugiat quis mauris ac, tristique fermentum elit. Phasellus velit lectus, rhoncus ac augue sed, tincidunt ornare purus. Nulla faucibus odio leo, sed tincidunt felis tempor a. Proin magna lacus, dictum at mattis vel, mattis a nisl. Aliquam dolor felis, pharetra at lacinia venenatis, ullamcorper vel nisi. Mauris blandit ligula hendrerit laoreet blandit.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam at dolor sit amet ex blandit congue. Suspendisse congue felis a sapien fermentum, a accumsan purus fringilla. Donec vitae elit ac enim sodales feugiat. Mauris luctus gravida ante, et sagittis lacus condimentum rhoncus. Proin ullamcorper velit eu mi malesuada varius. Phasellus sit amet pretium est, sit amet placerat nunc. Vivamus eget interdum lacus, rhoncus porta tellus. Nam vulputate sapien at dui suscipit, in fringilla enim cursus. Sed malesuada nec tortor eget accumsan. Sed pellentesque ac massa at rutrum. Duis elementum lacus quis ante varius consectetur. Sed iaculis nisi urna, a ultricies nisl suscipit non.Vivamus nulla nulla, venenatis sed dictum eget, lacinia non turpis. Proin eu vehicula eros, vel cursus tortor. Ut commodo convallis velit, vitae scelerisque est condimentum sodales. Aliquam convallis massa in libero euismod, vitae euismod mauris tempor. Duis elit mi, ornare quis purus pretium, aliquet sagittis sem. Morbi dapibus, felis sit amet faucibus facilisis, nisl nisi malesuada eros, a dignissim lorem neque non dolor. Sed lectus est, ultrices in placerat id, ullamcorper at augue. Nam sem erat, blandit et arcu a, posuere lobortis tellus.Nam non augue luctus, vulputate nisl eu, ornare turpis. Curabitur vehicula est vitae urna vestibulum pretium. Proin mollis, nulla et pretium euismod, arcu quam molestie nunc, in facilisis dolor nunc eu mauris. Nunc vulputate urna eu mi pulvinar consequat. Suspendisse tristique vel turpis eget molestie. Duis lorem ante, luctus in pellentesque a, volutpat quis dolor. Praesent ornare massa eros, eget porttitor ante consequat vitae. Aliquam molestie massa id libero blandit, a tincidunt lacus iaculis. Aenean id lacus et tellus viverra tempus. Donec sit amet efficitur diam. Mauris condimentum neque sed augue feugiat, a facilisis nisi convallis. Phasellus a arcu consequat, ullamcorper nisl vel, pretium tellus. Sed venenatis pretium turpis id semper. In gravida nunc rhoncus interdum elementum. Quisque quis orci orci. Cras suscipit efficitur nisl nec congue.Donec mollis, mi eget semper feugiat, magna neque pulvinar libero, in dictum tellus enim ut enim. Proin vel ex eleifend, porttitor risus sit amet, pellentesque mauris. Cras at mi et neque pellentesque cursus a at justo. Vestibulum tristique egestas lacus vel scelerisque. Phasellus vehicula pretium lorem, quis imperdiet ipsum interdum eget. Aliquam non purus pharetra, elementum eros eu, vestibulum erat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse ut risus in velit pellentesque sagittis ut non lacus. In porta ut nisl at mattis. Cras odio libero, hendrerit quis massa a, ultrices vestibulum nunc. Suspendisse volutpat, mauris nec iaculis cursus, odio mi laoreet arcu, eu feugiat urna augue non est. Duis tincidunt est sem, id sollicitudin enim fermentum quis.Nullam porta libero lacus, elementum ullamcorper lacus feugiat ac. Duis pulvinar, velit quis elementum dignissim, lorem neque tincidunt est, quis ultricies felis velit sit amet quam. In nec purus in quam vulputate venenatis eu quis velit. Morbi convallis tellus in nulla euismod semper. Aenean feugiat pharetra rhoncus. Nulla convallis efficitur convallis. Pellentesque finibus vehicula lectus vitae fermentum. Cras et egestas sapien, at vulputate magna. In tempus risus vitae tincidunt finibus. Integer non est eget nunc rutrum accumsan. Donec gravida, est sit amet pretium facilisis, lorem est dignissim diam, vel pretium lectus nisi ut arcu. Maecenas odio leo, fermentum eu turpis a, fermentum pulvinar magna. Praesent suscipit nibh mauris, dapibus suscipit libero maximus sed. Donec hendrerit a quam sed cursus. Aenean rhoncus nec ipsum nec pellentesque.Etiam blandit molestie purus, sed ultricies tortor malesuada a. Pellentesque eu porta purus, non consequat leo. Morbi ultricies fermentum mi a tincidunt. Praesent sodales metus quis elit feugiat faucibus. Etiam feugiat nulla in massa posuere, a molestie orci tincidunt. Cras venenatis tincidunt sodales. Quisque laoreet neque vitae sagittis convallis. Aliquam dictum mauris vitae lacus viverra sollicitudin.Morbi pretium vestibulum gravida. Sed leo arcu, volutpat vestibulum finibus vel, consectetur sit amet nisl. Maecenas a fermentum metus, et dignissim justo. Nullam quis metus ut sapien vulputate blandit. Aenean euismod mattis est. Fusce augue lectus, faucibus non velit at, lacinia commodo massa. Proin posuere, tellus eget malesuada faucibus, lectus nunc auctor sapien, et fermentum erat elit at leo. Vestibulum pellentesque rutrum tempor. Pellentesque scelerisque tortor ac dapibus cursus. Fusce aliquet ex in dictum laoreet. Proin porta consequat erat nec consequat. Maecenas posuere elit eget lacus pharetra, non facilisis velit dictum. Sed ornare mattis fringilla.Vestibulum pellentesque, odio a suscipit dictum, elit orci ultrices mi, rutrum porta nulla mi eget libero. Aliquam est lacus, sagittis eu ultrices sed, ullamcorper id lectus. Sed dignissim et velit ut fringilla. Nulla aliquet, nunc quis faucibus mollis, mauris diam finibus turpis, eget fermentum nibh elit quis lorem. Pellentesque aliquam pharetra erat sit amet consectetur. Vivamus et velit quis purus ullamcorper cursus quis at nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Morbi mauris justo, porttitor vitae leo vel, rhoncus elementum arcu. Donec aliquam enim sollicitudin libero posuere vestibulum. Sed mi tortor, molestie sed auctor vitae, faucibus id ipsum. Aliquam erat volutpat. Praesent non diam est. Etiam vehicula dui eu eros commodo, ut porta magna tempus. Morbi dapibus faucibus suscipit. Aenean eget accumsan magna. Etiam ut neque auctor, mollis nunc nec, sagittis diam.Integer et urna vulputate, eleifend lectus sed, placerat magna. Sed ornare libero et lectus varius, vehicula euismod sapien hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed quis tempus sapien. Ut quis gravida sapien, quis varius leo. Duis malesuada purus id magna sollicitudin interdum. Vestibulum tempor eros eget bibendum luctus. Nulla nec efficitur ligula. Nullam ipsum dui, rutrum eu ligula ac, dictum porta arcu. Quisque ut enim porta, posuere turpis quis, elementum felis. Sed eget massa mauris. Phasellus luctus est eget lacinia mattis. Integer eget neque felis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam congue congue leo, eu bibendum mi ornare et.Sed quis tempus urna. Etiam sodales mauris id risus ornare rhoncus. Aenean sed egestas nisl. Ut at commodo tortor. Vestibulum feugiat nunc leo, eget tempus odio vehicula et. Donec feugiat leo risus, ac ultricies ex bibendum nec. In hac habitasse platea dictumst. Duis malesuada sem vitae felis accumsan, at dignissim risus eleifend. Donec accumsan quam non bibendum finibus. Nulla euismod tellus eu lectus eleifend bibendum. Morbi at libero orci. Phasellus arcu enim, hendrerit laoreet ullamcorper sed, interdum non turpis. Suspendisse cursus nibh vitae odio mattis tempor. Donec at tincidunt tellus. Etiam at velit pellentesque, ornare mi blandit, elementum nunc.Maecenas egestas volutpat mi, in dictum augue mollis nec. Aenean massa mi, porta at laoreet vel, viverra ac erat. Fusce dictum sodales libero at dapibus. Praesent id magna vel dui molestie porttitor. In sed orci a felis iaculis congue sed consectetur elit. Nulla efficitur diam eu lacus vehicula, et tempor ex venenatis. Integer eleifend tellus ac orci venenatis auctor. Aenean neque dui, ultricies at commodo et, convallis eget metus. Mauris at felis consequat, sollicitudin velit eu, ultricies sapien. Vestibulum eget volutpat nulla, non sodales est. Etiam dignissim est vel metus mollis facilisis. Donec at mollis urna, quis venenatis neque. Nullam aliquam, nisl et porta elementum, ante neque condimentum mauris, eu volutpat ante lorem vitae orci. Suspendisse vel suscipit est, ut aliquet urna.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-in-prime/6498995602.html",
     "containedIn": {
-      "name": " (Flatbush @ Newkirk Plaza B/Q)", 
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "w/ Large outdoor space. For April 1st!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-outdoor-space-for-april/6498985027.html", 
+    "name": "w/ Large outdoor space. For April 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-outdoor-space-for-april/6498985027.html",
     "containedIn": {
-      "name": " (Clinton Steet)", 
+      "name": " (Clinton Steet)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5495.0, 
+      "name": "price",
+      "value": 5495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny // Two Baths // large apartment!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-two-baths-large/6498982528.html", 
+    "name": "Sunny // Two Baths // large apartment!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-two-baths-large/6498982528.html",
     "containedIn": {
-      "name": " (Tompkins Square Park)", 
+      "name": " (Tompkins Square Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE***PETS OK*** NICE VIEWS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feepets-ok-nice-views/6498982168.html", 
+    "name": "NO FEE***PETS OK*** NICE VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feepets-ok-nice-views/6498982168.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3749.0, 
+      "name": "price",
+      "value": 3749.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE 1BEDROOM DISHWASHER LAUNDRY ALOT OF CLOSETS NW TRAIN", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-1bedroom/6498981871.html", 
+    "name": "NO BROKER FEE 1BEDROOM DISHWASHER LAUNDRY ALOT OF CLOSETS NW TRAIN",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-1bedroom/6498981871.html",
     "containedIn": {
-      "name": " (ASTORIA)", 
+      "name": " (ASTORIA)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2095.0, 
+      "name": "price",
+      "value": 2095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "New bathroom features granite sink top and marble flooring", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-bathroom-features-granite/6498981701.html", 
+    "name": "New bathroom features granite sink top and marble flooring",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-bathroom-features-granite/6498981701.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3439.0, 
+      "name": "price",
+      "value": 3439.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "granite countertops and updated bathroom", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-countertops-and/6498981233.html", 
+    "name": "granite countertops and updated bathroom",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-countertops-and/6498981233.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 Levels - Located between Lexington and 3rd Ave!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-levels-located-between/6498980850.html", 
+    "name": "2 Levels - Located between Lexington and 3rd Ave!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-levels-located-between/6498980850.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3749.0, 
+      "name": "price",
+      "value": 3749.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Microwave, granite countertops and new cabinets", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/microwave-granite-countertops/6498980336.html", 
+    "name": "Microwave, granite countertops and new cabinets",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/microwave-granite-countertops/6498980336.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3439.0, 
+      "name": "price",
+      "value": 3439.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OWNER MANAGED***PETS OK***GUARANTORS WELCOME***", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/owner-managedpets/6498979904.html", 
+    "name": "OWNER MANAGED***PETS OK***GUARANTORS WELCOME***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/owner-managedpets/6498979904.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498975608.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498975608.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1815.0, 
+      "name": "price",
+      "value": 1815.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Construction // in mint condition // elevator.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6498973989.html", 
+    "name": "Brand New Construction // in mint condition // elevator.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6498973989.html",
     "containedIn": {
-      "name": " (East 100th // 2nd Ave)", 
+      "name": " (East 100th // 2nd Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4785.0, 
+      "name": "price",
+      "value": 4785.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Construction! Two Bed Two Bath.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6498972014.html", 
+    "name": "Brand New Construction! Two Bed Two Bath.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6498972014.html",
     "containedIn": {
-      "name": " (East 100th // 2nd Ave)", 
+      "name": " (East 100th // 2nd Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Light-Filled, Brand New 4 BR Box Apt - 2 Full Baths, Washer/Dryer", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/light-filled-brand-new-4-br/6498964517.html", 
+    "name": "Light-Filled, Brand New 4 BR Box Apt - 2 Full Baths, Washer/Dryer",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/light-filled-brand-new-4-br/6498964517.html",
     "containedIn": {
-      "name": " (Bedford Stuyvesant)", 
+      "name": " (Bedford Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498962943.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498962943.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1945.0, 
+      "name": "price",
+      "value": 1945.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUNNING 2 BED IN PRIME LOCATION W/ SHARED BACKYARD / WASHER-DRYER!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-bed-in-prime/6498962900.html", 
+    "name": "STUNNING 2 BED IN PRIME LOCATION W/ SHARED BACKYARD / WASHER-DRYER!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-bed-in-prime/6498962900.html",
     "containedIn": {
-      "name": " (WILLIAMSBURG)", 
+      "name": " (WILLIAMSBURG)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6498961195.html", 
+    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6498961195.html",
     "containedIn": {
-      "name": " (Prospect Lffert Gardens)", 
+      "name": " (Prospect Lffert Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2124.0, 
+      "name": "price",
+      "value": 2124.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udc9b\ud83d\udc9bAWESOME\ud83d\udc9b\ud83d\udc9b 3 BR W/ EXPOSED BRICK WALL IN PRIME", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6498960149.html", 
+    "name": "💛💛AWESOME💛💛 3 BR W/ EXPOSED BRICK WALL IN PRIME",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6498960149.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunset Park__NO FEE_3 BR_2 BALCONIES___SUNSET_PARK_SLOPE_INDUSTRY_CITY", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-parkno-fee3-br2/6497270914.html", 
+    "name": "Sunset Park__NO FEE_3 BR_2 BALCONIES___SUNSET_PARK_SLOPE_INDUSTRY_CITY",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-parkno-fee3-br2/6497270914.html",
     "containedIn": {
-      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)", 
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Prime Clinton Hill*Renovated 1BR*Next To C MTA*No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/prime-clinton-hillrenovated/6498957326.html", 
+    "name": "Prime Clinton Hill*Renovated 1BR*Next To C MTA*No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/prime-clinton-hillrenovated/6498957326.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Park Slope__NO FEE_3 BR_6 WEEKS FREE___PARK_SLOPE_INDUSTRY_CITY_SUNSET", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/park-slopeno-fee3-br6-weeks/6497284422.html", 
+    "name": "Park Slope__NO FEE_3 BR_6 WEEKS FREE___PARK_SLOPE_INDUSTRY_CITY_SUNSET",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/park-slopeno-fee3-br6-weeks/6497284422.html",
     "containedIn": {
-      "name": " (PARK SLOPE____EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)", 
+      "name": " (PARK SLOPE____EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498937696.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498937696.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1785.0, 
+      "name": "price",
+      "value": 1785.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUDIO ON UPPER WEST SIDE 1 Block from Central Park - $2095 (NO FEE)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-on-upper-west-side-1/6498932210.html", 
+    "name": "STUDIO ON UPPER WEST SIDE 1 Block from Central Park - $2095 (NO FEE)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-on-upper-west-side-1/6498932210.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2095.0, 
+      "name": "price",
+      "value": 2095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE \"Luxury Boutique\"+ Free Verizon FIOS, GYM & Amenities", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-luxury-boutique-free/6498928130.html", 
+    "name": "NO FEE \"Luxury Boutique\"+ Free Verizon FIOS, GYM & Amenities",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-luxury-boutique-free/6498928130.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "****________!!_NO_FEE_!!_______LARGE____Two__Bedroom__Apartment___****", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nofeelargetwobedroomapartment/6498923597.html", 
+    "name": "****________!!_NO_FEE_!!_______LARGE____Two__Bedroom__Apartment___****",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nofeelargetwobedroomapartment/6498923597.html",
     "containedIn": {
-      "name": " (______BAY RIDGE____TEMUR___________)", 
+      "name": " (______BAY RIDGE____TEMUR___________)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE APT!! Spacious/Modern 1 Bedroom, Pvt Balcony!!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-apt-spacious-modern-1/6498922177.html", 
+    "name": "NO FEE APT!! Spacious/Modern 1 Bedroom, Pvt Balcony!!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-apt-spacious-modern-1/6498922177.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "==IMMACULATE 1 BEDROOM D/W RENOVATED=DOORMAN==NO FEE 1 MONTH FREE==", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/immaculate-1-bedroom-w/6498921725.html", 
+    "name": "==IMMACULATE 1 BEDROOM D/W RENOVATED=DOORMAN==NO FEE 1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/immaculate-1-bedroom-w/6498921725.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3071.0, 
+      "name": "price",
+      "value": 3071.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE** \"Price REDUCTION\"+Free Gym & 24 HR Sky-Roof", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-price-reductionfree/6498921019.html", 
+    "name": "**NO FEE** \"Price REDUCTION\"+Free Gym & 24 HR Sky-Roof",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-price-reductionfree/6498921019.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2376.0, 
+      "name": "price",
+      "value": 2376.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6498920130.html", 
+    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee",
+    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6498920130.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2668.0, 
+      "name": "price",
+      "value": 2668.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge Closets, Extra Storage & Parking\"120,000 sq. ft of Amenities for", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-closets-extra-storage/6498918779.html", 
+    "name": "Huge Closets, Extra Storage & Parking\"120,000 sq. ft of Amenities for",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-closets-extra-storage/6498918779.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3868.0, 
+      "name": "price",
+      "value": 3868.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6498912277.html", 
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6498912277.html",
     "containedIn": {
-      "name": " (Ridgewood @ Seneca M)", 
+      "name": " (Ridgewood @ Seneca M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2609.0, 
+      "name": "price",
+      "value": 2609.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6498910879.html", 
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6498910879.html",
     "containedIn": {
-      "name": " (Prospect heights @ 2,3,B,Q)", 
+      "name": " (Prospect heights @ 2,3,B,Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6498910009.html", 
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6498910009.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey J)", 
+      "name": " (Bushwick @ Halsey J)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3150.0, 
+      "name": "price",
+      "value": 3150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Centrally Located Forest Hills Luxury rental", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6498894685.html", 
+    "name": "Centrally Located Forest Hills Luxury rental",
+    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6498894685.html",
     "containedIn": {
-      "name": " (Forest Hills)", 
+      "name": " (Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3075.0, 
+      "name": "price",
+      "value": 3075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6498873503.html", 
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6498873503.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498868016.html", 
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498868016.html",
     "containedIn": {
-      "name": " (Crown Heights Utica)", 
+      "name": " (Crown Heights Utica)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE++LAUNDRY++ ELEVATOR++ PETS++ AMAZING LAYOUT++ BEEKMAN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelaundry-elevator-pets/6498867633.html", 
+    "name": "NO FEE++LAUNDRY++ ELEVATOR++ PETS++ AMAZING LAYOUT++ BEEKMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelaundry-elevator-pets/6498867633.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2075.0, 
+      "name": "price",
+      "value": 2075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498866952.html", 
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498866952.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2195.0, 
+      "name": "price",
+      "value": 2195.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498866233.html", 
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498866233.html",
     "containedIn": {
-      "name": " (Fort Green)", 
+      "name": " (Fort Green)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498864997.html", 
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498864997.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Small Cozy 2 Bed apt-Good light- Full Size Kit-Good closet space-Quiet", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/small-cozy-2-bed-apt-good/6498862076.html", 
+    "name": "Small Cozy 2 Bed apt-Good light- Full Size Kit-Good closet space-Quiet",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/small-cozy-2-bed-apt-good/6498862076.html",
     "containedIn": {
-      "name": " (Upper East Side - Private Owner)", 
+      "name": " (Upper East Side - Private Owner)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6498856602.html", 
+    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6498856602.html",
     "containedIn": {
-      "name": " (Washington Heights)", 
+      "name": " (Washington Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6498854776.html", 
+    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6498854776.html",
     "containedIn": {
-      "name": " (Washington Heights)", 
+      "name": " (Washington Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6498853982.html", 
+    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6498853982.html",
     "containedIn": {
-      "name": " (Washington Heights)", 
+      "name": " (Washington Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, Beautifully Renovated 1 Bedroom!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6498851787.html", 
+    "name": "NO FEE, Beautifully Renovated 1 Bedroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6498851787.html",
     "containedIn": {
-      "name": " (Hamilton Heights)", 
+      "name": " (Hamilton Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6498850395.html", 
+    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6498850395.html",
     "containedIn": {
-      "name": " (Washington Heights)", 
+      "name": " (Washington Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 MONTHS FREE! Rooftop Pool, Concierge, Free Gym - Seaport/FiDi, Immd!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-free-rooftop-pool/6498841423.html", 
+    "name": "2 MONTHS FREE! Rooftop Pool, Concierge, Free Gym - Seaport/FiDi, Immd!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-free-rooftop-pool/6498841423.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4533.0, 
+      "name": "price",
+      "value": 4533.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PENTHOUSE 1BR - Rooftop Pool, Concierge, Gym Seaport/FiDi - 2 MOS FREE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-1br-rooftop-pool/6498840614.html", 
+    "name": "PENTHOUSE 1BR - Rooftop Pool, Concierge, Gym Seaport/FiDi - 2 MOS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-1br-rooftop-pool/6498840614.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3880 Orloff Ave, NEW RENO, SS Kit, DW, FREE Gym, Pets, Pkg - 1 MO FREE", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/3880-orloff-ave-new-reno-ss/6498839263.html", 
+    "name": "3880 Orloff Ave, NEW RENO, SS Kit, DW, FREE Gym, Pets, Pkg - 1 MO FREE",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/3880-orloff-ave-new-reno-ss/6498839263.html",
     "containedIn": {
-      "name": " (KINGSBRIDGE)", 
+      "name": " (KINGSBRIDGE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1463.0, 
+      "name": "price",
+      "value": 1463.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautifully renovated 2bed in prime area Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautifully-renovated-2bed-in/6498835446.html", 
+    "name": "Beautifully renovated 2bed in prime area Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautifully-renovated-2bed-in/6498835446.html",
     "containedIn": {
-      "name": " (Crown Heights Utica)", 
+      "name": " (Crown Heights Utica)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Charming Duplex in Cos Cob Call Joe Huley 203-253-5399", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/charming-duplex-in-cos-cob/6498818298.html", 
+    "name": "Charming Duplex in Cos Cob Call Joe Huley 203-253-5399",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/charming-duplex-in-cos-cob/6498818298.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2b50NO FEE! Awesome 3BR/2BA-Upper E Side-24HR DM/ELEV/LNDRY-W/D-GYM-6/Q", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-3br-2ba-upper/6498815681.html", 
+    "name": "⭐NO FEE! Awesome 3BR/2BA-Upper E Side-24HR DM/ELEV/LNDRY-W/D-GYM-6/Q",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-3br-2ba-upper/6498815681.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8750.0, 
+      "name": "price",
+      "value": 8750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498812267.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498812267.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3795.0, 
+      "name": "price",
+      "value": 3795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Old Greenwich 6 Bdrm Victorian South of Village|CALL DENISE 622.4000", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/old-greenwich-6-bdrm/6498805223.html", 
+    "name": "Old Greenwich 6 Bdrm Victorian South of Village|CALL DENISE 622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/old-greenwich-6-bdrm/6498805223.html",
     "containedIn": {
-      "name": " (Old Greenwich/Greenwich/Cos Cob)", 
+      "name": " (Old Greenwich/Greenwich/Cos Cob)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8995.0, 
+      "name": "price",
+      "value": 8995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Central Greenwich 4 Bdrm 2 1/2 Bath| 3 Levels | Denise 203.622.4000", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/central-greenwich-4-bdrmbath/6498804409.html", 
+    "name": "Central Greenwich 4 Bdrm 2 1/2 Bath| 3 Levels | Denise 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/central-greenwich-4-bdrmbath/6498804409.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8250.0, 
+      "name": "price",
+      "value": 8250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Like New (Built 2014) Large 2 Bdrm/2Bthrm Apt: Kathie@203.554.7237", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/like-new-built-2014-large-2/6498801953.html", 
+    "name": "Like New (Built 2014) Large 2 Bdrm/2Bthrm Apt: Kathie@203.554.7237",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/like-new-built-2014-large-2/6498801953.html",
     "containedIn": {
-      "name": " (Greenwich, Cos Cob)", 
+      "name": " (Greenwich, Cos Cob)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge 2 Bed Apt-Good light- Full Size Kit-Good Closet Space-Dishwasher", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-2-bed-apt-good-light/6498790755.html", 
+    "name": "Huge 2 Bed Apt-Good light- Full Size Kit-Good Closet Space-Dishwasher",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-2-bed-apt-good-light/6498790755.html",
     "containedIn": {
-      "name": " (Upper East Side - Private Owner)", 
+      "name": " (Upper East Side - Private Owner)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2725.0, 
+      "name": "price",
+      "value": 2725.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK WITH LAUNDRY IN APT", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6498778866.html", 
+    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK WITH LAUNDRY IN APT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6498778866.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6498778010.html", 
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6498778010.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6498777394.html", 
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6498777394.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6498776779.html", 
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6498776779.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498769352.html", 
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498769352.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498769276.html", 
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498769276.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6000.0, 
+      "name": "price",
+      "value": 6000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2b50NO FEE Awesome 1BR-beautiful MIDTOWN E-ELEV/LNDRY-SS-DW-MW-4/5/6/7/S", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-1br-beautiful/6498751900.html", 
+    "name": "⭐NO FEE Awesome 1BR-beautiful MIDTOWN E-ELEV/LNDRY-SS-DW-MW-4/5/6/7/S",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-1br-beautiful/6498751900.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE PRIME MURRAY HILL FLEX 2 BEDROOM IN ELEVATOR BLDG", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-murray-hill-flex/6498748001.html", 
+    "name": "NO FEE PRIME MURRAY HILL FLEX 2 BEDROOM IN ELEVATOR BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-murray-hill-flex/6498748001.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "REAL SPACIOUS STUDIO IN HARLEM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/real-spacious-studio-in-harlem/6498745705.html", 
+    "name": "REAL SPACIOUS STUDIO IN HARLEM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/real-spacious-studio-in-harlem/6498745705.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Big studio with WIC - City Hall / Brklyn Brdge, NO Fee, Prime Location", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-with-wic-city-hall/6498732596.html", 
+    "name": "Big studio with WIC - City Hall / Brklyn Brdge, NO Fee, Prime Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-with-wic-city-hall/6498732596.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OPEN HOUSE 2 BR in Kew Gardens by Atlantic Management 718-726-0003", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/open-house-2-br-in-kew/6498730928.html", 
+    "name": "OPEN HOUSE 2 BR in Kew Gardens by Atlantic Management 718-726-0003",
+    "url": "https://newyork.craigslist.org/que/nfb/d/open-house-2-br-in-kew/6498730928.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Great Views, Laundry*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498724139.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Great Views, Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498724139.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW*NO FEE+1 MO. FREE net rent $3020** 2 BR 2 MBL BTHS DRMN GYM GARAGE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-fee1-mo-free-net-rentbr/6498720233.html", 
+    "name": "WOW*NO FEE+1 MO. FREE net rent $3020** 2 BR 2 MBL BTHS DRMN GYM GARAGE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-fee1-mo-free-net-rentbr/6498720233.html",
     "containedIn": {
-      "name": " (East Harlem)", 
+      "name": " (East Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+ 1 MO.FREE UES  LG 2 BR 1 BTH Eat in KIT DW Dining Area LG Livi", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-mofree-ues-lg-2-br-1/6498720153.html", 
+    "name": "NO FEE+ 1 MO.FREE UES  LG 2 BR 1 BTH Eat in KIT DW Dining Area LG Livi",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-mofree-ues-lg-2-br-1/6498720153.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3795.0, 
+      "name": "price",
+      "value": 3795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MO.FREEnet rent $2837 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2837/6498720027.html", 
+    "name": "NO FEE+1 MO.FREEnet rent $2837 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2837/6498720027.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3095.0, 
+      "name": "price",
+      "value": 3095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AMAZING STUDIO FOR CHEAP NEAR MIDTOWN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-studio-for-cheap-near/6498710616.html", 
+    "name": "AMAZING STUDIO FOR CHEAP NEAR MIDTOWN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-studio-for-cheap-near/6498710616.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1870.0, 
+      "name": "price",
+      "value": 1870.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "$1100 / 100ft2 - 1 of 2 Rooms in Factory Loft (Bushwick)", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/ft2-1-of-2-rooms-in-factory/6498707790.html", 
+    "name": "$1100 / 100ft2 - 1 of 2 Rooms in Factory Loft (Bushwick)",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ft2-1-of-2-rooms-in-factory/6498707790.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1100.0, 
+      "name": "price",
+      "value": 1100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Private & shared rooftop deck and a premium Bosch washer and dryer", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/private-shared-rooftop-deck/6498707607.html", 
+    "name": "Private & shared rooftop deck and a premium Bosch washer and dryer",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/private-shared-rooftop-deck/6498707607.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3749.0, 
+      "name": "price",
+      "value": 3749.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "New Two Bedroom, Duplex apartment with a large patio and nice views!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-two-bedroom-duplex/6498707185.html", 
+    "name": "New Two Bedroom, Duplex apartment with a large patio and nice views!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-two-bedroom-duplex/6498707185.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3439.0, 
+      "name": "price",
+      "value": 3439.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large Studio with exposed brick!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-with-exposed/6498706768.html", 
+    "name": "Large Studio with exposed brick!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-with-exposed/6498706768.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Big Studio Flex 1Bdr close to City Hall - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-flex-1bdr-close-to/6498704315.html", 
+    "name": "Big Studio Flex 1Bdr close to City Hall - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-flex-1bdr-close-to/6498704315.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2672.0, 
+      "name": "price",
+      "value": 2672.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT SHARE! RENOVATED 2BR HOME+SS APPL+EXPOSED BRICK+REAL PICS!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-share-renovated-2br/6498690433.html", 
+    "name": "GREAT SHARE! RENOVATED 2BR HOME+SS APPL+EXPOSED BRICK+REAL PICS!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-share-renovated-2br/6498690433.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!HUGE!!DONT MISS THIS ONE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one/6498687244.html", 
+    "name": "!HUGE!!DONT MISS THIS ONE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one/6498687244.html",
     "containedIn": {
-      "name": " (williamsburg)", 
+      "name": " (williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6498686797.html", 
+    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6498686797.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4700.0, 
+      "name": "price",
+      "value": 4700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6498682346.html", 
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6498682346.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! Bensonhurst Spacious 1 Bedroom with On-site Laundry. See Pics!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-spacious-1/6498681491.html", 
+    "name": "NO FEE! Bensonhurst Spacious 1 Bedroom with On-site Laundry. See Pics!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-spacious-1/6498681491.html",
     "containedIn": {
-      "name": " (Bensonhurst)", 
+      "name": " (Bensonhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6498681466.html", 
+    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6498681466.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!HUGE!!DONT MISS THIS ONE !!! HEAT HOT   WATER INC! PRIVATE GARDEN!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one-heat/6498675955.html", 
+    "name": "!HUGE!!DONT MISS THIS ONE !!! HEAT HOT   WATER INC! PRIVATE GARDEN!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one-heat/6498675955.html",
     "containedIn": {
-      "name": " (east williamsburg)", 
+      "name": " (east williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 2 BEDROOMS RAILROOD HEAT HOT   WATER INC!!!!!!!!!!!!!!!!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-2-bedrooms-railrood-heat/6498673252.html", 
+    "name": "HUGE 2 BEDROOMS RAILROOD HEAT HOT   WATER INC!!!!!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-2-bedrooms-railrood-heat/6498673252.html",
     "containedIn": {
-      "name": " (east williamsburg)", 
+      "name": " (east williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Floor Thru Top Floor Of Townhouse-Fireplace Mantle-Laundry+Storage-New", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-top-floor-of/6498666869.html", 
+    "name": "Floor Thru Top Floor Of Townhouse-Fireplace Mantle-Laundry+Storage-New",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-top-floor-of/6498666869.html",
     "containedIn": {
-      "name": " (Park Slope)", 
+      "name": " (Park Slope)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2799.0, 
+      "name": "price",
+      "value": 2799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEWLY RENO MIDTOWN WEST 1BR*BALC*NO SEC.DEP.*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6498666158.html", 
+    "name": "NEWLY RENO MIDTOWN WEST 1BR*BALC*NO SEC.DEP.*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6498666158.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE ON PRIME PRISTINE 1 BEDROOM STEPS FROM PARK 2,3,Q,B", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-prime/6498665060.html", 
+    "name": "NO BROKER FEE ON PRIME PRISTINE 1 BEDROOM STEPS FROM PARK 2,3,Q,B",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-prime/6498665060.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6498646837.html", 
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6498646837.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6498646646.html", 
+    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6498646646.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6498642758.html", 
+    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6498642758.html",
     "containedIn": {
-      "name": " (Prospect Lefferts Vicinity)", 
+      "name": " (Prospect Lefferts Vicinity)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6498642036.html", 
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6498642036.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely Pad with  Extra Room& Gas included Today!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-pad-with-extra-room/6498641547.html", 
+    "name": "Lovely Pad with  Extra Room& Gas included Today!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-pad-with-extra-room/6498641547.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OVERSIZED STABILIZED 2 BEDROOM STEPS FROM CHILDREN'S MUSEUM A&C TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/oversized-stabilized-2/6498641457.html", 
+    "name": "OVERSIZED STABILIZED 2 BEDROOM STEPS FROM CHILDREN'S MUSEUM A&C TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/oversized-stabilized-2/6498641457.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PRIME Greenwich Village! ~~ Univ. Place! ~~ Elevator / Laundry!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-greenwich-village-univ/6498634528.html", 
+    "name": "PRIME Greenwich Village! ~~ Univ. Place! ~~ Elevator / Laundry!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-greenwich-village-univ/6498634528.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4400.0, 
+      "name": "price",
+      "value": 4400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498631879.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498631879.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498628687.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498628687.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2125.0, 
+      "name": "price",
+      "value": 2125.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498621662.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498621662.html",
     "containedIn": {
-      "name": " (Sheepshead Bay)", 
+      "name": " (Sheepshead Bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LARGE NEW CONSTRUCTION ONE BEDROOM!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-new-construction-one/6498614591.html", 
+    "name": "LARGE NEW CONSTRUCTION ONE BEDROOM!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-new-construction-one/6498614591.html",
     "containedIn": {
-      "name": " (East 10th Street)", 
+      "name": " (East 10th Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6498613168.html", 
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6498613168.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2450.0, 
+      "name": "price",
+      "value": 2450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6498612627.html", 
+    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6498612627.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS_________HUGE LIVING SPACE___________OVERSIZED WINDOWS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacioushuge-living/6498612198.html", 
+    "name": "SPACIOUS_________HUGE LIVING SPACE___________OVERSIZED WINDOWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacioushuge-living/6498612198.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3550.0, 
+      "name": "price",
+      "value": 3550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6498611933.html", 
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6498611933.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6498610936.html", 
+    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6498610936.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW | Massive Bed-Stuy 5+ BR Duplex | Yard | Laundry | NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-massive-bed-stuy-5/6498609723.html", 
+    "name": "BRAND NEW | Massive Bed-Stuy 5+ BR Duplex | Yard | Laundry | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-massive-bed-stuy-5/6498609723.html",
     "containedIn": {
-      "name": " (Bedstuy | Somers St | Near C & J Trains)", 
+      "name": " (Bedstuy | Somers St | Near C & J Trains)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3595.0, 
+      "name": "price",
+      "value": 3595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Unique & Spacious Bushwick 2 Bedroom | Pre-War Gem | Perfect Location!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/unique-spacious-bushwick-2/6498608943.html", 
+    "name": "Unique & Spacious Bushwick 2 Bedroom | Pre-War Gem | Perfect Location!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/unique-spacious-bushwick-2/6498608943.html",
     "containedIn": {
-      "name": " (Bushwick | Dekalb L Train)", 
+      "name": " (Bushwick | Dekalb L Train)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunlit Bedroom in East Williamsburg", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunlit-bedroom-in-east/6498608148.html", 
+    "name": "Sunlit Bedroom in East Williamsburg",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunlit-bedroom-in-east/6498608148.html",
     "containedIn": {
-      "name": " (East Williamsburg, Brooklyn)", 
+      "name": " (East Williamsburg, Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1073.0, 
+      "name": "price",
+      "value": 1073.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE! 3bed/2bath with laundry, a block from the park & B,Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-3bed-2bath-with/6498586278.html", 
+    "name": "NO BROKER FEE! 3bed/2bath with laundry, a block from the park & B,Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-3bed-2bath-with/6498586278.html",
     "containedIn": {
-      "name": " (prospect lefferts gardens)", 
+      "name": " (prospect lefferts gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2495.0, 
+      "name": "price",
+      "value": 2495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Attention All Sacred Heart Students! Bright & Sunny 4 Bedroom 2 Bath", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/attention-all-sacred-heart/6498584063.html", 
+    "name": "Attention All Sacred Heart Students! Bright & Sunny 4 Bedroom 2 Bath",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/attention-all-sacred-heart/6498584063.html",
     "containedIn": {
-      "name": " (Bridgeport,Trumbull,Fairfield)", 
+      "name": " (Bridgeport,Trumbull,Fairfield)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! BRAND NEW 3 BED, 2 BATH!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-3-bed-2-bath/6498579283.html", 
+    "name": "NO FEE! BRAND NEW 3 BED, 2 BATH!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-3-bed-2-bath/6498579283.html",
     "containedIn": {
-      "name": " (Hamilton Heights)", 
+      "name": " (Hamilton Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^HOT", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6498576979.html", 
+    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^HOT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6498576979.html",
     "containedIn": {
-      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)", 
+      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6498572411.html", 
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6498572411.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6498571397.html", 
+    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6498571397.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV JUNIOR1 BEDR PRIME  REGO PARK/FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior1/6498568067.html", 
+    "name": "NO FEE! NEWLY RENOV JUNIOR1 BEDR PRIME  REGO PARK/FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior1/6498568067.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6498567597.html", 
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6498567597.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html", 
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html",
     "containedIn": {
-      "name": " (Rego Park / Forest Hills)", 
+      "name": " (Rego Park / Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html", 
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html", 
+    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2075.0, 
+      "name": "price",
+      "value": 2075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html", 
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html",
     "containedIn": {
-      "name": " (Rego Park / Forest Hills)", 
+      "name": " (Rego Park / Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html", 
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html", 
+    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2075.0, 
+      "name": "price",
+      "value": 2075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6498551401.html", 
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6498551401.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6498550179.html", 
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6498550179.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUX Tower~LOFT LIKE ALCOVE STUDIO+WASHER/DRY~Pool~Gym~2 MO FREE+NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-towerloft-like-alcove/6498550023.html", 
+    "name": "LUX Tower~LOFT LIKE ALCOVE STUDIO+WASHER/DRY~Pool~Gym~2 MO FREE+NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-towerloft-like-alcove/6498550023.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6498548966.html", 
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6498548966.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6498546043.html", 
+    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6498546043.html",
     "containedIn": {
-      "name": " (Kew Gardens / Richmond Hill)", 
+      "name": " (Kew Gardens / Richmond Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6498544710.html", 
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6498544710.html",
     "containedIn": {
-      "name": " (Elmhurst)", 
+      "name": " (Elmhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6498542864.html", 
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6498542864.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2819.0, 
+      "name": "price",
+      "value": 2819.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great & Convenient 1BR in Full Service Building", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-convenient-1br-in-full/6498542639.html", 
+    "name": "Great & Convenient 1BR in Full Service Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-convenient-1br-in-full/6498542639.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Huge 1 Bedroom Williamsburg! By J/M/G/L Trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-huge-1-bedroom/6498541438.html", 
+    "name": "No Fee * Huge 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-huge-1-bedroom/6498541438.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6498539403.html", 
+    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6498539403.html",
     "containedIn": {
-      "name": " (New Rochelle)", 
+      "name": " (New Rochelle)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2145.0, 
+      "name": "price",
+      "value": 2145.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE*FEB/MARCH*TERRACE*Heat,Wtr,Gas INC*DW*Elv*Lundry*TRAIN*Poo", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb/6498537164.html", 
+    "name": "NO FEE*FEB/MARCH*TERRACE*Heat,Wtr,Gas INC*DW*Elv*Lundry*TRAIN*Poo",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb/6498537164.html",
     "containedIn": {
-      "name": " (Port Chester/ BORDER RYE)", 
+      "name": " (Port Chester/ BORDER RYE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1689.0, 
+      "name": "price",
+      "value": 1689.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+2 MNTS FREE__FLEX 4BR, 2BATHS__LUX DOORMAN BLD__GYM & POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee2-mnts-freeflex-4br/6498534395.html", 
+    "name": "NO FEE+2 MNTS FREE__FLEX 4BR, 2BATHS__LUX DOORMAN BLD__GYM & POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee2-mnts-freeflex-4br/6498534395.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5417.0, 
+      "name": "price",
+      "value": 5417.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6498531509.html", 
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6498531509.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2375.0, 
+      "name": "price",
+      "value": 2375.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6498529423.html", 
+    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6498529423.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6498528581.html", 
+    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6498528581.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4457.0, 
+      "name": "price",
+      "value": 4457.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6498528219.html", 
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6498528219.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6498527328.html", 
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6498527328.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6498526041.html", 
+    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6498526041.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3990.0, 
+      "name": "price",
+      "value": 3990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1000% NO FEE**GORGEOUS STUDIO** XL** MURRAY HILL**GYM** ROOF DECK** LAUNDRY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-no-feegorgeous-studio-xl/6498523989.html", 
+    "name": "1000% NO FEE**GORGEOUS STUDIO** XL** MURRAY HILL**GYM** ROOF DECK** LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-no-feegorgeous-studio-xl/6498523989.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6498523571.html", 
+    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6498523571.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2990.0, 
+      "name": "price",
+      "value": 2990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Studio \\ Gravesend \\ Sheepshead bay \\ No Broker's Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-gravesend-sheepshead/6498523471.html", 
+    "name": "Studio \\ Gravesend \\ Sheepshead bay \\ No Broker's Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-gravesend-sheepshead/6498523471.html",
     "containedIn": {
-      "name": " (Sheepsheadbay)", 
+      "name": " (Sheepsheadbay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1365.0, 
+      "name": "price",
+      "value": 1365.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6498521758.html", 
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6498521758.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL _Flex 3_24_Lux_ Drmn_Gym/Pool/_HiFloor_ No Fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-flex-324lux-drmngym-pool/6498519665.html", 
+    "name": "XL _Flex 3_24_Lux_ Drmn_Gym/Pool/_HiFloor_ No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-flex-324lux-drmngym-pool/6498519665.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 2BD Townhouse + Washer & Dryer with Covered Parking!!!", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-townhouse-washer/6498518575.html", 
+    "name": "Large 2BD Townhouse + Washer & Dryer with Covered Parking!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-townhouse-washer/6498518575.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6498517229.html", 
+    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6498517229.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Fabulous All Renov Spacious 1 Bd Rm + Den, New Eat In Kitch + Parking", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/fabulous-all-renov-spacious-1/6498509466.html", 
+    "name": "Fabulous All Renov Spacious 1 Bd Rm + Den, New Eat In Kitch + Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/fabulous-all-renov-spacious-1/6498509466.html",
     "containedIn": {
-      "name": " (Fleetwood)", 
+      "name": " (Fleetwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498504527.html", 
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498504527.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498503946.html", 
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498503946.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6000.0, 
+      "name": "price",
+      "value": 6000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1br-JUST HIT THE MARKET-TWO MONTHS FREE--LUXURY LIVING--MUST SEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1br-just-hit-the-market-two/6498499774.html", 
+    "name": "1br-JUST HIT THE MARKET-TWO MONTHS FREE--LUXURY LIVING--MUST SEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1br-just-hit-the-market-two/6498499774.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6498481410.html", 
+    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6498481410.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4700.0, 
+      "name": "price",
+      "value": 4700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**2 MONTHS FREE**STUNNING 1BR**24HR DM**LUX**W/D IN UNIT!!**100% NOFEE**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freestunning-1br24hr/6498481098.html", 
+    "name": "**2 MONTHS FREE**STUNNING 1BR**24HR DM**LUX**W/D IN UNIT!!**100% NOFEE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freestunning-1br24hr/6498481098.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Condo Finishes~~~Chefs Kitchen~~~Corner Home~~$2500 Move In Bonus~~", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/condo-finisheschefs/6498476398.html", 
+    "name": "Condo Finishes~~~Chefs Kitchen~~~Corner Home~~$2500 Move In Bonus~~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/condo-finisheschefs/6498476398.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8336.0, 
+      "name": "price",
+      "value": 8336.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 Real King BRs__Luxury Building__Endless Amenities__Floor-to-Ceiling", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-brsluxury/6498476328.html", 
+    "name": "3 Real King BRs__Luxury Building__Endless Amenities__Floor-to-Ceiling",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-brsluxury/6498476328.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8945.0, 
+      "name": "price",
+      "value": 8945.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Duplex PENTHOUSE~~W/D~~3 BED/3 BATH~~CORNER UNIT~~WRAP AROUND TERRACE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-penthousew-d3-bed-3/6498475966.html", 
+    "name": "Duplex PENTHOUSE~~W/D~~3 BED/3 BATH~~CORNER UNIT~~WRAP AROUND TERRACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-penthousew-d3-bed-3/6498475966.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 9250.0, 
+      "name": "price",
+      "value": 9250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Elegant 4 Bedroom Home__W/D in Unit__Sun-Drenched__Exquisite Amenities", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/elegant-4-bedroom-homew-in/6498475913.html", 
+    "name": "Elegant 4 Bedroom Home__W/D in Unit__Sun-Drenched__Exquisite Amenities",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/elegant-4-bedroom-homew-in/6498475913.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 15420.0, 
+      "name": "price",
+      "value": 15420.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Hudson River Views~~Walk In Closet~~Month Free~Sun-Drenched~~", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/hudson-river-viewswalk-in/6498475807.html", 
+    "name": "Hudson River Views~~Walk In Closet~~Month Free~Sun-Drenched~~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/hudson-river-viewswalk-in/6498475807.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5650.0, 
+      "name": "price",
+      "value": 5650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Jaw Dropping Views__Luxury Bldg__Wall-of-Windows__Sun Drenched__", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/jaw-dropping-viewsluxury/6498475739.html", 
+    "name": "Jaw Dropping Views__Luxury Bldg__Wall-of-Windows__Sun Drenched__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/jaw-dropping-viewsluxury/6498475739.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5789.0, 
+      "name": "price",
+      "value": 5789.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "69th Floor Living__Water Views__*Huge Living Room & Dining Room*__", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/69th-floor-livingwater/6498475677.html", 
+    "name": "69th Floor Living__Water Views__*Huge Living Room & Dining Room*__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/69th-floor-livingwater/6498475677.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5880.0, 
+      "name": "price",
+      "value": 5880.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Tribeca Townhouse__Wall of Windows__Sun Flooded__2 Bath__Luxury Bldg", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-townhousewall-of/6498475596.html", 
+    "name": "Tribeca Townhouse__Wall of Windows__Sun Flooded__2 Bath__Luxury Bldg",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-townhousewall-of/6498475596.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5887.0, 
+      "name": "price",
+      "value": 5887.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Center of Tribeca__Impressive Amenities__Luxury Loft Building__2Bath__", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribecaimpressive/6498475540.html", 
+    "name": "Center of Tribeca__Impressive Amenities__Luxury Loft Building__2Bath__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribecaimpressive/6498475540.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5936.0, 
+      "name": "price",
+      "value": 5936.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 Real King Size BR's__Jaw Dropping Views of Manhattan__Sun Flood", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-size-brsjaw/6498475481.html", 
+    "name": "3 Real King Size BR's__Jaw Dropping Views of Manhattan__Sun Flood",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-size-brsjaw/6498475481.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6339.0, 
+      "name": "price",
+      "value": 6339.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Now to April Move In~~Endless Amenities~~~River/City Views~~King Sized", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/now-to-april-move-inendless/6498475413.html", 
+    "name": "Now to April Move In~~Endless Amenities~~~River/City Views~~King Sized",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/now-to-april-move-inendless/6498475413.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6910.0, 
+      "name": "price",
+      "value": 6910.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CORNER UNIT~~PH Living~~Huge Rooftop~~Sunflooded~~Amazing Views!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-unitph-livinghuge/6498475359.html", 
+    "name": "CORNER UNIT~~PH Living~~Huge Rooftop~~Sunflooded~~Amazing Views!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-unitph-livinghuge/6498475359.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7370.0, 
+      "name": "price",
+      "value": 7370.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Triple Exposure~~Sun-Lit~~Exquisite Finishes~~Magnificent City Views", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/triple-exposuresun/6498475280.html", 
+    "name": "Triple Exposure~~Sun-Lit~~Exquisite Finishes~~Magnificent City Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/triple-exposuresun/6498475280.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7380.0, 
+      "name": "price",
+      "value": 7380.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CHIC FINISHES~~POOL~~~WALK IN CLOSET~~CHEFS KITCHEN~~SPLIT BEDS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/chic-finishespoolwalk-in/6498475211.html", 
+    "name": "CHIC FINISHES~~POOL~~~WALK IN CLOSET~~CHEFS KITCHEN~~SPLIT BEDS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/chic-finishespoolwalk-in/6498475211.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7845.0, 
+      "name": "price",
+      "value": 7845.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious Tribeca Townhouse~~ 5 Queen Sized Beds~~2 Full Baths~~W/D", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-tribeca-townhouse-5/6498475087.html", 
+    "name": "Spacious Tribeca Townhouse~~ 5 Queen Sized Beds~~2 Full Baths~~W/D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-tribeca-townhouse-5/6498475087.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7965.0, 
+      "name": "price",
+      "value": 7965.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Center of Tribeca__5 BR__Impressive Amenities__Luxury Loft Building__", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribeca5/6498475007.html", 
+    "name": "Center of Tribeca__5 BR__Impressive Amenities__Luxury Loft Building__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribeca5/6498475007.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8210.0, 
+      "name": "price",
+      "value": 8210.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse Living~57th Fl~Triple Exposure~King Sized BRs~Serene Views", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-living57th-fltriple/6498474954.html", 
+    "name": "Penthouse Living~57th Fl~Triple Exposure~King Sized BRs~Serene Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-living57th-fltriple/6498474954.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 11730.0, 
+      "name": "price",
+      "value": 11730.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUNNING ONE BEDROOM APARTMENT!", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6498474365.html", 
+    "name": "STUNNING ONE BEDROOM APARTMENT!",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6498474365.html",
     "containedIn": {
-      "name": " (staten island)", 
+      "name": " (staten island)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1200.0, 
+      "name": "price",
+      "value": 1200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FREE UTILITIES * TRUE 3 BED * 1000 SQFT * ELEVATOR + LAUNDRY * NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-3-bed/6498462843.html", 
+    "name": "FREE UTILITIES * TRUE 3 BED * 1000 SQFT * ELEVATOR + LAUNDRY * NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-3-bed/6498462843.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FREE UTILITIES * TRUE 2 BED * 800 SQFT * ELEVATOR + LAUNDRY * NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-2-bed-800/6498461930.html", 
+    "name": "FREE UTILITIES * TRUE 2 BED * 800 SQFT * ELEVATOR + LAUNDRY * NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-2-bed-800/6498461930.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "~NO FEE~1 BR with Manhattan views**Chefs Kitchen**ELEV + LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1-br-with-manhattan/6498419226.html", 
+    "name": "~NO FEE~1 BR with Manhattan views**Chefs Kitchen**ELEV + LAUNDRY!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1-br-with-manhattan/6498419226.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2399.0, 
+      "name": "price",
+      "value": 2399.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ROOM FOR RENT $1008 - Morning Side  - West 114 - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent-1008-morning/6498404717.html", 
+    "name": "ROOM FOR RENT $1008 - Morning Side  - West 114 - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent-1008-morning/6498404717.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1008.0, 
+      "name": "price",
+      "value": 1008.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498404239.html", 
+    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498404239.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6498404162.html", 
+    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6498404162.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4996.0, 
+      "name": "price",
+      "value": 4996.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498403698.html", 
+    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498403698.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "121st St & Lexington - 2 Bed 1 Bath 690 SF - FREE UTILITIES - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/121st-st-lexington-2-bed-1/6498403241.html", 
+    "name": "121st St & Lexington - 2 Bed 1 Bath 690 SF - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/121st-st-lexington-2-bed-1/6498403241.html",
     "containedIn": {
-      "name": " (East Harlem)", 
+      "name": " (East Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498403104.html", 
+    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498403104.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6498402777.html", 
+    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6498402777.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 85th - CONV 1 Bed 1 Bath - Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-85th-conv-1-bed-1-bath/6498400499.html", 
+    "name": "East 85th - CONV 1 Bed 1 Bath - Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-85th-conv-1-bed-1-bath/6498400499.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2654.0, 
+      "name": "price",
+      "value": 2654.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 91st St  - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6498397751.html", 
+    "name": "East 91st St  - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6498397751.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4395.0, 
+      "name": "price",
+      "value": 4395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498397569.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498397569.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6498395407.html", 
+    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6498395407.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2837.0, 
+      "name": "price",
+      "value": 2837.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GIGANTIC AUTHENTIC Williamsburg Loft DUPLEX - LIVE / WORK Dream!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gigantic-authentic/6498293318.html", 
+    "name": "GIGANTIC AUTHENTIC Williamsburg Loft DUPLEX - LIVE / WORK Dream!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gigantic-authentic/6498293318.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 8000.0, 
+      "name": "price",
+      "value": 8000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SUNNY AUTHENTIC Williamsburg Loft 2BR Elevator Building w. ROOF DECK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-authentic-williamsburg/6498292544.html", 
+    "name": "SUNNY AUTHENTIC Williamsburg Loft 2BR Elevator Building w. ROOF DECK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-authentic-williamsburg/6498292544.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4700.0, 
+      "name": "price",
+      "value": 4700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6498291432.html", 
+    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6498291432.html",
     "containedIn": {
-      "name": " (GREENPOINT)", 
+      "name": " (GREENPOINT)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3599.0, 
+      "name": "price",
+      "value": 3599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Fab Renov, Balcony, w/ W&D! 2 blks from 4,5,6&MetroN. No Bkr Fee!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/fab-renov-balcony-wd-2-blks/6498277344.html", 
+    "name": "Fab Renov, Balcony, w/ W&D! 2 blks from 4,5,6&MetroN. No Bkr Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fab-renov-balcony-wd-2-blks/6498277344.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2979.0, 
+      "name": "price",
+      "value": 2979.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498277007.html", 
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498277007.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7410.0, 
+      "name": "price",
+      "value": 7410.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW STUDIOS! In a Beautiful Luxury Build - F/G Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studios-in/6498270185.html", 
+    "name": "BRAND NEW STUDIOS! In a Beautiful Luxury Build - F/G Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studios-in/6498270185.html",
     "containedIn": {
-      "name": " (Gowanus)", 
+      "name": " (Gowanus)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2270.0, 
+      "name": "price",
+      "value": 2270.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 BEDROOM WALK UP", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/1-bedroom-walk-up/6498266031.html", 
+    "name": "1 BEDROOM WALK UP",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/1-bedroom-walk-up/6498266031.html",
     "containedIn": {
-      "name": " (HUGHES AVE)", 
+      "name": " (HUGHES AVE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1300.0, 
+      "name": "price",
+      "value": 1300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u239dNO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6498261497.html", 
+    "name": "⎝NO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6498261497.html",
     "containedIn": {
-      "name": " (Upper East Side / Roosevelt Island)", 
+      "name": " (Upper East Side / Roosevelt Island)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2265.0, 
+      "name": "price",
+      "value": 2265.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FREE Month! Luxury Studio w/Open Kitchen A/C/G/2/3/4/5/B/Q/R", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/free-month-luxury-studio-open/6498258331.html", 
+    "name": "FREE Month! Luxury Studio w/Open Kitchen A/C/G/2/3/4/5/B/Q/R",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/free-month-luxury-studio-open/6498258331.html",
     "containedIn": {
-      "name": " (Downtown BK)", 
+      "name": " (Downtown BK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Live in Prime Fort Greene | Steps to 2/3/4/5/B/Q/R/G | NO BROKER FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-fort-greene/6498256377.html", 
+    "name": "Live in Prime Fort Greene | Steps to 2/3/4/5/B/Q/R/G | NO BROKER FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-fort-greene/6498256377.html",
     "containedIn": {
-      "name": " (Fort Greene)", 
+      "name": " (Fort Greene)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2470.0, 
+      "name": "price",
+      "value": 2470.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MAJOR DEAL! Jr 1 Bed in Luxury Building 2/3/4/5/B/Q/R Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/major-deal-jr-1-bed-in-luxury/6498251029.html", 
+    "name": "MAJOR DEAL! Jr 1 Bed in Luxury Building 2/3/4/5/B/Q/R Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/major-deal-jr-1-bed-in-luxury/6498251029.html",
     "containedIn": {
-      "name": " (Fort Greene)", 
+      "name": " (Fort Greene)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2590.0, 
+      "name": "price",
+      "value": 2590.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498234922.html", 
+    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498234922.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498227019.html", 
+    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498227019.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498208185.html", 
+    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498208185.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 2 Bedroom-Renovated in Williamsburg-Laundry in building", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-2-bedroom-renovated-in/6498200418.html", 
+    "name": "Large 2 Bedroom-Renovated in Williamsburg-Laundry in building",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-2-bedroom-renovated-in/6498200418.html",
     "containedIn": {
-      "name": " (Williamsburg @ JM at Lorimer St)", 
+      "name": " (Williamsburg @ JM at Lorimer St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL 1 BEDROOM LOFT - HUGE WINDOWS, AMAZING LIGHT.", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-loft-huge/6498199658.html", 
+    "name": "BEAUTIFUL 1 BEDROOM LOFT - HUGE WINDOWS, AMAZING LIGHT.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-loft-huge/6498199658.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498198848.html", 
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498198848.html",
     "containedIn": {
-      "name": " (Crown Heights Utica)", 
+      "name": " (Crown Heights Utica)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498198491.html", 
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498198491.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2195.0, 
+      "name": "price",
+      "value": 2195.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498198122.html", 
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498198122.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498197502.html", 
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498197502.html",
     "containedIn": {
-      "name": " (Fort Green)", 
+      "name": " (Fort Green)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6498191692.html", 
+    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6498191692.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6498182163.html", 
+    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6498182163.html",
     "containedIn": {
-      "name": " (Crown Heights @ Nostrand 2/3)", 
+      "name": " (Crown Heights @ Nostrand 2/3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2749.0, 
+      "name": "price",
+      "value": 2749.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6498181679.html", 
+    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6498181679.html",
     "containedIn": {
-      "name": " (Williamsburg @ Lorimer J/M/Z)", 
+      "name": " (Williamsburg @ Lorimer J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6498181134.html", 
+    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6498181134.html",
     "containedIn": {
-      "name": " (Bushwick @ Hasley J/M/Z)", 
+      "name": " (Bushwick @ Hasley J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3199.0, 
+      "name": "price",
+      "value": 3199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6498180765.html", 
+    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6498180765.html",
     "containedIn": {
-      "name": " (Williamsburg @ Flushing J/M/Z)", 
+      "name": " (Williamsburg @ Flushing J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6498180259.html", 
+    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6498180259.html",
     "containedIn": {
-      "name": " (Flatbush @ Newkirk Plaza B/Q)", 
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS , HUGE 2 BEDROOM", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/gorgeous-huge-2-bedroom/6498175281.html", 
+    "name": "GORGEOUS , HUGE 2 BEDROOM",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/gorgeous-huge-2-bedroom/6498175281.html",
     "containedIn": {
-      "name": " (NEEDHAM AVE)", 
+      "name": " (NEEDHAM AVE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6498169775.html", 
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6498169775.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6498169422.html", 
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6498169422.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Two bedroom/1.5 Bathroom Duplex with Private Courtyard in Williamsburg", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/two-bedroom-15-bathroom/6498169276.html", 
+    "name": "Two bedroom/1.5 Bathroom Duplex with Private Courtyard in Williamsburg",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/two-bedroom-15-bathroom/6498169276.html",
     "containedIn": {
-      "name": " (Williamsburg L at Grand St)", 
+      "name": " (Williamsburg L at Grand St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3150.0, 
+      "name": "price",
+      "value": 3150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6498168629.html", 
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6498168629.html",
     "containedIn": {
-      "name": " (Nolita / Bowery)", 
+      "name": " (Nolita / Bowery)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6498168028.html", 
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6498168028.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6498167733.html", 
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6498167733.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6498167087.html", 
+    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6498167087.html",
     "containedIn": {
-      "name": " (Ditmas Park @B,Q at Newkirk Av)", 
+      "name": " (Ditmas Park @B,Q at Newkirk Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6498165676.html", 
+    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6498165676.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant @ c ralph ave)", 
+      "name": " (Bedford-Stuyvesant @ c ralph ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2399.0, 
+      "name": "price",
+      "value": 2399.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6498164423.html", 
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6498164423.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)", 
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "newly renovated 3 Queen Bedroom-2 bath-11 foot ceilings-NOFEE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/newly-renovated-3-queen/6498163978.html", 
+    "name": "newly renovated 3 Queen Bedroom-2 bath-11 foot ceilings-NOFEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/newly-renovated-3-queen/6498163978.html",
     "containedIn": {
-      "name": " (ridgewood @ M at Seneca Av)", 
+      "name": " (ridgewood @ M at Seneca Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2bedroom 2bath-heart of Bushwick-Laundry in Building -no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/2bedroom-2bath-heart-of/6498162629.html", 
+    "name": "2bedroom 2bath-heart of Bushwick-Laundry in Building -no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2bedroom-2bath-heart-of/6498162629.html",
     "containedIn": {
-      "name": " (Bushwick @ M at Central Av)", 
+      "name": " (Bushwick @ M at Central Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "studio in a glorious Brownstone-Excellent block - no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-in-glorious-brownstone/6498161901.html", 
+    "name": "studio in a glorious Brownstone-Excellent block - no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-in-glorious-brownstone/6498161901.html",
     "containedIn": {
-      "name": " (Bedford-StuyvesantC,S at Franklin Av)", 
+      "name": " (Bedford-StuyvesantC,S at Franklin Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FULL SERVICE WHITE GLOVE SERVICE *BRAND NEW* All No Fee - Free Rent -", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/full-service-white-glove/6498155877.html", 
+    "name": "FULL SERVICE WHITE GLOVE SERVICE *BRAND NEW* All No Fee - Free Rent -",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/full-service-white-glove/6498155877.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2907.0, 
+      "name": "price",
+      "value": 2907.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely Studio in Clinton Hill \u2022 No Fee \u2022 Great Apartment \u2022 Must See!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-studio-in-clinton-hill/6498124257.html", 
+    "name": "Lovely Studio in Clinton Hill • No Fee • Great Apartment • Must See!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-studio-in-clinton-hill/6498124257.html",
     "containedIn": {
-      "name": " (Brevoort @ Franklin Ave C, S Train)", 
+      "name": " (Brevoort @ Franklin Ave C, S Train)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE***PRIME GRAMERCY***3BD***ELEVATOR***LAUNDRY***LIVE IN SUPER***CENTRAL AIR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeprime/6498122884.html", 
+    "name": "NO FEE***PRIME GRAMERCY***3BD***ELEVATOR***LAUNDRY***LIVE IN SUPER***CENTRAL AIR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeprime/6498122884.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3950.0, 
+      "name": "price",
+      "value": 3950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE***TRIBECA** LUX***STUDIO***24/DM***GYM***POOL***STEPS FROM TRAINS***", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetribeca-luxstudio24/6498111618.html", 
+    "name": "NO FEE***TRIBECA** LUX***STUDIO***24/DM***GYM***POOL***STEPS FROM TRAINS***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetribeca-luxstudio24/6498111618.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous 2 Bedroom w Balcony- Luxury Doorman Buildings- Gym Roof Top", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-2-bedroom-balcony/6498102958.html", 
+    "name": "Gorgeous 2 Bedroom w Balcony- Luxury Doorman Buildings- Gym Roof Top",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-2-bedroom-balcony/6498102958.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3023.0, 
+      "name": "price",
+      "value": 3023.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE & 1 MONTH FREE** LUXURY DEAL ALERT! SPACIOUS 2 BED ON W 33RD!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-luxury/6498102521.html", 
+    "name": "**NO FEE & 1 MONTH FREE** LUXURY DEAL ALERT! SPACIOUS 2 BED ON W 33RD!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-luxury/6498102521.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6498102257.html", 
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6498102257.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Iconic Bed-Stuy 3BR Classic \u2022B.I.G. Mural Building \u2022 NO FEE \u2022 Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/iconic-bed-stuy-3br-classic/6498100758.html", 
+    "name": "Iconic Bed-Stuy 3BR Classic •B.I.G. Mural Building • NO FEE • Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/iconic-bed-stuy-3br-classic/6498100758.html",
     "containedIn": {
-      "name": " (Bedford @ Franklin ave C, S train)", 
+      "name": " (Bedford @ Franklin ave C, S train)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious & Lovely \u2022 w/ Backyard \\\\ Prime Bushwick // No Fee \u2022 Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-lovely-backyard/6498098336.html", 
+    "name": "Spacious & Lovely • w/ Backyard \\\\ Prime Bushwick // No Fee • Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-lovely-backyard/6498098336.html",
     "containedIn": {
-      "name": " (Bushwick - L @ Halsey M @ Myrt-Wykoff)", 
+      "name": " (Bushwick - L @ Halsey M @ Myrt-Wykoff)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6498097905.html", 
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6498097905.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW**NO FEE**PENTHOUSE_2BR_HUGE TERRACE ->Manhattan views!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/newno-feepenthouse2brhuge/6498078069.html", 
+    "name": "NEW**NO FEE**PENTHOUSE_2BR_HUGE TERRACE ->Manhattan views!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/newno-feepenthouse2brhuge/6498078069.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3395.0, 
+      "name": "price",
+      "value": 3395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498074137.html", 
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498074137.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498074068.html", 
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498074068.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6000.0, 
+      "name": "price",
+      "value": 6000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6498074001.html", 
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6498074001.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4600.0, 
+      "name": "price",
+      "value": 4600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Very high Ceilings, queen size bedrooms, washer dryer, skylight, J M Z", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/very-high-ceilings-queen-size/6498064349.html", 
+    "name": "Very high Ceilings, queen size bedrooms, washer dryer, skylight, J M Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-high-ceilings-queen-size/6498064349.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3199.0, 
+      "name": "price",
+      "value": 3199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 3 Bed", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6498063196.html", 
+    "name": "Beautiful 3 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6498063196.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3895.0, 
+      "name": "price",
+      "value": 3895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6498062984.html", 
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6498062984.html",
     "containedIn": {
-      "name": " (midwood/ Sheepshead bay)", 
+      "name": " (midwood/ Sheepshead bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6498058934.html", 
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6498058934.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605COLUMBUS CIRCLE NO FEE! XL LIVING ~KING-SIZE BR ~Dman ~FREE GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-no-fee-xl/6498043593.html", 
+    "name": "★COLUMBUS CIRCLE NO FEE! XL LIVING ~KING-SIZE BR ~Dman ~FREE GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-no-fee-xl/6498043593.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605LINCOLN CENTER NO FEE! MODERN FINISHES ~Dman ~GYM+POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lincoln-center-no-fee-modern/6498043480.html", 
+    "name": "★LINCOLN CENTER NO FEE! MODERN FINISHES ~Dman ~GYM+POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lincoln-center-no-fee-modern/6498043480.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3650.0, 
+      "name": "price",
+      "value": 3650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605NO FEE!  DMAN ~IRVING PLACE ~KING BR ~NEW KIT. ~HUGE WINDOWS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-dman-irving-place-king/6498043418.html", 
+    "name": "★NO FEE!  DMAN ~IRVING PLACE ~KING BR ~NEW KIT. ~HUGE WINDOWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-dman-irving-place-king/6498043418.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4300.0, 
+      "name": "price",
+      "value": 4300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605NO FEE!!! E 20 st. ~TRUE 2BR/2BA ~DMAN ~KING BRs ~NEW KIT.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-20-st-true-2br-2ba/6498043376.html", 
+    "name": "★NO FEE!!! E 20 st. ~TRUE 2BR/2BA ~DMAN ~KING BRs ~NEW KIT.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-20-st-true-2br-2ba/6498043376.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4150.0, 
+      "name": "price",
+      "value": 4150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498043395.html", 
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498043395.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7410.0, 
+      "name": "price",
+      "value": 7410.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous Studio with Balcony- Luxury Doorman Buildings- Gym Roof Top", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-studio-with-balcony/6498043281.html", 
+    "name": "Gorgeous Studio with Balcony- Luxury Doorman Buildings- Gym Roof Top",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-studio-with-balcony/6498043281.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1937.0, 
+      "name": "price",
+      "value": 1937.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Doorman Building, Gym, Brand new renovations - NO FEE Plus Free", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-gym/6498027279.html", 
+    "name": "Luxury Doorman Building, Gym, Brand new renovations - NO FEE Plus Free",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-gym/6498027279.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2672.0, 
+      "name": "price",
+      "value": 2672.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*BRAND NEW* FULL WHITE GLOVE SERVICE All No Fee - Free Rent - Luxury -", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-white-glove/6498010869.html", 
+    "name": "*BRAND NEW* FULL WHITE GLOVE SERVICE All No Fee - Free Rent - Luxury -",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-white-glove/6498010869.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2266.0, 
+      "name": "price",
+      "value": 2266.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ASAP MOVE IN__27TH FLOOR___21'X19' LIVING AREA___NEW RENOVAT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-in27th-floor21x19/6498007800.html", 
+    "name": "ASAP MOVE IN__27TH FLOOR___21'X19' LIVING AREA___NEW RENOVAT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-in27th-floor21x19/6498007800.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "34th FLOOR___FLOOR-TO-CEILING WINDOWS__WATER & CITY VIEW____MASSIVE CL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/34th-floorfloor-to-ceiling/6498005910.html", 
+    "name": "34th FLOOR___FLOOR-TO-CEILING WINDOWS__WATER & CITY VIEW____MASSIVE CL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/34th-floorfloor-to-ceiling/6498005910.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3510.0, 
+      "name": "price",
+      "value": 3510.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6498005808.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6498005808.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6498001365.html", 
+    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6498001365.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant)", 
+      "name": " (Bedford-Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW *FULL SERVICE LUXURY BUILDING  All No Fee - Free Rent - Luxu", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-service-luxury/6497994917.html", 
+    "name": "BRAND NEW *FULL SERVICE LUXURY BUILDING  All No Fee - Free Rent - Luxu",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-service-luxury/6497994917.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3778.0, 
+      "name": "price",
+      "value": 3778.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LONG ISLAND CITY'S NEWEST ADDRESS LOWEST PRICING *Free RENT * NO FEE *", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-citys-newest/6497994835.html", 
+    "name": "LONG ISLAND CITY'S NEWEST ADDRESS LOWEST PRICING *Free RENT * NO FEE *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-citys-newest/6497994835.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3185.0, 
+      "name": "price",
+      "value": 3185.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Top-of-the-Line Large 3 Bed/3 Bath Penthouse Apartment in Tribeca - Pr", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/top-of-the-line-large-3-bed-3/6497994557.html", 
+    "name": "Top-of-the-Line Large 3 Bed/3 Bath Penthouse Apartment in Tribeca - Pr",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/top-of-the-line-large-3-bed-3/6497994557.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 12600.0, 
+      "name": "price",
+      "value": 12600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6497994517.html", 
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6497994517.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5000.0, 
+      "name": "price",
+      "value": 5000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "High Fl. 922 sq/ft loft, kitchen island, brand new reno, amazing deal", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-fl-922-sq-ft-loft/6497984214.html", 
+    "name": "High Fl. 922 sq/ft loft, kitchen island, brand new reno, amazing deal",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-fl-922-sq-ft-loft/6497984214.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3799.0, 
+      "name": "price",
+      "value": 3799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "$1675,Close to DWNTWN,Mod Kit,HugeTerr,Inc.Heat,gas,water,Prkng", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/1675close-to-dwntwnmod/6497981297.html", 
+    "name": "$1675,Close to DWNTWN,Mod Kit,HugeTerr,Inc.Heat,gas,water,Prkng",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1675close-to-dwntwnmod/6497981297.html",
     "containedIn": {
-      "name": " (stamford downtown)", 
+      "name": " (stamford downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LARGE LIVING ROOM, True Two Bed. Houston and 2nd Ave", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-living-room-true-two/6497978476.html", 
+    "name": "LARGE LIVING ROOM, True Two Bed. Houston and 2nd Ave",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-living-room-true-two/6497978476.html",
     "containedIn": {
-      "name": " (East 1st and 2nd Ave)", 
+      "name": " (East 1st and 2nd Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4395.0, 
+      "name": "price",
+      "value": 4395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Construction! Two Bed Two Bath.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6497975821.html", 
+    "name": "Brand New Construction! Two Bed Two Bath.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6497975821.html",
     "containedIn": {
-      "name": " (East 100th // 2nd Ave)", 
+      "name": " (East 100th // 2nd Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Construction // in mint condition // elevator.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6497970356.html", 
+    "name": "Brand New Construction // in mint condition // elevator.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6497970356.html",
     "containedIn": {
-      "name": " (East 100th // 2nd Ave)", 
+      "name": " (East 100th // 2nd Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4785.0, 
+      "name": "price",
+      "value": 4785.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "THREE BEDROOM MIDTOWN WEST NO FEE EQUAL SIZED ROOMS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/three-bedroom-midtown-west-no/6497961395.html", 
+    "name": "THREE BEDROOM MIDTOWN WEST NO FEE EQUAL SIZED ROOMS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/three-bedroom-midtown-west-no/6497961395.html",
     "containedIn": {
-      "name": " (MIDTOWN WEST)", 
+      "name": " (MIDTOWN WEST)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4095.0, 
+      "name": "price",
+      "value": 4095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CONVERTIBLE TO TWO! ELEVATOR BUILDING!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-to-two-elevator/6497958782.html", 
+    "name": "CONVERTIBLE TO TWO! ELEVATOR BUILDING!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-to-two-elevator/6497958782.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2588 \u25b6NICE FLOOR THRU 1BR*short walk to 4th Ave F,G,R*NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-floor-thru-1brshort-walk/6497956221.html", 
+    "name": "█ ▶NICE FLOOR THRU 1BR*short walk to 4th Ave F,G,R*NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-floor-thru-1brshort-walk/6497956221.html",
     "containedIn": {
-      "name": " (Brooklyn)", 
+      "name": " (Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated 3 bedroom apt check it out!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-3-bedroom-apt-check/6497947842.html", 
+    "name": "Renovated 3 bedroom apt check it out!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-3-bedroom-apt-check/6497947842.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2290.0, 
+      "name": "price",
+      "value": 2290.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**Pre Construction in Fidi / Seaport **Ultra Lux Rental Tower**Rooftop", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/pre-construction-in-fidi/6497928391.html", 
+    "name": "**Pre Construction in Fidi / Seaport **Ultra Lux Rental Tower**Rooftop",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/pre-construction-in-fidi/6497928391.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FANATSTIC 3 BEDROOMS APARTMENT - EXTRA LARGE - 2 FULL BATHS - W/4", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/fanatstic-3-bedrooms/6497922709.html", 
+    "name": "FANATSTIC 3 BEDROOMS APARTMENT - EXTRA LARGE - 2 FULL BATHS - W/4",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fanatstic-3-bedrooms/6497922709.html",
     "containedIn": {
-      "name": " (Greenwich Village)", 
+      "name": " (Greenwich Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5995.0, 
+      "name": "price",
+      "value": 5995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury 3 bedroom (dog owner's dream)", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-3-bedroom-dog-owners/6497920129.html", 
+    "name": "Luxury 3 bedroom (dog owner's dream)",
+    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-3-bedroom-dog-owners/6497920129.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3857.0, 
+      "name": "price",
+      "value": 3857.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**New Year New Deal**Sun Drenched**Spacious**Chefs Kitchen**Basketball", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-year-new-dealsun/6497911092.html", 
+    "name": "**New Year New Deal**Sun Drenched**Spacious**Chefs Kitchen**Basketball",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-year-new-dealsun/6497911092.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3800.0, 
+      "name": "price",
+      "value": 3800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6497910848.html", 
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6497910848.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, Beautiful Renovated 2 Bedroom!", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-beautiful-renovated-2/6497909986.html", 
+    "name": "NO FEE, Beautiful Renovated 2 Bedroom!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-beautiful-renovated-2/6497909986.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! LARGE STUDIO W/ SEPARATE KITCHEN!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-separate/6497908890.html", 
+    "name": "NO FEE! LARGE STUDIO W/ SEPARATE KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-separate/6497908890.html",
     "containedIn": {
-      "name": " (Harlem)", 
+      "name": " (Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS STUDIO IN A FULL SERVICE BUILDING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/spacious-studio-in-full/6497905458.html", 
+    "name": "SPACIOUS STUDIO IN A FULL SERVICE BUILDING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/spacious-studio-in-full/6497905458.html",
     "containedIn": {
-      "name": " (QUEENS)", 
+      "name": " (QUEENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2331.0, 
+      "name": "price",
+      "value": 2331.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**HIGH CEILINGS**OVERSIZED WINDOWS**SPACIOUS**TONS OF CLOSET SPACE**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-ceilingsoversized/6497905048.html", 
+    "name": "**HIGH CEILINGS**OVERSIZED WINDOWS**SPACIOUS**TONS OF CLOSET SPACE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-ceilingsoversized/6497905048.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens *Spacious, Kitchens & Laundry*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497903676.html", 
+    "name": "NO FEE RENTALS, Kings & Queens *Spacious, Kitchens & Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497903676.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2075.0, 
+      "name": "price",
+      "value": 2075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge Converted 2 Bed w/ Wall up!! Luxury Doorman, 1 Free Month and NO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-converted-2-bed-wall-up/6497903757.html", 
+    "name": "Huge Converted 2 Bed w/ Wall up!! Luxury Doorman, 1 Free Month and NO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-converted-2-bed-wall-up/6497903757.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3160.0, 
+      "name": "price",
+      "value": 3160.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6497903278.html", 
+    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6497903278.html",
     "containedIn": {
-      "name": " (Flatiron)", 
+      "name": " (Flatiron)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4295.0, 
+      "name": "price",
+      "value": 4295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497902633.html", 
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497902633.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Below Market West Village 1BR/1BA!! No Fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6497902383.html", 
+    "name": "Below Market West Village 1BR/1BA!! No Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6497902383.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 1 BR Luxury in Greenwich Village!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6497901967.html", 
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6497901967.html",
     "containedIn": {
-      "name": " (Greenwich Village)", 
+      "name": " (Greenwich Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning 2BR! Best Deal Available! No Fee!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-2br-best-deal/6497901501.html", 
+    "name": "Stunning 2BR! Best Deal Available! No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-2br-best-deal/6497901501.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4050.0, 
+      "name": "price",
+      "value": 4050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497898950.html", 
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497898950.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497896907.html", 
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497896907.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens. *Near Transport* *Great Location*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497888597.html", 
+    "name": "NO FEE RENTALS, Kings & Queens. *Near Transport* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497888597.html",
     "containedIn": {
-      "name": " (Brooklyn)", 
+      "name": " (Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 2BR/1.5 Duplex!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-15-duplex/6497879524.html", 
+    "name": "Massive 2BR/1.5 Duplex!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-15-duplex/6497879524.html",
     "containedIn": {
-      "name": " (Union Square)", 
+      "name": " (Union Square)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5150.0, 
+      "name": "price",
+      "value": 5150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEBRUARY MOVE IN ////////// UNIT 16D ====== WATER VIEWS  === BOUKLIS G", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-16d/6497865119.html", 
+    "name": "FEBRUARY MOVE IN ////////// UNIT 16D ====== WATER VIEWS  === BOUKLIS G",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-16d/6497865119.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2275.0, 
+      "name": "price",
+      "value": 2275.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6497861778.html", 
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6497861778.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6497861275.html", 
+    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6497861275.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 2BD in Downtown Stamford + Washer & Dryer and Covered Parking!", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-in-downtown/6497861139.html", 
+    "name": "Large 2BD in Downtown Stamford + Washer & Dryer and Covered Parking!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-in-downtown/6497861139.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6497860902.html", 
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6497860902.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6497860509.html", 
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6497860509.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6497852638.html", 
+    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6497852638.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6497850002.html", 
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6497850002.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2450.0, 
+      "name": "price",
+      "value": 2450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS STUDIO IN IDEAL LOCATION", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-ideal/6497848860.html", 
+    "name": "SPACIOUS STUDIO IN IDEAL LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-ideal/6497848860.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1875.0, 
+      "name": "price",
+      "value": 1875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FABULOUS ONE BEDROOM APARTMENT- HELL KITCHEN- NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/fabulous-one-bedroom/6497843914.html", 
+    "name": "FABULOUS ONE BEDROOM APARTMENT- HELL KITCHEN- NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fabulous-one-bedroom/6497843914.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- RENOVATED TWO BEDROOM OVERLOOKING THE PARK: Amazing price, large.", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-two-bedroom/6497827534.html", 
+    "name": "- RENOVATED TWO BEDROOM OVERLOOKING THE PARK: Amazing price, large.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-two-bedroom/6497827534.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Granite counter tops and a premium Bosch washer and dryer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-counter-tops-and/6497825109.html", 
+    "name": "Granite counter tops and a premium Bosch washer and dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-counter-tops-and/6497825109.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2689.0, 
+      "name": "price",
+      "value": 2689.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Just a block from the 1 train at Lincoln Center", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-block-from-the-1-train/6497824555.html", 
+    "name": "Just a block from the 1 train at Lincoln Center",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-block-from-the-1-train/6497824555.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3179.0, 
+      "name": "price",
+      "value": 3179.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RENOVATED Kitchen and Bathroom!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-kitchen-and-bathroom/6497824096.html", 
+    "name": "RENOVATED Kitchen and Bathroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-kitchen-and-bathroom/6497824096.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2229.0, 
+      "name": "price",
+      "value": 2229.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- Right on the park: Gut renovated: amazing layout, big rooms!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/right-on-the-park-gut/6497823221.html", 
+    "name": "- Right on the park: Gut renovated: amazing layout, big rooms!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/right-on-the-park-gut/6497823221.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1990.0, 
+      "name": "price",
+      "value": 1990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing Large Studio Rare Availibility On Jane Street!!! NO FEE!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-large-studio-rare/6497819997.html", 
+    "name": "Amazing Large Studio Rare Availibility On Jane Street!!! NO FEE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-large-studio-rare/6497819997.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- NO FEE: Gut renovated spacious three bedrooms! Across from the park!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-spacious/6497818015.html", 
+    "name": "- NO FEE: Gut renovated spacious three bedrooms! Across from the park!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-spacious/6497818015.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- Beautiful - New - Renovated. Minutes to prospect park. No fee at all", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-new-renovated/6497815491.html", 
+    "name": "- Beautiful - New - Renovated. Minutes to prospect park. No fee at all",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-new-renovated/6497815491.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- NO FEE. BRAND NEW. EXPOSED BRISKS. MASSIVE. FANCY RENO - STUNNING!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-exposed/6497814505.html", 
+    "name": "- NO FEE. BRAND NEW. EXPOSED BRISKS. MASSIVE. FANCY RENO - STUNNING!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-exposed/6497814505.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- MODERN STYLE: Dishwasher, Microwave. ACROSS FROM THE PARK!! *NO FEE!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-style-dishwasher/6497813805.html", 
+    "name": "- MODERN STYLE: Dishwasher, Microwave. ACROSS FROM THE PARK!! *NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-style-dishwasher/6497813805.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497812984.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497812984.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- NO FEE: Gut renovated real three spacious bedrooms! MUST SEE! ^HOT!^", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-real/6497812961.html", 
+    "name": "- NO FEE: Gut renovated real three spacious bedrooms! MUST SEE! ^HOT!^",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-real/6497812961.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- *BRAND NEW DEVELOPMENT: ROOF DECK - GYM - LAUNDRY - BIKE ROOM*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-development-roof/6497811173.html", 
+    "name": "- *BRAND NEW DEVELOPMENT: ROOF DECK - GYM - LAUNDRY - BIKE ROOM*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-development-roof/6497811173.html",
     "containedIn": {
-      "name": " (brooklyn)", 
+      "name": " (brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST 2 BEDROOM ON THE MARKET TODAY!! O.H ALL WEEK!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-2-bedroom-on-the-market/6497807895.html", 
+    "name": "BEST 2 BEDROOM ON THE MARKET TODAY!! O.H ALL WEEK!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-2-bedroom-on-the-market/6497807895.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "- WOW!! No fee Stunning  BRAND NEW 3 BEDS! Renovated building!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-no-fee-stunning-brand-new/6497806924.html", 
+    "name": "- WOW!! No fee Stunning  BRAND NEW 3 BEDS! Renovated building!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-no-fee-stunning-brand-new/6497806924.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497806765.html", 
+    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497806765.html",
     "containedIn": {
-      "name": " (prospect heights)", 
+      "name": " (prospect heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "All Brand New - All Everything - Be The First - Hot Area!!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/all-brand-new-all-everything/6497799242.html", 
+    "name": "All Brand New - All Everything - Be The First - Hot Area!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/all-brand-new-all-everything/6497799242.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2245.0, 
+      "name": "price",
+      "value": 2245.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 2 Bedroom In The Heart Of Greenwich (Elevator / Laundry Buildi", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2-bedroom-in-the/6497789772.html", 
+    "name": "Massive 2 Bedroom In The Heart Of Greenwich (Elevator / Laundry Buildi",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2-bedroom-in-the/6497789772.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5650.0, 
+      "name": "price",
+      "value": 5650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497782902.html", 
+    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497782902.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE GIGANTIC CONV3/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-conv3-2bath/6497782918.html", 
+    "name": "NO FEE GIGANTIC CONV3/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-conv3-2bath/6497782918.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5800.0, 
+      "name": "price",
+      "value": 5800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6497780698.html", 
+    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6497780698.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WASHER AND DRYER*****GARAGE PARKING******GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/washer-and-dryergarage/6497771611.html", 
+    "name": "WASHER AND DRYER*****GARAGE PARKING******GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washer-and-dryergarage/6497771611.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3041.0, 
+      "name": "price",
+      "value": 3041.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM---()---TONS OF LIGHT---", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497759907.html", 
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM---()---TONS OF LIGHT---",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497759907.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2630.0, 
+      "name": "price",
+      "value": 2630.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "667 Grand Street - Duplex 2 Br. Views of Manhattan skyline, No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/667-grand-street-duplex-2-br/6497753491.html", 
+    "name": "667 Grand Street - Duplex 2 Br. Views of Manhattan skyline, No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/667-grand-street-duplex-2-br/6497753491.html",
     "containedIn": {
-      "name": " (Williamsburg, BK)", 
+      "name": " (Williamsburg, BK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6497751134.html", 
+    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6497751134.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4050.0, 
+      "name": "price",
+      "value": 4050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497744509.html", 
+    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497744509.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497736405.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497736405.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2065.0, 
+      "name": "price",
+      "value": 2065.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, New Amenities & Laundry on Site!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497734357.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, New Amenities & Laundry on Site!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497734357.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2490.0, 
+      "name": "price",
+      "value": 2490.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497731180.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497731180.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2075.0, 
+      "name": "price",
+      "value": 2075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 1 Bedroom, 1 Bath, Flex 3 Bedroom w/ Balcony and Tons of Clos", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bedroom-1-bath/6497730750.html", 
+    "name": "Spacious 1 Bedroom, 1 Bath, Flex 3 Bedroom w/ Balcony and Tons of Clos",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bedroom-1-bath/6497730750.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4595.0, 
+      "name": "price",
+      "value": 4595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "New New New - Everything Is Brand New - Be The First To Live Here!!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-new-new-everything-is/6497720413.html", 
+    "name": "New New New - Everything Is Brand New - Be The First To Live Here!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-new-new-everything-is/6497720413.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2850.0, 
+      "name": "price",
+      "value": 2850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 3 Bed", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6497694768.html", 
+    "name": "Beautiful 3 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6497694768.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3895.0, 
+      "name": "price",
+      "value": 3895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Apartment In Brand New Building w/Great Bldg Amenities", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-apartment-in-brand/6497687090.html", 
+    "name": "Brand New Apartment In Brand New Building w/Great Bldg Amenities",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-apartment-in-brand/6497687090.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE** CHELSEA_TOTAL BARGAIN $1,900_BELOW MARKET PRICE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-chelseatotal-bargain/6497684936.html", 
+    "name": "**NO FEE** CHELSEA_TOTAL BARGAIN $1,900_BELOW MARKET PRICE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-chelseatotal-bargain/6497684936.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 BED STEPS TO FULTON  - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-steps-to-fulton-no-fee/6497669695.html", 
+    "name": "3 BED STEPS TO FULTON  - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-steps-to-fulton-no-fee/6497669695.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE**61&2nd  //NATURAL light%separate kitchen<3", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee612nd-natural/6497650366.html", 
+    "name": "NO FEE**61&2nd  //NATURAL light%separate kitchen<3",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee612nd-natural/6497650366.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1875.0, 
+      "name": "price",
+      "value": 1875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE 1 Bedroom Apartment", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bedroom-apartment/6497639390.html", 
+    "name": "NO FEE 1 Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bedroom-apartment/6497639390.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1925.0, 
+      "name": "price",
+      "value": 1925.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Columbus Circle - Glorious 4.5BR / 3BA ~~ Classic NYC ~~ Doorman", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-glorious-45br/6497637371.html", 
+    "name": "Columbus Circle - Glorious 4.5BR / 3BA ~~ Classic NYC ~~ Doorman",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-glorious-45br/6497637371.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 10750.0, 
+      "name": "price",
+      "value": 10750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand new renovations along with an updated bathroom and kitchen", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-renovations-along/6497634994.html", 
+    "name": "Brand new renovations along with an updated bathroom and kitchen",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-renovations-along/6497634994.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2689.0, 
+      "name": "price",
+      "value": 2689.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Located in the most iconic section of the upper west side", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/located-in-the-most-iconic/6497634024.html", 
+    "name": "Located in the most iconic section of the upper west side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/located-in-the-most-iconic/6497634024.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3179.0, 
+      "name": "price",
+      "value": 3179.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6497633972.html", 
+    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6497633972.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Newly Refinished Flooring Throughout The Apartment!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-refinished-flooring/6497633515.html", 
+    "name": "Newly Refinished Flooring Throughout The Apartment!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-refinished-flooring/6497633515.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2229.0, 
+      "name": "price",
+      "value": 2229.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee_ Large 2BR, Sep Kitchen, Stainless Steel Appliances, A/C Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2br-sep-kitchen/6497620457.html", 
+    "name": "No Fee_ Large 2BR, Sep Kitchen, Stainless Steel Appliances, A/C Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2br-sep-kitchen/6497620457.html",
     "containedIn": {
-      "name": " (Crown Heights, Pacific St: NO FEE)", 
+      "name": " (Crown Heights, Pacific St: NO FEE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE HUGE  PRIVATE BALCONY  INDOOR POOL ROOF DECK DM LUXURY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-huge-private-balcony/6497607866.html", 
+    "name": "HUGE HUGE  PRIVATE BALCONY  INDOOR POOL ROOF DECK DM LUXURY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-huge-private-balcony/6497607866.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6100.0, 
+      "name": "price",
+      "value": 6100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6497593263.html", 
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6497593263.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1932.0, 
+      "name": "price",
+      "value": 1932.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6497591219.html", 
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6497591219.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6497589825.html", 
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6497589825.html",
     "containedIn": {
-      "name": " (Elmhurst)", 
+      "name": " (Elmhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6497587073.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6497587073.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6497576886.html", 
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6497576886.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7410.0, 
+      "name": "price",
+      "value": 7410.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Spacious, Laundry!*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497576705.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Spacious, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497576705.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2780.0, 
+      "name": "price",
+      "value": 2780.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6497576075.html", 
+    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6497576075.html",
     "containedIn": {
-      "name": " (Kew Gardens / Richmond Hill)", 
+      "name": " (Kew Gardens / Richmond Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW LUXURY BUILDING LOCATED IN LONG ISLAND CITY", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-luxury-building/6497575511.html", 
+    "name": "BRAND NEW LUXURY BUILDING LOCATED IN LONG ISLAND CITY",
+    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-luxury-building/6497575511.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2215.0, 
+      "name": "price",
+      "value": 2215.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6497566209.html", 
+    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6497566209.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW RENOV. APART-ELEVATOR BUILD. $1795/ P-MONTH", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-renov-apart-elevator/6497565312.html", 
+    "name": "NEW RENOV. APART-ELEVATOR BUILD. $1795/ P-MONTH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-renov-apart-elevator/6497565312.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Centrally Located Forest Hills Luxury rental", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6497564496.html", 
+    "name": "Centrally Located Forest Hills Luxury rental",
+    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6497564496.html",
     "containedIn": {
-      "name": " (Forest Hills)", 
+      "name": " (Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3075.0, 
+      "name": "price",
+      "value": 3075.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6497564418.html", 
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6497564418.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2819.0, 
+      "name": "price",
+      "value": 2819.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Avail March 1~ Renovated True 2 bed/1bath~ Near Subway~No Broker fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-renovated-true/6497562578.html", 
+    "name": "Avail March 1~ Renovated True 2 bed/1bath~ Near Subway~No Broker fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-renovated-true/6497562578.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6497561810.html", 
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6497561810.html",
     "containedIn": {
-      "name": " (Rego Park / Forest Hills)", 
+      "name": " (Rego Park / Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6497558839.html", 
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6497558839.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6497558183.html", 
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6497558183.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*****ENORMOUS WINDOWS_______NO FEE____SPACIOUS_______PET FRIENDLY (Fin", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/enormous-windowsno/6497552555.html", 
+    "name": "*****ENORMOUS WINDOWS_______NO FEE____SPACIOUS_______PET FRIENDLY (Fin",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/enormous-windowsno/6497552555.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2520.0, 
+      "name": "price",
+      "value": 2520.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Convenient to the subway (4, 5, and 6 Trains)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/convenient-to-the-subway-4-5/6497551277.html", 
+    "name": "Convenient to the subway (4, 5, and 6 Trains)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convenient-to-the-subway-4-5/6497551277.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2689.0, 
+      "name": "price",
+      "value": 2689.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "One of the best school districts!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-of-the-best-school/6497550743.html", 
+    "name": "One of the best school districts!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-of-the-best-school/6497550743.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3179.0, 
+      "name": "price",
+      "value": 3179.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Faux Fireplace Mantle_Hardwood Floors_Updated Appliances", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-faux-fireplace/6497550250.html", 
+    "name": "Beautiful Faux Fireplace Mantle_Hardwood Floors_Updated Appliances",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-faux-fireplace/6497550250.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2229.0, 
+      "name": "price",
+      "value": 2229.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6497550206.html", 
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6497550206.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE** GUT RENO** SS APPLIANCES** GORGEOUS**HARDWOOD FLOORS**", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-reno-ss-appliances/6497546236.html", 
+    "name": "NO FEE** GUT RENO** SS APPLIANCES** GORGEOUS**HARDWOOD FLOORS**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-reno-ss-appliances/6497546236.html",
     "containedIn": {
-      "name": " (sheepshead bay)", 
+      "name": " (sheepshead bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New Studio with Walk-In Closet", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studio-with-walk-in/6497540432.html", 
+    "name": "Brand New Studio with Walk-In Closet",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studio-with-walk-in/6497540432.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2415.0, 
+      "name": "price",
+      "value": 2415.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stratford 3 bedroom 1.5 bath Near Train Station", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/stratford-3-bedroom-15-bath/6497526631.html", 
+    "name": "Stratford 3 bedroom 1.5 bath Near Train Station",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/stratford-3-bedroom-15-bath/6497526631.html",
     "containedIn": {
-      "name": " (Stratford)", 
+      "name": " (Stratford)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Cozy 2 bedroom/ Stainless Steel Appliances/ Lots of Sunlight/ J/M/Z", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/cozy-2-bedroom-stainless/6497526265.html", 
+    "name": "Cozy 2 bedroom/ Stainless Steel Appliances/ Lots of Sunlight/ J/M/Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/cozy-2-bedroom-stainless/6497526265.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605Delancey/Clinton\u2605Bright, Renovated 2BR, Exp Brk, MAR 1", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/delancey-clintonbright/6497519550.html", 
+    "name": "★Delancey/Clinton★Bright, Renovated 2BR, Exp Brk, MAR 1",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/delancey-clintonbright/6497519550.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 BED FIDI PRIME LOCATION - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-fidi-prime-location-no/6497505951.html", 
+    "name": "3 BED FIDI PRIME LOCATION - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-fidi-prime-location-no/6497505951.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 3 Bed 2bth New Kitchen/Bath On-site parking Close to Train", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-3-bed-2bth-new-kitchen/6497500542.html", 
+    "name": "No Fee 3 Bed 2bth New Kitchen/Bath On-site parking Close to Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-3-bed-2bth-new-kitchen/6497500542.html",
     "containedIn": {
-      "name": " (New Rochelle NY)", 
+      "name": " (New Rochelle NY)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Doorman Building, Prime Location   - No Fee!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-prime/6497499021.html", 
+    "name": "Luxury Doorman Building, Prime Location   - No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-prime/6497499021.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***Lux Building***Brand new Renovations***W/D in Unit***100% No Fee ***", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingbrand-new/6497489333.html", 
+    "name": "***Lux Building***Brand new Renovations***W/D in Unit***100% No Fee ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingbrand-new/6497489333.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 2 Bed New Kitchen and Bath London Terrace No FEE", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-new-kitchen-and/6497487626.html", 
+    "name": "No Fee 2 Bed New Kitchen and Bath London Terrace No FEE",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-new-kitchen-and/6497487626.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1765.0, 
+      "name": "price",
+      "value": 1765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 1 Bed New Kitchen and Bath London Terrace No FEE", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bed-new-kitchen-and/6497482725.html", 
+    "name": "No Fee 1 Bed New Kitchen and Bath London Terrace No FEE",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bed-new-kitchen-and/6497482725.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1550.0, 
+      "name": "price",
+      "value": 1550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 2 Bed 1b New Kitchen/Bath On-site parking Close to Train", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-1b-new-kitchen/6497479679.html", 
+    "name": "No Fee 2 Bed 1b New Kitchen/Bath On-site parking Close to Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-1b-new-kitchen/6497479679.html",
     "containedIn": {
-      "name": " (New Rochelle NY)", 
+      "name": " (New Rochelle NY)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2145.0, 
+      "name": "price",
+      "value": 2145.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6497477013.html", 
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6497477013.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2395.0, 
+      "name": "price",
+      "value": 2395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! - 1100sf 2 BED - STAINLESS STEEL KITCHEN, CENTRAL AIR, LAUNDRY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1100sf-2-bed-stainless/6497476460.html", 
+    "name": "NO FEE! - 1100sf 2 BED - STAINLESS STEEL KITCHEN, CENTRAL AIR, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1100sf-2-bed-stainless/6497476460.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3900.0, 
+      "name": "price",
+      "value": 3900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6497476413.html", 
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6497476413.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE 1 Bedroom New Kitchen and Bath on-site Parking Walk To Train", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bedroom-new-kitchen/6497475292.html", 
+    "name": "NO FEE 1 Bedroom New Kitchen and Bath on-site Parking Walk To Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bedroom-new-kitchen/6497475292.html",
     "containedIn": {
-      "name": " (port chester, ny)", 
+      "name": " (port chester, ny)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1690.0, 
+      "name": "price",
+      "value": 1690.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "---->> Empire State Building View! --- 10 Min to Lex/59 --- Penthouse!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/empire-state-building-view-10/6497475184.html", 
+    "name": "---->> Empire State Building View! --- 10 Min to Lex/59 --- Penthouse!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/empire-state-building-view-10/6497475184.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Condo by the Harbor - the perfect location!", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/condo-by-the-harbor-the/6497475115.html", 
+    "name": "Condo by the Harbor - the perfect location!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/condo-by-the-harbor-the/6497475115.html",
     "containedIn": {
-      "name": " (Mamaroneck)", 
+      "name": " (Mamaroneck)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6497474143.html", 
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6497474143.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "_____Ultra Luxurious LAYOUT_________Walk In Closet___Great Location___", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxurious-layoutwalk-in/6497472254.html", 
+    "name": "_____Ultra Luxurious LAYOUT_________Walk In Closet___Great Location___",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxurious-layoutwalk-in/6497472254.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2949.0, 
+      "name": "price",
+      "value": 2949.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "__>>LIVE ON WALL ST______CONDO FINISHES____W / D IN YOUR UNIT<_", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/live-on-wall-stcondo/6497472210.html", 
+    "name": "__>>LIVE ON WALL ST______CONDO FINISHES____W / D IN YOUR UNIT<_",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/live-on-wall-stcondo/6497472210.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2979.0, 
+      "name": "price",
+      "value": 2979.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "--PENTHOUSE--Amazing Water Views--GUT RENOVATIONS--Back on the Market", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-amazing-water-views/6497472135.html", 
+    "name": "--PENTHOUSE--Amazing Water Views--GUT RENOVATIONS--Back on the Market",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-amazing-water-views/6497472135.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3695.0, 
+      "name": "price",
+      "value": 3695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "___________BACK ON THE MARKET____FIDI/BATTERY PARK________DOORMAN+GYM+", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/back-on-the-marketfidi/6497471971.html", 
+    "name": "___________BACK ON THE MARKET____FIDI/BATTERY PARK________DOORMAN+GYM+",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/back-on-the-marketfidi/6497471971.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2679.0, 
+      "name": "price",
+      "value": 2679.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MODERN FINISHES===AMPLE AMOUNTS OF CLOSET SPACE===GRANITE COUNTER TOPS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/modern-finishesample-amounts/6497460307.html", 
+    "name": "MODERN FINISHES===AMPLE AMOUNTS OF CLOSET SPACE===GRANITE COUNTER TOPS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/modern-finishesample-amounts/6497460307.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2660.0, 
+      "name": "price",
+      "value": 2660.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunset Park_1 BR__NO FEE__$1650__LAUNDRY___Sunset Park Slope Boro Park", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park1-brno/6497459429.html", 
+    "name": "Sunset Park_1 BR__NO FEE__$1650__LAUNDRY___Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park1-brno/6497459429.html",
     "containedIn": {
-      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)", 
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM------TONS OF LIGHT-----", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497458960.html", 
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM------TONS OF LIGHT-----",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497458960.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2580.0, 
+      "name": "price",
+      "value": 2580.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated four bedroom unit located in Ossining!", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/renovated-four-bedroom-unit/6497457113.html", 
+    "name": "Renovated four bedroom unit located in Ossining!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/renovated-four-bedroom-unit/6497457113.html",
     "containedIn": {
-      "name": " (Main Street, Ossining)", 
+      "name": " (Main Street, Ossining)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6497456396.html", 
+    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6497456396.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "VERY BRIGHT and COZY 4Br with Shared Yard!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/very-bright-and-cozy-4br-with/6497456374.html", 
+    "name": "VERY BRIGHT and COZY 4Br with Shared Yard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-bright-and-cozy-4br-with/6497456374.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3550.0, 
+      "name": "price",
+      "value": 3550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6497452554.html", 
+    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6497452554.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3750.0, 
+      "name": "price",
+      "value": 3750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6497449547.html", 
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6497449547.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6497447070.html", 
+    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6497447070.html",
     "containedIn": {
-      "name": " (Bedford Stuyvesant)", 
+      "name": " (Bedford Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Top floor renovated 3 bedroom for rent in Katonah!", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/top-floor-renovated-3-bedroom/6497444049.html", 
+    "name": "Top floor renovated 3 bedroom for rent in Katonah!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/top-floor-renovated-3-bedroom/6497444049.html",
     "containedIn": {
-      "name": " (Anderson Road, Katonah)", 
+      "name": " (Anderson Road, Katonah)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2b50NO FEE Beautiful Mint Cond STUDIO-ELEV/LAUNDRY-DW-MW-2 Min A Express", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-mint-cond/6497440048.html", 
+    "name": "⭐NO FEE Beautiful Mint Cond STUDIO-ELEV/LAUNDRY-DW-MW-2 Min A Express",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-mint-cond/6497440048.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Very large one bedroom TRIPLEX LOFT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-one-bedroom/6497432953.html", 
+    "name": "Very large one bedroom TRIPLEX LOFT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-one-bedroom/6497432953.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL Large 1 Br apartment with Private Backyard!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1-br/6497431598.html", 
+    "name": "BEAUTIFUL Large 1 Br apartment with Private Backyard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1-br/6497431598.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497431348.html", 
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497431348.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3490.0, 
+      "name": "price",
+      "value": 3490.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497430638.html", 
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497430638.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3490.0, 
+      "name": "price",
+      "value": 3490.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497427931.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497427931.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497427194.html", 
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497427194.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3490.0, 
+      "name": "price",
+      "value": 3490.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunset Park_2 BR__NO FEE__NEAR MAIMONEDES__Sunset Park Slope Boro Park", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feenear/6497426450.html", 
+    "name": "Sunset Park_2 BR__NO FEE__NEAR MAIMONEDES__Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feenear/6497426450.html",
     "containedIn": {
-      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)", 
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM----WINDOW IN EVERY ROOM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497424993.html", 
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM----WINDOW IN EVERY ROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497424993.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4545.0, 
+      "name": "price",
+      "value": 4545.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Convertible 2 Bed/Large 1 Bed in Luxury Building - NO FEE!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-2-bed-large-1-bed/6497423470.html", 
+    "name": "Convertible 2 Bed/Large 1 Bed in Luxury Building - NO FEE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-2-bed-large-1-bed/6497423470.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunset Park__2 BR_NO FEE__EXPRESS TRAINS___Sunset Park Slope Boro Park", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feeexpress/6497418725.html", 
+    "name": "Sunset Park__2 BR_NO FEE__EXPRESS TRAINS___Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feeexpress/6497418725.html",
     "containedIn": {
-      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)", 
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1875.0, 
+      "name": "price",
+      "value": 1875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6497416942.html", 
+    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6497416942.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4550.0, 
+      "name": "price",
+      "value": 4550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6497411834.html", 
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6497411834.html",
     "containedIn": {
-      "name": " (Lefferts Garden/Prospect Park)", 
+      "name": " (Lefferts Garden/Prospect Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1595.0, 
+      "name": "price",
+      "value": 1595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Boutique Apt in Central Greenwich DENISE ROSATO 203.622.4000", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-boutique-apt-in/6497411671.html", 
+    "name": "Luxury Boutique Apt in Central Greenwich DENISE ROSATO 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-boutique-apt-in/6497411671.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6497410221.html", 
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6497410221.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6497409714.html", 
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6497409714.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6497409341.html", 
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6497409341.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 1206 Square Foot 2 Bed/2 Bath w/ Terrace and Views!! - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-1206-square-foot-2-bed-2/6497406933.html", 
+    "name": "HUGE 1206 Square Foot 2 Bed/2 Bath w/ Terrace and Views!! - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-1206-square-foot-2-bed-2/6497406933.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5200.0, 
+      "name": "price",
+      "value": 5200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Private Byram Shore Estate |Stunning Apt |Call Patricia 914.830.8191", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/private-byram-shore-estate/6497404749.html", 
+    "name": "Private Byram Shore Estate |Stunning Apt |Call Patricia 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/private-byram-shore-estate/6497404749.html",
     "containedIn": {
-      "name": " (Greenwich)", 
+      "name": " (Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Residence on Private Belle Haven Estate CALL PAT 914-830-8191", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-residence-on-private/6497403982.html", 
+    "name": "Luxury Residence on Private Belle Haven Estate CALL PAT 914-830-8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-residence-on-private/6497403982.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4950.0, 
+      "name": "price",
+      "value": 4950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated 3Bdrm 2Bath Central Greenwich*Walk 2Train*Pat@ 914.830.8191", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-3bdrm-2bath-central/6497402048.html", 
+    "name": "Renovated 3Bdrm 2Bath Central Greenwich*Walk 2Train*Pat@ 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-3bdrm-2bath-central/6497402048.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE** CRAZY AMENITIES** BRAND NEW**SPACIOUS**GYM**LAUNDRY**THEATER", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-crazy-amenities-brand/6497401243.html", 
+    "name": "NO FEE** CRAZY AMENITIES** BRAND NEW**SPACIOUS**GYM**LAUNDRY**THEATER",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-crazy-amenities-brand/6497401243.html",
     "containedIn": {
-      "name": " (Bedford-stuyvesant)", 
+      "name": " (Bedford-stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2383.0, 
+      "name": "price",
+      "value": 2383.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated 2 Bdrm|Dwntn Greenwich|Walk  to Train|CALL PAT 914.830.8191", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-2-bdrmdwntn/6497400908.html", 
+    "name": "Renovated 2 Bdrm|Dwntn Greenwich|Walk  to Train|CALL PAT 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-2-bdrmdwntn/6497400908.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated, Microwave, Dishwasher, Laundry on Site.", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-microwave/6497389879.html", 
+    "name": "Renovated, Microwave, Dishwasher, Laundry on Site.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-microwave/6497389879.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant)", 
+      "name": " (Bedford-Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6497389076.html", 
+    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6497389076.html",
     "containedIn": {
-      "name": " (New Rochelle)", 
+      "name": " (New Rochelle)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2145.0, 
+      "name": "price",
+      "value": 2145.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6497388119.html", 
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6497388119.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2175.0, 
+      "name": "price",
+      "value": 2175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge Living Room, Big Bedrooms, Master Bedroom w/ Private Bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-living-room-big-bedrooms/6497386909.html", 
+    "name": "Huge Living Room, Big Bedrooms, Master Bedroom w/ Private Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-living-room-big-bedrooms/6497386909.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large Living Space, Lots Of Closet Space, Close to 2 5", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-living-space-lots-of/6497386384.html", 
+    "name": "Large Living Space, Lots Of Closet Space, Close to 2 5",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-living-space-lots-of/6497386384.html",
     "containedIn": {
-      "name": " (East Flatbush)", 
+      "name": " (East Flatbush)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE 1 MONTH FREE// 38TH FLOOR  // HUGE 4 BED/2 BATH // 24H D/M", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-1-month-free-38th/6497384779.html", 
+    "name": "100% NO FEE 1 MONTH FREE// 38TH FLOOR  // HUGE 4 BED/2 BATH // 24H D/M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-1-month-free-38th/6497384779.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5300.0, 
+      "name": "price",
+      "value": 5300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6497379795.html", 
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6497379795.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2375.0, 
+      "name": "price",
+      "value": 2375.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6497377455.html", 
+    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6497377455.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-Walls of Windows, Condo Finishes, Bright; Hardwood Floors, High", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walls-of-windows-condo/6497372933.html", 
+    "name": "NO FEE-Walls of Windows, Condo Finishes, Bright; Hardwood Floors, High",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walls-of-windows-condo/6497372933.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6497366682.html", 
+    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6497366682.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2861.0, 
+      "name": "price",
+      "value": 2861.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497366232.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497366232.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6497360993.html", 
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6497360993.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Bdrm Apt in Springdale Section of Stamford  Call Joe 203.253.5399", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/1-bdrm-apt-in-springdale/6497358908.html", 
+    "name": "1 Bdrm Apt in Springdale Section of Stamford  Call Joe 203.253.5399",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1-bdrm-apt-in-springdale/6497358908.html",
     "containedIn": {
-      "name": " (Stamford/Springdale)", 
+      "name": " (Stamford/Springdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! XL Studio, Doorman", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-xl-studio-doorman/6497354594.html", 
+    "name": "NO FEE! XL Studio, Doorman",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-xl-studio-doorman/6497354594.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2585.0, 
+      "name": "price",
+      "value": 2585.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "A newly renovated gorgeous three-bedroom apartment", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-gorgeous/6497354337.html", 
+    "name": "A newly renovated gorgeous three-bedroom apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-gorgeous/6497354337.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Spacious Kitchens *Near Shopping*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497352416.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Spacious Kitchens *Near Shopping*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497352416.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6497345393.html", 
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6497345393.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey J)", 
+      "name": " (Bushwick @ Halsey J)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3175.0, 
+      "name": "price",
+      "value": 3175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6497344698.html", 
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6497344698.html",
     "containedIn": {
-      "name": " (Prospect heights @ 2,3,B,Q)", 
+      "name": " (Prospect heights @ 2,3,B,Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6497342655.html", 
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6497342655.html",
     "containedIn": {
-      "name": " (Ridgewood @ Seneca M)", 
+      "name": " (Ridgewood @ Seneca M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2609.0, 
+      "name": "price",
+      "value": 2609.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497339453.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497339453.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6497338007.html", 
+    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6497338007.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS +++ HIGH CEILINGS +++ OVERSIZED WINDOWS +++ OPEN KITCHEN +++", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-high-ceilings/6497332326.html", 
+    "name": "SPACIOUS +++ HIGH CEILINGS +++ OVERSIZED WINDOWS +++ OPEN KITCHEN +++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-high-ceilings/6497332326.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3855.0, 
+      "name": "price",
+      "value": 3855.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6497331073.html", 
+    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6497331073.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2670.0, 
+      "name": "price",
+      "value": 2670.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 75th St - CONV 1 BED - Luxury, Doorman, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-75th-st-conv-1-bed/6497318561.html", 
+    "name": "East 75th St - CONV 1 BED - Luxury, Doorman, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-75th-st-conv-1-bed/6497318561.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2654.0, 
+      "name": "price",
+      "value": 2654.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6497317475.html", 
+    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6497317475.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4457.0, 
+      "name": "price",
+      "value": 4457.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE + 2 MNTS FREE**FLEX 3**24H_LUX_DRMN_GYM**GREAT LOCATION", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freeflex/6497313827.html", 
+    "name": "NO FEE + 2 MNTS FREE**FLEX 3**24H_LUX_DRMN_GYM**GREAT LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freeflex/6497313827.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3934.0, 
+      "name": "price",
+      "value": 3934.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6497309550.html", 
+    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6497309550.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3990.0, 
+      "name": "price",
+      "value": 3990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "West 60th St. - CONV 3 BED 2 BATH - Luxury ,Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-conv-3-bed-2/6497307279.html", 
+    "name": "West 60th St. - CONV 3 BED 2 BATH - Luxury ,Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-conv-3-bed-2/6497307279.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5798.0, 
+      "name": "price",
+      "value": 5798.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6497306152.html", 
+    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6497306152.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2990.0, 
+      "name": "price",
+      "value": 2990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497305494.html", 
+    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497305494.html",
     "containedIn": {
-      "name": " (prospect heights)", 
+      "name": " (prospect heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE + 2 MNTS FREE***24h_LUX_ DRMN _BLDG***GYM/LOUNGE_ WASHER/DRYER", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-free24hlux-drmn/6497302567.html", 
+    "name": "NO FEE + 2 MNTS FREE***24h_LUX_ DRMN _BLDG***GYM/LOUNGE_ WASHER/DRYER",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-free24hlux-drmn/6497302567.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEES!! - Super Large Apt Glendale/2 bedrooms- Private Deck & Yard", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fees-super-large-apt/6497300585.html", 
+    "name": "NO FEES!! - Super Large Apt Glendale/2 bedrooms- Private Deck & Yard",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fees-super-large-apt/6497300585.html",
     "containedIn": {
-      "name": " (79th Street)", 
+      "name": " (79th Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6497297297.html", 
+    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6497297297.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 88th St - CONV 3 Bed 2 Bath - Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-conv-3-bed-2/6497296574.html", 
+    "name": "East 88th St - CONV 3 Bed 2 Bath - Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-conv-3-bed-2/6497296574.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5862.0, 
+      "name": "price",
+      "value": 5862.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6497288539.html", 
+    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6497288539.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4395.0, 
+      "name": "price",
+      "value": 4395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee +2 Mnts Free_XL_Flex 2_24H Lux Drmn_Gym/Rooftop", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freexlflex-224h/6497286013.html", 
+    "name": "No Fee +2 Mnts Free_XL_Flex 2_24H Lux Drmn_Gym/Rooftop",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freexlflex-224h/6497286013.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6497283850.html", 
+    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6497283850.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee_XL_ Flex 2_Real Wall_ 24h_Lux_Drmn_Gym/Pool_HiFloor", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feexl-flex-2real-wall/6497278969.html", 
+    "name": "No Fee_XL_ Flex 2_Real Wall_ 24h_Lux_Drmn_Gym/Pool_HiFloor",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feexl-flex-2real-wall/6497278969.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Oversized_Flex 4_24_Lux_Drmn Bldg_Gym/Pool/Lounge_/Real Wall_25th st a", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/oversizedflex-424luxdrmn/6497273214.html", 
+    "name": "Oversized_Flex 4_24_Lux_Drmn Bldg_Gym/Pool/Lounge_/Real Wall_25th st a",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/oversizedflex-424luxdrmn/6497273214.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5990.0, 
+      "name": "price",
+      "value": 5990.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS  STUDIO - NO FEE + 1 MONTH FREE!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-no-fee-1/6497271585.html", 
+    "name": "GORGEOUS  STUDIO - NO FEE + 1 MONTH FREE!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-no-fee-1/6497271585.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2423.0, 
+      "name": "price",
+      "value": 2423.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lg 3 Bed, Chefs Kitchen, Private Backyard, Utilities Included! NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lg-3-bed-chefs-kitchen/6497270135.html", 
+    "name": "Lg 3 Bed, Chefs Kitchen, Private Backyard, Utilities Included! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lg-3-bed-chefs-kitchen/6497270135.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Room in 2 Bedroom Apartment in Central Park West and 108th No Fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-in-2-bedroom-apartment/6497267348.html", 
+    "name": "Room in 2 Bedroom Apartment in Central Park West and 108th No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-in-2-bedroom-apartment/6497267348.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2-Family Private Home ~~ Beautiful Duplex ~~ Best Area ~  ~R2O ~", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/2-family-private-home/6497258228.html", 
+    "name": "2-Family Private Home ~~ Beautiful Duplex ~~ Best Area ~  ~R2O ~",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/2-family-private-home/6497258228.html",
     "containedIn": {
-      "name": " (Belmont)", 
+      "name": " (Belmont)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "INCREDIBLE New Reno 1BR Apt*SS Apls*SHARED YARD*Prime CARROLL GARDENS!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-new-reno-1br-aptss/6497252397.html", 
+    "name": "INCREDIBLE New Reno 1BR Apt*SS Apls*SHARED YARD*Prime CARROLL GARDENS!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-new-reno-1br-aptss/6497252397.html",
     "containedIn": {
-      "name": " (Carroll Gardens)", 
+      "name": " (Carroll Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Fabulous Sunny TWO Bedroom Apartment in BAY TERRACE*Washer/Dryer Combo", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/fabulous-sunny-two-bedroom/6497251948.html", 
+    "name": "Fabulous Sunny TWO Bedroom Apartment in BAY TERRACE*Washer/Dryer Combo",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/fabulous-sunny-two-bedroom/6497251948.html",
     "containedIn": {
-      "name": " (Bay Terrace)", 
+      "name": " (Bay Terrace)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Incredible Sunny 1BR Condo Apt*SS Apls*DW*LNDRY*Prime Prospect Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-sunny-1br-condo/6497251335.html", 
+    "name": "Incredible Sunny 1BR Condo Apt*SS Apls*DW*LNDRY*Prime Prospect Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-sunny-1br-condo/6497251335.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6497242040.html", 
+    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6497242040.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning 3BR in Great Location! No Fee | Large Apt!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3br-in-great/6497239359.html", 
+    "name": "Stunning 3BR in Great Location! No Fee | Large Apt!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3br-in-great/6497239359.html",
     "containedIn": {
-      "name": " (Bushwick @ Gates JMZ)", 
+      "name": " (Bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Perfect No Fee Studio | Super Location steps from the Franklin C!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/perfect-no-fee-studio-super/6497236207.html", 
+    "name": "Perfect No Fee Studio | Super Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/perfect-no-fee-studio-super/6497236207.html",
     "containedIn": {
-      "name": " (Bed Stuy / Clinton Hill)", 
+      "name": " (Bed Stuy / Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6497234246.html", 
+    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6497234246.html",
     "containedIn": {
-      "name": " (Bed Stuy@ Myrtle G/J/M)", 
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3450.0, 
+      "name": "price",
+      "value": 3450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6497232425.html", 
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6497232425.html",
     "containedIn": {
-      "name": " (Bushwick @ Gates JMZ)", 
+      "name": " (Bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Studio Apt *** No Fees", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-apt-no-fees/6497218018.html", 
+    "name": "Studio Apt *** No Fees",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-apt-no-fees/6497218018.html",
     "containedIn": {
-      "name": " (bensonhurst)", 
+      "name": " (bensonhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1350.0, 
+      "name": "price",
+      "value": 1350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "One Bedroom For Rent on 2nd Floor of Two-Family Home - No Brokers Fee!", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/one-bedroom-for-rent-on-2nd/6497190399.html", 
+    "name": "One Bedroom For Rent on 2nd Floor of Two-Family Home - No Brokers Fee!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/one-bedroom-for-rent-on-2nd/6497190399.html",
     "containedIn": {
-      "name": " (Eastchester)", 
+      "name": " (Eastchester)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6497189085.html", 
+    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6497189085.html",
     "containedIn": {
-      "name": " (Flatbush/ Brooklyn College/Ditmas Park)", 
+      "name": " (Flatbush/ Brooklyn College/Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497181167.html", 
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497181167.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6497181030.html", 
+    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6497181030.html",
     "containedIn": {
-      "name": " (holywood ave)", 
+      "name": " (holywood ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1638.0, 
+      "name": "price",
+      "value": 1638.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497178329.html", 
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497178329.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV, 2BEDR  CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6497176760.html", 
+    "name": "NO FEE! NEWLY RENOV, 2BEDR  CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6497176760.html",
     "containedIn": {
-      "name": " (Flushing)", 
+      "name": " (Flushing)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2232.0, 
+      "name": "price",
+      "value": 2232.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6497170515.html", 
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6497170515.html",
     "containedIn": {
-      "name": " (Flushing)", 
+      "name": " (Flushing)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6497167313.html", 
+    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6497167313.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4700.0, 
+      "name": "price",
+      "value": 4700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6497164386.html", 
+    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6497164386.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4100.0, 
+      "name": "price",
+      "value": 4100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV JUNIOR-1BEDR PRIME  REGO PARK/FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior/6497164305.html", 
+    "name": "NO FEE! NEWLY RENOV JUNIOR-1BEDR PRIME  REGO PARK/FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior/6497164305.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! LARGE STUDIO CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-close-to/6497161727.html", 
+    "name": "NO FEE! LARGE STUDIO CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-close-to/6497161727.html",
     "containedIn": {
-      "name": " (FLUSHING)", 
+      "name": " (FLUSHING)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny Spacious ALL RENOV 1 BdRm, Just 2 1/2 Blks to Wakefield Station", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/sunny-spacious-all-renov-1/6497161198.html", 
+    "name": "Sunny Spacious ALL RENOV 1 BdRm, Just 2 1/2 Blks to Wakefield Station",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/sunny-spacious-all-renov-1/6497161198.html",
     "containedIn": {
-      "name": " (East Yonkers: Bronx River Rd)", 
+      "name": " (East Yonkers: Bronx River Rd)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1520.0, 
+      "name": "price",
+      "value": 1520.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OVERSIZED 850 SF Sunny Renovated One Bed Rm, Just 2 Blks to RR Station", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/oversized-850-sf-sunny/6497157959.html", 
+    "name": "OVERSIZED 850 SF Sunny Renovated One Bed Rm, Just 2 Blks to RR Station",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/oversized-850-sf-sunny/6497157959.html",
     "containedIn": {
-      "name": " (Yonkers, West)", 
+      "name": " (Yonkers, West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1520.0, 
+      "name": "price",
+      "value": 1520.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CLASSIC PRE WAR SPACIOUS 1 Bed Rm w Working Brick F/Pl", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/classic-pre-war-spacious-1/6497155865.html", 
+    "name": "CLASSIC PRE WAR SPACIOUS 1 Bed Rm w Working Brick F/Pl",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/classic-pre-war-spacious-1/6497155865.html",
     "containedIn": {
-      "name": " (HARTSDALE)", 
+      "name": " (HARTSDALE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1580.0, 
+      "name": "price",
+      "value": 1580.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large Basement for rent", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-basement-for-rent/6497151467.html", 
+    "name": "Large Basement for rent",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-basement-for-rent/6497151467.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1200.0, 
+      "name": "price",
+      "value": 1200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6497065218.html", 
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6497065218.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6133.0, 
+      "name": "price",
+      "value": 6133.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Bed Luxury Long Island City + Indoor Swimming Pool + 2 Months Free!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/1-bed-luxury-long-island-city/6497054873.html", 
+    "name": "1 Bed Luxury Long Island City + Indoor Swimming Pool + 2 Months Free!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/1-bed-luxury-long-island-city/6497054873.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2120.0, 
+      "name": "price",
+      "value": 2120.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 bedroom apartment-Balcony-Red Hook-Guarantors welcome-nofee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-apartment-balcony/6497043817.html", 
+    "name": "2 bedroom apartment-Balcony-Red Hook-Guarantors welcome-nofee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-apartment-balcony/6497043817.html",
     "containedIn": {
-      "name": " (redhook @ F ,G at Smith-9th St)", 
+      "name": " (redhook @ F ,G at Smith-9th St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "gorgeous 3 Bedroom-very spacious- Laundry In Building-NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-very/6497043585.html", 
+    "name": "gorgeous 3 Bedroom-very spacious- Laundry In Building-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-very/6497043585.html",
     "containedIn": {
-      "name": " (ridgewood @ M at forest ave)", 
+      "name": " (ridgewood @ M at forest ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6497043233.html", 
+    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6497043233.html",
     "containedIn": {
-      "name": " (Crown Heights C,S at Franklin Av)", 
+      "name": " (Crown Heights C,S at Franklin Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "4 Nice-sized Bedrooms-2 Full Bathrooms-long island city_NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/4-nice-sized-bedrooms-2-full/6497042880.html", 
+    "name": "4 Nice-sized Bedrooms-2 Full Bathrooms-long island city_NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/4-nice-sized-bedrooms-2-full/6497042880.html",
     "containedIn": {
-      "name": " (long island city @F at 21st St)", 
+      "name": " (long island city @F at 21st St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6497042475.html", 
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6497042475.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)", 
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS 2 BEDROOM DUPLEX -BEDSTUY -NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-2-bedroom-duplex/6497041968.html", 
+    "name": "SPACIOUS 2 BEDROOM DUPLEX -BEDSTUY -NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-2-bedroom-duplex/6497041968.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant A,C at Utica Av)", 
+      "name": " (Bedford-Stuyvesant A,C at Utica Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "large 3 bedroom-nice living -bushwick-great deal-no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3-bedroom-nice-living/6497040733.html", 
+    "name": "large 3 bedroom-nice living -bushwick-great deal-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3-bedroom-nice-living/6497040733.html",
     "containedIn": {
-      "name": " (Bushwick M at Knickerbocker Av)", 
+      "name": " (Bushwick M at Knickerbocker Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6497040329.html", 
+    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6497040329.html",
     "containedIn": {
-      "name": " (park slope @ F,G,R at 4 Av-9 St)", 
+      "name": " (park slope @ F,G,R at 4 Av-9 St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "4 bedroom 2 bath-renovated-2 skylights-bushwick- Great deal-no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/4-bedroom-2-bath-renovated-2/6497039907.html", 
+    "name": "4 bedroom 2 bath-renovated-2 skylights-bushwick- Great deal-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/4-bedroom-2-bath-renovated-2/6497039907.html",
     "containedIn": {
-      "name": " (Bushwick  j at Halsey St)", 
+      "name": " (Bushwick  j at Halsey St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3199.0, 
+      "name": "price",
+      "value": 3199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6497039497.html", 
+    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6497039497.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant @ c ralph ave)", 
+      "name": " (Bedford-Stuyvesant @ c ralph ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2399.0, 
+      "name": "price",
+      "value": 2399.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6497039107.html", 
+    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6497039107.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)", 
+      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6497038515.html", 
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6497038515.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6497037985.html", 
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6497037985.html",
     "containedIn": {
-      "name": " (Nolita / Bowery)", 
+      "name": " (Nolita / Bowery)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6497037569.html", 
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6497037569.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6497037336.html", 
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6497037336.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6497037083.html", 
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6497037083.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny 2BR - 4th Floor - Walk Up - No Fee - Desirable UWS Location", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-4th-floor-walk-up/6497029130.html", 
+    "name": "Sunny 2BR - 4th Floor - Walk Up - No Fee - Desirable UWS Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-4th-floor-walk-up/6497029130.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3250.0, 
+      "name": "price",
+      "value": 3250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Largest Duplex With Backyard Near Broadway/Junction", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-largest-duplex-with/6497001947.html", 
+    "name": "NO FEE Largest Duplex With Backyard Near Broadway/Junction",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-largest-duplex-with/6497001947.html",
     "containedIn": {
-      "name": " (Ocean Hill)", 
+      "name": " (Ocean Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Xtra-Large Duplex w/ Backyard near BWAY/Junction* Hull/E. Pkway", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-xtra-large-duplex/6497001425.html", 
+    "name": "NO FEE Xtra-Large Duplex w/ Backyard near BWAY/Junction* Hull/E. Pkway",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-xtra-large-duplex/6497001425.html",
     "containedIn": {
-      "name": " (Ocean Hill)", 
+      "name": " (Ocean Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 luxury Long Beach apartments for rent", 
-    "url": "https://newyork.craigslist.org/lgi/nfb/d/2-luxury-long-beach/6496976642.html", 
+    "name": "2 luxury Long Beach apartments for rent",
+    "url": "https://newyork.craigslist.org/lgi/nfb/d/2-luxury-long-beach/6496976642.html",
     "containedIn": {
-      "name": " (Hewlett)", 
+      "name": " (Hewlett)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605NO FEE! OPULENT LUXURY ~WD ~OPEN KIT. ~HUGE WINDOWS ~GYM ~POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-opulent-luxury-wd-open/6496972491.html", 
+    "name": "★NO FEE! OPULENT LUXURY ~WD ~OPEN KIT. ~HUGE WINDOWS ~GYM ~POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-opulent-luxury-wd-open/6496972491.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605NO FEE! MODERN FINISHES ~WD ~HIGH CEILING ~Dman ~GYM ~ROOF DECK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-modern-finishes-wd/6496972469.html", 
+    "name": "★NO FEE! MODERN FINISHES ~WD ~HIGH CEILING ~Dman ~GYM ~ROOF DECK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-modern-finishes-wd/6496972469.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3650.0, 
+      "name": "price",
+      "value": 3650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605NO FEE! 7th AVE. ~WD ~NEW FINISHES ~OPEN KIT. ~Dman ~GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-7th-ave-wd-new/6496951127.html", 
+    "name": "★NO FEE! 7th AVE. ~WD ~NEW FINISHES ~OPEN KIT. ~Dman ~GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-7th-ave-wd-new/6496951127.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4100.0, 
+      "name": "price",
+      "value": 4100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605DESIGNER APT.! 19TH St. ~EXQUISITE FINISHES ~FURN. ~ELEV.&LAUN.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/designer-apt-19th-st/6496951105.html", 
+    "name": "★DESIGNER APT.! 19TH St. ~EXQUISITE FINISHES ~FURN. ~ELEV.&LAUN.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/designer-apt-19th-st/6496951105.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4995.0, 
+      "name": "price",
+      "value": 4995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MASSIVE BRAND NEW 1600 SQFT FLEX4BR/2BTH/CITY VIEWS IN LUX,DOORMAN BLD", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-brand-new-1600-sqft/6496919037.html", 
+    "name": "MASSIVE BRAND NEW 1600 SQFT FLEX4BR/2BTH/CITY VIEWS IN LUX,DOORMAN BLD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-brand-new-1600-sqft/6496919037.html",
     "containedIn": {
-      "name": " (Union Square)", 
+      "name": " (Union Square)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6395.0, 
+      "name": "price",
+      "value": 6395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE. Renovated 2 Bedroom Apartment", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-2-bedroom/6496917357.html", 
+    "name": "NO FEE. Renovated 2 Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-2-bedroom/6496917357.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "A Spacious One-Bedroom Apartment", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-one-bedroom-apartment/6496914266.html", 
+    "name": "A Spacious One-Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-one-bedroom-apartment/6496914266.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6496902903.html", 
+    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6496902903.html",
     "containedIn": {
-      "name": " (Greenwood / 4th Ave & 27th St)", 
+      "name": " (Greenwood / 4th Ave & 27th St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL! 3 BED APT W/ WASH/DRY IN UNIT!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876783.html", 
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL! 3 BED APT W/ WASH/DRY IN UNIT!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876783.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3800.0, 
+      "name": "price",
+      "value": 3800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876593.html", 
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876593.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6496864218.html", 
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6496864218.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MASSIVE 1 Bed**NO BROKER FEE**PLG**AMAZING DEAL!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-1-bedno-broker/6496851108.html", 
+    "name": "MASSIVE 1 Bed**NO BROKER FEE**PLG**AMAZING DEAL!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-1-bedno-broker/6496851108.html",
     "containedIn": {
-      "name": " (Prospect Park-Lefferts Garden)", 
+      "name": " (Prospect Park-Lefferts Garden)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6496850109.html", 
+    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6496850109.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496836487.html", 
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496836487.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6133.0, 
+      "name": "price",
+      "value": 6133.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No FEE! 1 Month Free!  Spcious 3 Bdrm - Pets Ok! 148th & Broadway", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spcious-3/6496829890.html", 
+    "name": "No FEE! 1 Month Free!  Spcious 3 Bdrm - Pets Ok! 148th & Broadway",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spcious-3/6496829890.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 1000sq.ft 3 Bed in Elev Bldg - Laundry - Pets Ok - 157 & Bway", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1000sqft-3-bed-in/6496823805.html", 
+    "name": "Spacious 1000sq.ft 3 Bed in Elev Bldg - Laundry - Pets Ok - 157 & Bway",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1000sqft-3-bed-in/6496823805.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2833.0, 
+      "name": "price",
+      "value": 2833.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Pet-friendly 1bd/1ba steps from subway and large kitchen!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/pet-friendly-1bd-1ba-steps/6496822668.html", 
+    "name": "Pet-friendly 1bd/1ba steps from subway and large kitchen!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pet-friendly-1bd-1ba-steps/6496822668.html",
     "containedIn": {
-      "name": " (Fort Greene)", 
+      "name": " (Fort Greene)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496810675.html", 
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496810675.html",
     "containedIn": {
-      "name": " (Ditmas park / Cortelyou Rd)", 
+      "name": " (Ditmas park / Cortelyou Rd)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HOT DEAL! MASSIVE SUNNY STUDIO ** 100 % NO BROKERS FEE** LAUNDRY!!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/hot-deal-massive-sunny-studio/6496810212.html", 
+    "name": "HOT DEAL! MASSIVE SUNNY STUDIO ** 100 % NO BROKERS FEE** LAUNDRY!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hot-deal-massive-sunny-studio/6496810212.html",
     "containedIn": {
-      "name": " (Midwood / 2,5 & B Trains)", 
+      "name": " (Midwood / 2,5 & B Trains)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "===1 MONTH FREE===NEWLY RENOVATED===WALK-IN CLOSET===SUNDRNECHED===TRI", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-freenewly/6496797750.html", 
+    "name": "===1 MONTH FREE===NEWLY RENOVATED===WALK-IN CLOSET===SUNDRNECHED===TRI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-freenewly/6496797750.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6200.0, 
+      "name": "price",
+      "value": 6200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "+++BATTERY PARK+++2 MONTHS FREE+++PANORAMIC ROOFDECK+++LATE SHOWINGS++", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-park2-months/6496797127.html", 
+    "name": "+++BATTERY PARK+++2 MONTHS FREE+++PANORAMIC ROOFDECK+++LATE SHOWINGS++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-park2-months/6496797127.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5500.0, 
+      "name": "price",
+      "value": 5500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "+++1 MONTH FREE+++LUXURY+++RENOVATED+++NATURAL LIGHT+++LATE SHOWING", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month/6496796409.html", 
+    "name": "+++1 MONTH FREE+++LUXURY+++RENOVATED+++NATURAL LIGHT+++LATE SHOWING",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month/6496796409.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3470.0, 
+      "name": "price",
+      "value": 3470.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "===2 MONTHS FREE===LATE SHOWING===SPACIOUS===LUXURY===RENOVATED===", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freelate/6496795799.html", 
+    "name": "===2 MONTHS FREE===LATE SHOWING===SPACIOUS===LUXURY===RENOVATED===",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freelate/6496795799.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "===BATTERY PARK===RIVER VIEWS===1 MONTH FREE===HUGE WINDOWS===CHEFS KI", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-parkriver-views1/6496794052.html", 
+    "name": "===BATTERY PARK===RIVER VIEWS===1 MONTH FREE===HUGE WINDOWS===CHEFS KI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-parkriver-views1/6496794052.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Immaculate Spacious 2 Bdrm with den", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-spacious-2-bdrm/6496790991.html", 
+    "name": "Immaculate Spacious 2 Bdrm with den",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-spacious-2-bdrm/6496790991.html",
     "containedIn": {
-      "name": " (Bonaire)", 
+      "name": " (Bonaire)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 BDRM with DINING ROOM AND Den in gorgeous 2nd empire", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/1-bdrm-with-dining-room-and/6496784934.html", 
+    "name": "1 BDRM with DINING ROOM AND Den in gorgeous 2nd empire",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/1-bdrm-with-dining-room-and/6496784934.html",
     "containedIn": {
-      "name": " (STAPLETON)", 
+      "name": " (STAPLETON)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Immaculate Oversized One Bedroom", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-oversized-one/6496783505.html", 
+    "name": "Immaculate Oversized One Bedroom",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-oversized-one/6496783505.html",
     "containedIn": {
-      "name": " (Saint George)", 
+      "name": " (Saint George)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny Apartment", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-apartment/6496780977.html", 
+    "name": "Sunny Apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-apartment/6496780977.html",
     "containedIn": {
-      "name": " (Dyker Heights)", 
+      "name": " (Dyker Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1400.0, 
+      "name": "price",
+      "value": 1400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6496772662.html", 
+    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6496772662.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4400.0, 
+      "name": "price",
+      "value": 4400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CLOSE TO PROSPECT PARK'S SHOPS AND CAFES*SPACIOUS*NEWLY RENOVATED", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-prospect-parks-shops/6496742550.html", 
+    "name": "CLOSE TO PROSPECT PARK'S SHOPS AND CAFES*SPACIOUS*NEWLY RENOVATED",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-prospect-parks-shops/6496742550.html",
     "containedIn": {
-      "name": " (PROSPECT PARK SOUTH)", 
+      "name": " (PROSPECT PARK SOUTH)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496741302.html", 
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496741302.html",
     "containedIn": {
-      "name": " (13 Humboldt Street)", 
+      "name": " (13 Humboldt Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS*NEWLY RENOVATED*OUTDOOR SPACE* CLOSE TO KINGS PLAZA", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spaciousnewly/6496732746.html", 
+    "name": "SPACIOUS*NEWLY RENOVATED*OUTDOOR SPACE* CLOSE TO KINGS PLAZA",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spaciousnewly/6496732746.html",
     "containedIn": {
-      "name": " (Mill Basin)", 
+      "name": " (Mill Basin)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6496731301.html", 
+    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6496731301.html",
     "containedIn": {
-      "name": " (Flatbush/ Brooklyn College/Ditmas Park)", 
+      "name": " (Flatbush/ Brooklyn College/Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Newly Renovated NO FEE 3B 2B with Balcony close to Grand Central!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-no-fee-3b-2b/6496726773.html", 
+    "name": "Newly Renovated NO FEE 3B 2B with Balcony close to Grand Central!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-no-fee-3b-2b/6496726773.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6500.0, 
+      "name": "price",
+      "value": 6500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6496714027.html", 
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6496714027.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2195.0, 
+      "name": "price",
+      "value": 2195.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6496712822.html", 
+    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6496712822.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1895.0, 
+      "name": "price",
+      "value": 1895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6496710643.html", 
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6496710643.html",
     "containedIn": {
-      "name": " (CROWN HEIGHTS)", 
+      "name": " (CROWN HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6496709055.html", 
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6496709055.html",
     "containedIn": {
-      "name": " (Fort Green)", 
+      "name": " (Fort Green)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3BR/2.5 Bath Private House No Broker Fee", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/3br-25-bath-private-house-no/6496697899.html", 
+    "name": "3BR/2.5 Bath Private House No Broker Fee",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/3br-25-bath-private-house-no/6496697899.html",
     "containedIn": {
-      "name": " (Hartsdale)", 
+      "name": " (Hartsdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "DON'T MISS OUT THIS UNIT WONT LAST LONG!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/dont-miss-out-this-unit-wont/6496697746.html", 
+    "name": "DON'T MISS OUT THIS UNIT WONT LAST LONG!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/dont-miss-out-this-unit-wont/6496697746.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Breathtaking Hotel-Style 2 Bedroom in Bed-Stuy NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/breathtaking-hotel-style-2/6496697007.html", 
+    "name": "Breathtaking Hotel-Style 2 Bedroom in Bed-Stuy NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/breathtaking-hotel-style-2/6496697007.html",
     "containedIn": {
-      "name": " (Bed-Stuy)", 
+      "name": " (Bed-Stuy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2383.0, 
+      "name": "price",
+      "value": 2383.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee Amazing apartment with balcony and super tall ceilings Gramercy", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-apartment-with/6496683797.html", 
+    "name": "No Fee Amazing apartment with balcony and super tall ceilings Gramercy",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-apartment-with/6496683797.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5266.0, 
+      "name": "price",
+      "value": 5266.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Great Views, New Amenities*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496682105.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Great Views, New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496682105.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "no fee!modern Studio  2/3/4/5/S/A/C trains bike storage", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feemodern-studioa-trains/6496681733.html", 
+    "name": "no fee!modern Studio  2/3/4/5/S/A/C trains bike storage",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feemodern-studioa-trains/6496681733.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - TRUE 4BR/2BA W90's W/D in Unit - CLOSETS GALORE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-4br-2ba-w90s-d-in/6496665768.html", 
+    "name": "NO FEE - TRUE 4BR/2BA W90's W/D in Unit - CLOSETS GALORE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-4br-2ba-w90s-d-in/6496665768.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6864.0, 
+      "name": "price",
+      "value": 6864.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496655316.html", 
+    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496655316.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TONS OF CLOSETS --- STAINLESS STEEL APPLIANCES --- KING SIZED BEDROOMS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/tons-of-closets-stainless/6496654825.html", 
+    "name": "TONS OF CLOSETS --- STAINLESS STEEL APPLIANCES --- KING SIZED BEDROOMS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tons-of-closets-stainless/6496654825.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3590.0, 
+      "name": "price",
+      "value": 3590.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496654035.html", 
+    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496654035.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3690.0, 
+      "name": "price",
+      "value": 3690.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496646939.html", 
+    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496646939.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3900.0, 
+      "name": "price",
+      "value": 3900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "APRIL 15TH MOVE IN ////////// UNIT 17K ====== CITY VIEWS=== BOUKLIS GR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-unit-17k/6496632887.html", 
+    "name": "APRIL 15TH MOVE IN ////////// UNIT 17K ====== CITY VIEWS=== BOUKLIS GR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-unit-17k/6496632887.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2095.0, 
+      "name": "price",
+      "value": 2095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNDER MKT / FS LUX 1BR / KIT WITH GRANITE, DW, MW/ MARBL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-mkt-fs-lux-1br-kit-with/6496632666.html", 
+    "name": "UNDER MKT / FS LUX 1BR / KIT WITH GRANITE, DW, MW/ MARBL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-mkt-fs-lux-1br-kit-with/6496632666.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2929.0, 
+      "name": "price",
+      "value": 2929.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated Studio Available March 1st! Exposed Brick & W/D!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-studio-available/6496632156.html", 
+    "name": "Renovated Studio Available March 1st! Exposed Brick & W/D!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-studio-available/6496632156.html",
     "containedIn": {
-      "name": " (Bedstuy)", 
+      "name": " (Bedstuy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee- Jr 1 Bed| Gym, Roof Deck, Laundry| Prime Location- E 60s", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-jr-1-bed-gym-roof-deck/6496623448.html", 
+    "name": "No Fee- Jr 1 Bed| Gym, Roof Deck, Laundry| Prime Location- E 60s",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-jr-1-bed-gym-roof-deck/6496623448.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2425.0, 
+      "name": "price",
+      "value": 2425.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Mill Hill Area Single Family", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/mill-hill-area-single-family/6496619369.html", 
+    "name": "Mill Hill Area Single Family",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/mill-hill-area-single-family/6496619369.html",
     "containedIn": {
-      "name": " (Bridgeport)", 
+      "name": " (Bridgeport)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MARCH MOVE IN ////////// UNIT 15D ====== WATER VIEWS  === BOUKLIS GROU", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-15d-water/6496616614.html", 
+    "name": "MARCH MOVE IN ////////// UNIT 15D ====== WATER VIEWS  === BOUKLIS GROU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-15d-water/6496616614.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated 2 Bedroom Apartment with lots of sunlight / Pictures", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-2-bedroom-apartment/6496616009.html", 
+    "name": "Renovated 2 Bedroom Apartment with lots of sunlight / Pictures",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-2-bedroom-apartment/6496616009.html",
     "containedIn": {
-      "name": " (East Williamsburg)", 
+      "name": " (East Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stamford Downtown, 4br/2Ba, yard", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/stamford-downtown-4br-2ba-yard/6496600120.html", 
+    "name": "Stamford Downtown, 4br/2Ba, yard",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/stamford-downtown-4br-2ba-yard/6496600120.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6496600030.html", 
+    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6496600030.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6496597011.html", 
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6496597011.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MARCH MOVE IN ////////// UNIT 18L ====== CITY VIEWS=== BOUKLIS GROUP P", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-18l-city/6496590759.html", 
+    "name": "MARCH MOVE IN ////////// UNIT 18L ====== CITY VIEWS=== BOUKLIS GROUP P",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-18l-city/6496590759.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3595.0, 
+      "name": "price",
+      "value": 3595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496580650.html", 
+    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496580650.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PERFECT FOR SHARING __ ROOMMATES ON BUDGET__38 ST & 2 AVE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-for-sharing-roommates/6496579581.html", 
+    "name": "PERFECT FOR SHARING __ ROOMMATES ON BUDGET__38 ST & 2 AVE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-for-sharing-roommates/6496579581.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2525.0, 
+      "name": "price",
+      "value": 2525.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee - New Development - HUGE PRIVATE TERRACE - Doorman Building", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-huge/6496567997.html", 
+    "name": "No Fee - New Development - HUGE PRIVATE TERRACE - Doorman Building",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-huge/6496567997.html",
     "containedIn": {
-      "name": " (Prospect Lefferts Gardens)", 
+      "name": " (Prospect Lefferts Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2725.0, 
+      "name": "price",
+      "value": 2725.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RARE LOFT SPACE - It still exists in Williamsburg! NO FEE - Roof Deck", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/rare-loft-space-it-still/6496561070.html", 
+    "name": "RARE LOFT SPACE - It still exists in Williamsburg! NO FEE - Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/rare-loft-space-it-still/6496561070.html",
     "containedIn": {
-      "name": " (Williamsburg (Northside))", 
+      "name": " (Williamsburg (Northside))",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3175.0, 
+      "name": "price",
+      "value": 3175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - New Development in RED HOOK 2 bedrooms-$2950-$3100", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-in-red/6496558822.html", 
+    "name": "NO FEE - New Development in RED HOOK 2 bedrooms-$2950-$3100",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-in-red/6496558822.html",
     "containedIn": {
-      "name": " (Red Hook)", 
+      "name": " (Red Hook)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6496554783.html", 
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6496554783.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Luxury One Bedroom Unit in Fort Greene! 1.5 MONTHS FREE & NO", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-luxury-one-bedroom/6496554511.html", 
+    "name": "Beautiful Luxury One Bedroom Unit in Fort Greene! 1.5 MONTHS FREE & NO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-luxury-one-bedroom/6496554511.html",
     "containedIn": {
-      "name": " (Fort Greene/Downtown/Boehrum Hill)", 
+      "name": " (Fort Greene/Downtown/Boehrum Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2590.0, 
+      "name": "price",
+      "value": 2590.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6496553964.html", 
+    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6496553964.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- RENOVATED BEAUTIFUL TRUE 2 BED- EXPOSED BRICK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-beautiful/6496553781.html", 
+    "name": "NO FEE- RENOVATED BEAUTIFUL TRUE 2 BED- EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-beautiful/6496553781.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*Lrg 3 Bed 2 Bath in Luxurious Walk Up! * Laundry in Unit * No Fee!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lrg-3-bed-2-bath-in-luxurious/6496552806.html", 
+    "name": "*Lrg 3 Bed 2 Bath in Luxurious Walk Up! * Laundry in Unit * No Fee!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lrg-3-bed-2-bath-in-luxurious/6496552806.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE***LUXURY- 2 BED-24 HR DOORMAN-FURNISHED ROOF DECK WITH A POOL-H", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeluxury-2-bed-24-hr/6496552751.html", 
+    "name": "NO FEE***LUXURY- 2 BED-24 HR DOORMAN-FURNISHED ROOF DECK WITH A POOL-H",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeluxury-2-bed-24-hr/6496552751.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496549594.html", 
+    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496549594.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-LEX AVE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY R", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-lex-ave-luxury-massive/6496549204.html", 
+    "name": "NO FEE-LEX AVE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY R",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-lex-ave-luxury-massive/6496549204.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6496548034.html", 
+    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6496548034.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- RENOVATED BRIGHT BEAUTIFUL TRUE 2 BED- EXPOSED BRICK- WASHER&D", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-bright/6496548011.html", 
+    "name": "NO FEE- RENOVATED BRIGHT BEAUTIFUL TRUE 2 BED- EXPOSED BRICK- WASHER&D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-bright/6496548011.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE**MASSIVE LUXURY 2BED-FITNESS CLUB-RESIDENTS LOUNGE-MEDIA ROOM-H", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feemassive-luxury-2bed/6496546971.html", 
+    "name": "NO FEE**MASSIVE LUXURY 2BED-FITNESS CLUB-RESIDENTS LOUNGE-MEDIA ROOM-H",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feemassive-luxury-2bed/6496546971.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY RENOVATED", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-massive-2bed/6496545714.html", 
+    "name": "NO FEE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY RENOVATED",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-massive-2bed/6496545714.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-LIVE IN LUXURY- BRIGHT 2BED-FITNESS CLUB- FURNISHED ROOFDECK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-live-in-luxury-bright/6496544139.html", 
+    "name": "NO FEE-LIVE IN LUXURY- BRIGHT 2BED-FITNESS CLUB- FURNISHED ROOFDECK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-live-in-luxury-bright/6496544139.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496542647.html", 
+    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496542647.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6496541652.html", 
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6496541652.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6496538962.html", 
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6496538962.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6496537389.html", 
+    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6496537389.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS STUDIO IN LUXURY BUILDING* NO FEE* FREE RENT* 516-591-7478", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-in-luxury/6496525029.html", 
+    "name": "GORGEOUS STUDIO IN LUXURY BUILDING* NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-in-luxury/6496525029.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2769.0, 
+      "name": "price",
+      "value": 2769.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6496524752.html", 
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6496524752.html",
     "containedIn": {
-      "name": " (Crown Heights Utica)", 
+      "name": " (Crown Heights Utica)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496524192.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496524192.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous 3 bedroom/ Laundry / Stainless steel appliances/ 2 3 4 5", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-laundry/6496506305.html", 
+    "name": "Gorgeous 3 bedroom/ Laundry / Stainless steel appliances/ 2 3 4 5",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-laundry/6496506305.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 1 bedroom in great location! NO FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html", 
+    "name": "Large 1 bedroom in great location! NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html", 
+    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html", 
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1899.0, 
+      "name": "price",
+      "value": 1899.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html", 
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html", 
+    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2450.0, 
+      "name": "price",
+      "value": 2450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 1 bedroom in great location! NO FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html", 
+    "name": "Large 1 bedroom in great location! NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html", 
+    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html", 
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1899.0, 
+      "name": "price",
+      "value": 1899.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html", 
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html", 
+    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2450.0, 
+      "name": "price",
+      "value": 2450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE- Waterfront Elevated- Impeccable 2 Bedrooms \"Views\" $2170", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-waterfront-elevated/6496484674.html", 
+    "name": "NO FEE- Waterfront Elevated- Impeccable 2 Bedrooms \"Views\" $2170",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-waterfront-elevated/6496484674.html",
     "containedIn": {
-      "name": " (New Rochelle)", 
+      "name": " (New Rochelle)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2170.0, 
+      "name": "price",
+      "value": 2170.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AMAZING Pelham- 1 Bedroom - Updated -Elevated nr train, NO FEE-DOG OK", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-pelham-1-bedroom/6496478136.html", 
+    "name": "AMAZING Pelham- 1 Bedroom - Updated -Elevated nr train, NO FEE-DOG OK",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-pelham-1-bedroom/6496478136.html",
     "containedIn": {
-      "name": " (Pelham- Best Apt Selection)", 
+      "name": " (Pelham- Best Apt Selection)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6496438562.html", 
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6496438562.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST DOWNTOWN BK **** CONDO FINISHES **** 11FT CEILINGS *** FREE POOL+", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/best-downtown-bk-condo/6496437549.html", 
+    "name": "BEST DOWNTOWN BK **** CONDO FINISHES **** 11FT CEILINGS *** FREE POOL+",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/best-downtown-bk-condo/6496437549.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee! Gorgeous Sunny 1 Bedroom Jackson Heights! Close to 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-sunny-1/6496434870.html", 
+    "name": "No Fee! Gorgeous Sunny 1 Bedroom Jackson Heights! Close to 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-sunny-1/6496434870.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496431422.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496431422.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2050.0, 
+      "name": "price",
+      "value": 2050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496430354.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496430354.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6496428635.html", 
+    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6496428635.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6496423596.html", 
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6496423596.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6496422297.html", 
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6496422297.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6496419575.html", 
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6496419575.html",
     "containedIn": {
-      "name": " (Rego Park / Forest Hills)", 
+      "name": " (Rego Park / Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6496416834.html", 
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6496416834.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1932.0, 
+      "name": "price",
+      "value": 1932.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6496413817.html", 
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6496413817.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6496412240.html", 
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6496412240.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2395.0, 
+      "name": "price",
+      "value": 2395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6496412097.html", 
+    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6496412097.html",
     "containedIn": {
-      "name": " (Woodside)", 
+      "name": " (Woodside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SMALL FULLY RENOVATED 1 BEDROOM NEAR  BROOKLYN COLLEGE 2,5 TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/small-fully-renovated-1/6496411072.html", 
+    "name": "SMALL FULLY RENOVATED 1 BEDROOM NEAR  BROOKLYN COLLEGE 2,5 TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/small-fully-renovated-1/6496411072.html",
     "containedIn": {
-      "name": " (Flatbush)", 
+      "name": " (Flatbush)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6496410985.html", 
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6496410985.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6496410003.html", 
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6496410003.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6496409897.html", 
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6496409897.html",
     "containedIn": {
-      "name": " (Elmhurst)", 
+      "name": " (Elmhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6496408848.html", 
+    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6496408848.html",
     "containedIn": {
-      "name": " (Prospect Lefferts Vicinity)", 
+      "name": " (Prospect Lefferts Vicinity)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6496408465.html", 
+    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6496408465.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6496407342.html", 
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6496407342.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2819.0, 
+      "name": "price",
+      "value": 2819.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE ON BRIGHT BEAUTIFUL 1 BEDROOM 1 BLOCK FROM PARK 2,3,Q,B", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-bright/6496404851.html", 
+    "name": "NO BROKER FEE ON BRIGHT BEAUTIFUL 1 BEDROOM 1 BLOCK FROM PARK 2,3,Q,B",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-bright/6496404851.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6496404198.html", 
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6496404198.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6496403753.html", 
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6496403753.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6496402783.html", 
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6496402783.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Completely Renovated--Spectacular Finishes--Impecable Value--Gym/Loung", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/completely-renovated/6496379985.html", 
+    "name": "Completely Renovated--Spectacular Finishes--Impecable Value--Gym/Loung",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/completely-renovated/6496379985.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3800.0, 
+      "name": "price",
+      "value": 3800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6496378974.html", 
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6496378974.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5100.0, 
+      "name": "price",
+      "value": 5100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous 2.5 bedroom 1 bathroom/ Spacious / Balcony/ Dishwasher", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-25-bedroom-1/6496374386.html", 
+    "name": "Gorgeous 2.5 bedroom 1 bathroom/ Spacious / Balcony/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-25-bedroom-1/6496374386.html",
     "containedIn": {
-      "name": " (Red Hook)", 
+      "name": " (Red Hook)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496373650.html", 
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496373650.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1899.0, 
+      "name": "price",
+      "value": 1899.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***RARE 4 BEDROOM IN ASTORIA***", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6496373469.html", 
+    "name": "***RARE 4 BEDROOM IN ASTORIA***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6496373469.html",
     "containedIn": {
-      "name": " (3415 9th street)", 
+      "name": " (3415 9th street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496373009.html", 
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496373009.html",
     "containedIn": {
-      "name": " (13 Humboldt Street)", 
+      "name": " (13 Humboldt Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AWESOME STUDIO UWS 72nd St/CPW with NICE MURPHY BED avail!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-uws-72nd-st/6496370062.html", 
+    "name": "AWESOME STUDIO UWS 72nd St/CPW with NICE MURPHY BED avail!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-uws-72nd-st/6496370062.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Wow! Huge 4BR, Flex 5BR Duplex in Bed Stuy with Backyard!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-huge-4br-flex-5br-duplex/6496351187.html", 
+    "name": "Wow! Huge 4BR, Flex 5BR Duplex in Bed Stuy with Backyard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-huge-4br-flex-5br-duplex/6496351187.html",
     "containedIn": {
-      "name": " (Bedford Stuyvesant)", 
+      "name": " (Bedford Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3595.0, 
+      "name": "price",
+      "value": 3595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous Newly Renovated  3BR - 1 block from Halsey L train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-newly-renovated-3br/6496349757.html", 
+    "name": "Gorgeous Newly Renovated  3BR - 1 block from Halsey L train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-newly-renovated-3br/6496349757.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2495.0, 
+      "name": "price",
+      "value": 2495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496349225.html", 
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496349225.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6133.0, 
+      "name": "price",
+      "value": 6133.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Studio in Brooklyn - near Prospect Park and BK Museum!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-studio-in-brooklyn/6496348297.html", 
+    "name": "Beautiful Studio in Brooklyn - near Prospect Park and BK Museum!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-studio-in-brooklyn/6496348297.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW! Gorgeous Murray Hill Luxury Studio in Amazing Building! No Fee!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-gorgeous-murray-hill/6496345144.html", 
+    "name": "NEW! Gorgeous Murray Hill Luxury Studio in Amazing Building! No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-gorgeous-murray-hill/6496345144.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2296.0, 
+      "name": "price",
+      "value": 2296.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, apts in a great location!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496334329.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496334329.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3795.0, 
+      "name": "price",
+      "value": 3795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Laundry, New Kitchens, Near Subway*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496330728.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Laundry, New Kitchens, Near Subway*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496330728.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing 3BR w/ Yard! Heat &HW included! Great Location! NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/amazing-3br-yard-heat-hw/6496327862.html", 
+    "name": "Amazing 3BR w/ Yard! Heat &HW included! Great Location! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/amazing-3br-yard-heat-hw/6496327862.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey L)", 
+      "name": " (Bushwick @ Halsey L)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2570.0, 
+      "name": "price",
+      "value": 2570.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Layouts, New Amenities!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496327115.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Layouts, New Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496327115.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2765.0, 
+      "name": "price",
+      "value": 2765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 4BR 2BA Apt in Bed Stuy, Brooklyn | No Fee | Laundry in Unit!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/large-4br-2ba-apt-in-bed-stuy/6496308067.html", 
+    "name": "Large 4BR 2BA Apt in Bed Stuy, Brooklyn | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/large-4br-2ba-apt-in-bed-stuy/6496308067.html",
     "containedIn": {
-      "name": " (Bed Stuy@ Myrtle G/J/M)", 
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3450.0, 
+      "name": "price",
+      "value": 3450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6496317491.html", 
+    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6496317491.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*BUSHWICK NO FEE*3 Bedroom 2 Bath Duplex\u25b0Backyard\u25b0LJMZ TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bushwick-no-fee3-bedroom-2/6496316749.html", 
+    "name": "*BUSHWICK NO FEE*3 Bedroom 2 Bath Duplex▰Backyard▰LJMZ TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bushwick-no-fee3-bedroom-2/6496316749.html",
     "containedIn": {
-      "name": " (Bushwick, Brooklyn Call 347-484-9965)", 
+      "name": " (Bushwick, Brooklyn Call 347-484-9965)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6496315171.html", 
+    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6496315171.html",
     "containedIn": {
-      "name": " (Bed Stuy@ Myrtle G/J/M)", 
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3450.0, 
+      "name": "price",
+      "value": 3450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEB/MAR MOVE IN___25th FLOOR___CEILING TO FLOOR WINDOW___SUNRISE VIEW", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/feb-mar-move-in25th/6496313933.html", 
+    "name": "FEB/MAR MOVE IN___25th FLOOR___CEILING TO FLOOR WINDOW___SUNRISE VIEW",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/feb-mar-move-in25th/6496313933.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6496313601.html", 
+    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6496313601.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6496310326.html", 
+    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6496310326.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2050.0, 
+      "name": "price",
+      "value": 2050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely No Fee Studio | Super Location steps from the Franklin C!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-super/6496306309.html", 
+    "name": "Lovely No Fee Studio | Super Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-super/6496306309.html",
     "containedIn": {
-      "name": " (Bed Stuy / Clinton Hill)", 
+      "name": " (Bed Stuy / Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CITY VIEWS-------WALL TO WALL WINDOWS-----CUSTOM CABINTRY---------NO F", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/city-views-wall-to-wall/6496305824.html", 
+    "name": "CITY VIEWS-------WALL TO WALL WINDOWS-----CUSTOM CABINTRY---------NO F",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/city-views-wall-to-wall/6496305824.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3800.0, 
+      "name": "price",
+      "value": 3800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6496305742.html", 
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6496305742.html",
     "containedIn": {
-      "name": " (Bushwick @ Gates JMZ)", 
+      "name": " (Bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "e 31 / lexington ave ~ NEWLY renovated, GORGEOUS, 2 bedroom-2 baths ~", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/31-lexington-ave-newly/6496302690.html", 
+    "name": "e 31 / lexington ave ~ NEWLY renovated, GORGEOUS, 2 bedroom-2 baths ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/31-lexington-ave-newly/6496302690.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4100.0, 
+      "name": "price",
+      "value": 4100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6496301814.html", 
+    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6496301814.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2670.0, 
+      "name": "price",
+      "value": 2670.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUOS STUDIO LAYOUT________SUN DRENCH_____OVERSIZE WINDOWS______HA", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spaciouos-studio-layoutsun/6496299139.html", 
+    "name": "SPACIOUOS STUDIO LAYOUT________SUN DRENCH_____OVERSIZE WINDOWS______HA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spaciouos-studio-layoutsun/6496299139.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2590.0, 
+      "name": "price",
+      "value": 2590.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Duplex Townhouse Style - Pets welcome - bring Fido & Fluffy -", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/duplex-townhouse-style-pets/6496298786.html", 
+    "name": "Duplex Townhouse Style - Pets welcome - bring Fido & Fluffy -",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/duplex-townhouse-style-pets/6496298786.html",
     "containedIn": {
-      "name": " (Harrison)", 
+      "name": " (Harrison)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3375.0, 
+      "name": "price",
+      "value": 3375.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 1 BR Luxury in Greenwich Village!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6496298018.html", 
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6496298018.html",
     "containedIn": {
-      "name": " (Greenwich Village)", 
+      "name": " (Greenwich Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW BUILDING________POOL ON ROOF_________10Ft CEILING_____", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-buildingpool-on/6496297663.html", 
+    "name": "BRAND NEW BUILDING________POOL ON ROOF_________10Ft CEILING_____",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-buildingpool-on/6496297663.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2470.0, 
+      "name": "price",
+      "value": 2470.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Totally Renovated Apartment For Rent", 
-    "url": "https://newyork.craigslist.org/lgi/nfb/d/totally-renovated-apartment/6496294161.html", 
+    "name": "Totally Renovated Apartment For Rent",
+    "url": "https://newyork.craigslist.org/lgi/nfb/d/totally-renovated-apartment/6496294161.html",
     "containedIn": {
-      "name": " (Selden)", 
+      "name": " (Selden)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6496290035.html", 
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6496290035.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6496287500.html", 
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6496287500.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6496286107.html", 
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6496286107.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6496285389.html", 
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6496285389.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Townhome Community 2 Bdrms 2 1/2 Baths DENISE 203.622.4000", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-townhome-community-2/6496277935.html", 
+    "name": "Luxury Townhome Community 2 Bdrms 2 1/2 Baths DENISE 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-townhome-community-2/6496277935.html",
     "containedIn": {
-      "name": " (Greenwich/Cos Cob/Old Greenwich)", 
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ONE BEDROOM NEAR HARLEM HOSPITAL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-bedroom-near-harlem/6496100226.html", 
+    "name": "ONE BEDROOM NEAR HARLEM HOSPITAL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-bedroom-near-harlem/6496100226.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1425.0, 
+      "name": "price",
+      "value": 1425.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6496258458.html", 
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6496258458.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4600.0, 
+      "name": "price",
+      "value": 4600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning 900 Sq Ft 1 Bed W/Dining Alcove * No Fee & 1 Month Free", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-900-sq-ft-1-bed/6496248255.html", 
+    "name": "Stunning 900 Sq Ft 1 Bed W/Dining Alcove * No Fee & 1 Month Free",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-900-sq-ft-1-bed/6496248255.html",
     "containedIn": {
-      "name": " (Flatiron)", 
+      "name": " (Flatiron)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4450.0, 
+      "name": "price",
+      "value": 4450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6496246112.html", 
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6496246112.html",
     "containedIn": {
-      "name": " (Lefferts Garden/Prospect Park)", 
+      "name": " (Lefferts Garden/Prospect Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1595.0, 
+      "name": "price",
+      "value": 1595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "****2 BR FLEX***FULL WALL**LUX BUILDING**100% NO FEE**POOL*GYM**ROOFTO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-br-flexfull-walllux/6496240206.html", 
+    "name": "****2 BR FLEX***FULL WALL**LUX BUILDING**100% NO FEE**POOL*GYM**ROOFTO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-br-flexfull-walllux/6496240206.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3195.0, 
+      "name": "price",
+      "value": 3195.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Penthouse, gourmet Kitchen, washer & dryer and spectacular outd", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-penthouse-gourmet/6496237691.html", 
+    "name": "Luxury Penthouse, gourmet Kitchen, washer & dryer and spectacular outd",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-penthouse-gourmet/6496237691.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 12675.0, 
+      "name": "price",
+      "value": 12675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6496228220.html", 
+    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6496228220.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE* Columbus Circle 24HR LUXURY swimming POOL/roof deck", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-columbus-circle-24hr/6496227066.html", 
+    "name": "*NO FEE* Columbus Circle 24HR LUXURY swimming POOL/roof deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-columbus-circle-24hr/6496227066.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2723.0, 
+      "name": "price",
+      "value": 2723.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496221565.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496221565.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2205.0, 
+      "name": "price",
+      "value": 2205.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 850SQ FT NO FEE 1BD IN DRMN/GYM/LNDRY BLDG", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-850sq-ft-no-fee-1bd-in/6496213867.html", 
+    "name": "HUGE 850SQ FT NO FEE 1BD IN DRMN/GYM/LNDRY BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-850sq-ft-no-fee-1bd-in/6496213867.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous West Village 1BR/1BA!! Great Deal!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-west-village-1br-1ba/6496206944.html", 
+    "name": "Gorgeous West Village 1BR/1BA!! Great Deal!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-west-village-1br-1ba/6496206944.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3750.0, 
+      "name": "price",
+      "value": 3750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE OPEN HOUSE in Kew Gardens by Atlantic Management 718-726-0003", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-open-house-in-kew/6496200994.html", 
+    "name": "NO FEE OPEN HOUSE in Kew Gardens by Atlantic Management 718-726-0003",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-open-house-in-kew/6496200994.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Midtown West - Large Studio W 34th Street and 9th Ave - PRICE BREAK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/midtown-west-large-studio/6496190532.html", 
+    "name": "Midtown West - Large Studio W 34th Street and 9th Ave - PRICE BREAK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/midtown-west-large-studio/6496190532.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GIANT WINDOWS__GOURMET KITCHEN___NEW APPLIANCES___MINT CONDO FINISH", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/giant-windowsgourmet/6496188628.html", 
+    "name": "GIANT WINDOWS__GOURMET KITCHEN___NEW APPLIANCES___MINT CONDO FINISH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/giant-windowsgourmet/6496188628.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3120.0, 
+      "name": "price",
+      "value": 3120.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Exceptional 1,900 Sq Ft 3 Bed 2 Bath Palace ~ Wrap Around Terrace ~ So", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/exceptional-1900-sq-ft-3-bed/6496188039.html", 
+    "name": "Exceptional 1,900 Sq Ft 3 Bed 2 Bath Palace ~ Wrap Around Terrace ~ So",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/exceptional-1900-sq-ft-3-bed/6496188039.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7550.0, 
+      "name": "price",
+      "value": 7550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous No Fee +1 Mnth Free Studio In Drmn/Elev/Lndry/Gym Building", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-no-fee-1-mnth-free/6496186262.html", 
+    "name": "Gorgeous No Fee +1 Mnth Free Studio In Drmn/Elev/Lndry/Gym Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-no-fee-1-mnth-free/6496186262.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2353.0, 
+      "name": "price",
+      "value": 2353.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NEW LIST*HUGE 870SQ FT NO FEE+1MONTH FREE 1BD IN DRMN/GYM/LNDRY BLDG", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-listhuge-870sq-ft-no/6496181375.html", 
+    "name": "*NEW LIST*HUGE 870SQ FT NO FEE+1MONTH FREE 1BD IN DRMN/GYM/LNDRY BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-listhuge-870sq-ft-no/6496181375.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3276.0, 
+      "name": "price",
+      "value": 3276.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6496180835.html", 
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6496180835.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Below Market West Village 1BR/1BA!! No Fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6496165056.html", 
+    "name": "Below Market West Village 1BR/1BA!! No Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6496165056.html",
     "containedIn": {
-      "name": " (West Village)", 
+      "name": " (West Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6496157213.html", 
+    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6496157213.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6496152425.html", 
+    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6496152425.html",
     "containedIn": {
-      "name": " (East Flatbush)", 
+      "name": " (East Flatbush)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1475.0, 
+      "name": "price",
+      "value": 1475.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE*IN THE HEART OF TOWN..CLOSE TO RR/SHOPS*CHARMING*BUILDING*CATS", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feein-the-heart-of/6496133794.html", 
+    "name": "NO FEE*IN THE HEART OF TOWN..CLOSE TO RR/SHOPS*CHARMING*BUILDING*CATS",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feein-the-heart-of/6496133794.html",
     "containedIn": {
-      "name": " (TARRYTOWN)", 
+      "name": " (TARRYTOWN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u273fCOMMUTERS DREAM~REAL2BR~YOU'LL LOVE THIS APT & THE LOCATION !", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/commuters-dreamreal2bryoull/6496102159.html", 
+    "name": "✿COMMUTERS DREAM~REAL2BR~YOU'LL LOVE THIS APT & THE LOCATION !",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/commuters-dreamreal2bryoull/6496102159.html",
     "containedIn": {
-      "name": " (\ud821\udf4dWalk to Metro-North Fleetwood)", 
+      "name": " (𘝍Walk to Metro-North Fleetwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - 1 Beautifully furnished 1 bedroom apartment (id 43)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-beautifully/6496097778.html", 
+    "name": "NO FEE - 1 Beautifully furnished 1 bedroom apartment (id 43)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-beautifully/6496097778.html",
     "containedIn": {
-      "name": " (Kips Bay)", 
+      "name": " (Kips Bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5800.0, 
+      "name": "price",
+      "value": 5800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496092233.html", 
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496092233.html",
     "containedIn": {
-      "name": " (Ditmas park / Cortelyou Rd)", 
+      "name": " (Ditmas park / Cortelyou Rd)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6496082858.html", 
+    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6496082858.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6496082551.html", 
+    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6496082551.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6496082095.html", 
+    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6496082095.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6496068611.html", 
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6496068611.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1825,SS Kit,HRDWD,Gym,W/D,Gar,Terr", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6496068357.html", 
+    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1825,SS Kit,HRDWD,Gym,W/D,Gar,Terr",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6496068357.html",
     "containedIn": {
-      "name": " (Stamford)", 
+      "name": " (Stamford)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u25baSoho/LOFTSTYLE$1620,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1620hi-ceilngwk/6496067211.html", 
+    "name": "►Soho/LOFTSTYLE$1620,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1620hi-ceilngwk/6496067211.html",
     "containedIn": {
-      "name": " (STAMFORD, CT)", 
+      "name": " (STAMFORD, CT)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1620.0, 
+      "name": "price",
+      "value": 1620.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SOARING CEILINGS__22nd FLOOR___MASSIVE WINDOWS___EXTRA CLOSETS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/soaring-ceilings22nd/6496049379.html", 
+    "name": "SOARING CEILINGS__22nd FLOOR___MASSIVE WINDOWS___EXTRA CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/soaring-ceilings22nd/6496049379.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496037020.html", 
+    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496037020.html",
     "containedIn": {
-      "name": " (Bay Ridge)", 
+      "name": " (Bay Ridge)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1395.0, 
+      "name": "price",
+      "value": 1395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens *Spacious Apt Near Subway*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496034792.html", 
+    "name": "NO FEE RENTALS, Kings & Queens *Spacious Apt Near Subway*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496034792.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3795.0, 
+      "name": "price",
+      "value": 3795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FURNISHED ROOMS (Shared Apartment) Long/Short Term", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/furnished-rooms-shared/6496033760.html", 
+    "name": "FURNISHED ROOMS (Shared Apartment) Long/Short Term",
+    "url": "https://newyork.craigslist.org/que/nfb/d/furnished-rooms-shared/6496033760.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1000.0, 
+      "name": "price",
+      "value": 1000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496033059.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496033059.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2780.0, 
+      "name": "price",
+      "value": 2780.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CENTRAL PARK NORTH - 2 Bed 1 Bath - FREE UTILITIES - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/central-park-north-2-bed-1/6496023639.html", 
+    "name": "CENTRAL PARK NORTH - 2 Bed 1 Bath - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/central-park-north-2-bed-1/6496023639.html",
     "containedIn": {
-      "name": " (East Harlem)", 
+      "name": " (East Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New FiDi, W/D, No Brokers Fee Plus 2 Months Free Rent, No Fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-fidi-d-no-brokers/6496023151.html", 
+    "name": "Brand New FiDi, W/D, No Brokers Fee Plus 2 Months Free Rent, No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-fidi-d-no-brokers/6496023151.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3777.0, 
+      "name": "price",
+      "value": 3777.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 92nd ? UES - Luxury Studio $2,432 - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-92nd-ues-luxury-studio/6496022006.html", 
+    "name": "East 92nd ? UES - Luxury Studio $2,432 - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-92nd-ues-luxury-studio/6496022006.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2432.0, 
+      "name": "price",
+      "value": 2432.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6496021776.html", 
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6496021776.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey J)", 
+      "name": " (Bushwick @ Halsey J)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3175.0, 
+      "name": "price",
+      "value": 3175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6496021625.html", 
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6496021625.html",
     "containedIn": {
-      "name": " (Prospect heights @ 2,3,B,Q)", 
+      "name": " (Prospect heights @ 2,3,B,Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6496021332.html", 
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6496021332.html",
     "containedIn": {
-      "name": " (Ridgewood @ Seneca M)", 
+      "name": " (Ridgewood @ Seneca M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2609.0, 
+      "name": "price",
+      "value": 2609.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "West 34th St. - CONV 3 Bed 2 Bath $4,450 net - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-34th-st-conv-3-bed-2/6496020074.html", 
+    "name": "West 34th St. - CONV 3 Bed 2 Bath $4,450 net - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-34th-st-conv-3-bed-2/6496020074.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4450.0, 
+      "name": "price",
+      "value": 4450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6496019700.html", 
+    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6496019700.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*STEPS TO PROSPECT PARK-BEAUTIFUL AREA-NEWLY RENOVATED-VERY SPACIOUS*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/steps-to-prospect-park/6496019241.html", 
+    "name": "*STEPS TO PROSPECT PARK-BEAUTIFUL AREA-NEWLY RENOVATED-VERY SPACIOUS*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/steps-to-prospect-park/6496019241.html",
     "containedIn": {
-      "name": " (crown heights)", 
+      "name": " (crown heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 81st St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-81st-st-1-bed-white/6496018345.html", 
+    "name": "East 81st St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-81st-st-1-bed-white/6496018345.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2837.0, 
+      "name": "price",
+      "value": 2837.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Modern Room in shared apartment close to the train minutes to Manhatta", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-room-in-shared/6496017837.html", 
+    "name": "Modern Room in shared apartment close to the train minutes to Manhatta",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-room-in-shared/6496017837.html",
     "containedIn": {
-      "name": " (Bedford stuyvesant)", 
+      "name": " (Bedford stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 800.0, 
+      "name": "price",
+      "value": 800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 88th St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-1-bed-white/6496017175.html", 
+    "name": "East 88th St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-1-bed-white/6496017175.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2929.0, 
+      "name": "price",
+      "value": 2929.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*VERY AFFORDABLE NICE SIZED ROOM IN MODERN BUILDING CLOSE TO TRAIN**", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/very-affordable-nice-sized/6496016638.html", 
+    "name": "*VERY AFFORDABLE NICE SIZED ROOM IN MODERN BUILDING CLOSE TO TRAIN**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-affordable-nice-sized/6496016638.html",
     "containedIn": {
-      "name": " (East Flatbush)", 
+      "name": " (East Flatbush)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 650.0, 
+      "name": "price",
+      "value": 650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large---------Studio --Vacant Ready---Near All  Call 646-250-8787", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/large-studio-vacant-ready/6496016099.html", 
+    "name": "Large---------Studio --Vacant Ready---Near All  Call 646-250-8787",
+    "url": "https://newyork.craigslist.org/que/nfb/d/large-studio-vacant-ready/6496016099.html",
     "containedIn": {
-      "name": " (Forest Hills)", 
+      "name": " (Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1475.0, 
+      "name": "price",
+      "value": 1475.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated, Close to A C L, Roof Access", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-close-to-c-roof/6496012152.html", 
+    "name": "Renovated, Close to A C L, Roof Access",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-close-to-c-roof/6496012152.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large Bedrooms/Living Room, Hardwood Floors, Close to B Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-living-room/6496012091.html", 
+    "name": "Large Bedrooms/Living Room, Hardwood Floors, Close to B Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-living-room/6496012091.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large Bedrooms, Large Living Room, Yard, By L train, Close to J M Z", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-large-living/6496011924.html", 
+    "name": "Large Bedrooms, Large Living Room, Yard, By L train, Close to J M Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-large-living/6496011924.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bright, Luxury Studio / Modern Finishes, Laundry In-Unit, Pool, Gym, H", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-luxury-studio-modern/6495977703.html", 
+    "name": "Bright, Luxury Studio / Modern Finishes, Laundry In-Unit, Pool, Gym, H",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-luxury-studio-modern/6495977703.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!! JUNIOR 1 BR/ALCOVE STUDIO IN FORT GREENE / DOBRO", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-junior-1-br-alcove/6495977515.html", 
+    "name": "NO FEE!! JUNIOR 1 BR/ALCOVE STUDIO IN FORT GREENE / DOBRO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-junior-1-br-alcove/6495977515.html",
     "containedIn": {
-      "name": " (Boerum Hill)", 
+      "name": " (Boerum Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning and Vibrant Alcove Studio Apartment Located in Downtown Brook", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-and-vibrant-alcove/6495977368.html", 
+    "name": "Stunning and Vibrant Alcove Studio Apartment Located in Downtown Brook",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-and-vibrant-alcove/6495977368.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2325.0, 
+      "name": "price",
+      "value": 2325.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495977244.html", 
+    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495977244.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE* ELEGANT STUDIO+HOME OFFICE, FLEX 2BR, 24HR DOORMAN, GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-elegant-studiohome/6495976913.html", 
+    "name": "*NO FEE* ELEGANT STUDIO+HOME OFFICE, FLEX 2BR, 24HR DOORMAN, GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-elegant-studiohome/6495976913.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2867.0, 
+      "name": "price",
+      "value": 2867.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495976719.html", 
+    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495976719.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large NO FEE Studio in the heart of the Financial District", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-no-fee-studio-in-the/6495976230.html", 
+    "name": "Large NO FEE Studio in the heart of the Financial District",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-no-fee-studio-in-the/6495976230.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2355.0, 
+      "name": "price",
+      "value": 2355.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury TRUE 1 / Flex 2 Bedroom *Modern Finishes*Laundry In-Unit*Pool*G", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-true-1-flex-2-bedroom/6495975819.html", 
+    "name": "Luxury TRUE 1 / Flex 2 Bedroom *Modern Finishes*Laundry In-Unit*Pool*G",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-true-1-flex-2-bedroom/6495975819.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE LUXURY STUDIO, WITH OPEN KITCHEN, 24HR DOORMAN, FREE GYM AND AMAZ", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-luxury-studio-with-open/6495975507.html", 
+    "name": "HUGE LUXURY STUDIO, WITH OPEN KITCHEN, 24HR DOORMAN, FREE GYM AND AMAZ",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-luxury-studio-with-open/6495975507.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury Beautiful *NO FEE* One Bedroom in Fort Greene / Washer In Unit!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-beautiful-no-fee-one/6495975380.html", 
+    "name": "Luxury Beautiful *NO FEE* One Bedroom in Fort Greene / Washer In Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-beautiful-no-fee-one/6495975380.html",
     "containedIn": {
-      "name": " (Boerum Hill)", 
+      "name": " (Boerum Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely Studio Apartment with Top Notch Finishes Located in Battery Par", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lovely-studio-apartment-with/6495970984.html", 
+    "name": "Lovely Studio Apartment with Top Notch Finishes Located in Battery Par",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lovely-studio-apartment-with/6495970984.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 2.5 BR Apartment - Great price - Stuyvesant Heights", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-25-br-apartment/6495967695.html", 
+    "name": "Beautiful 2.5 BR Apartment - Great price - Stuyvesant Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-25-br-apartment/6495967695.html",
     "containedIn": {
-      "name": " (Stuyvesant Heights)", 
+      "name": " (Stuyvesant Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "REDUCED FEE!!!!! Spacious open layout GEM in PRIME Riverdale Loc", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/reduced-fee-spacious-open/6495951203.html", 
+    "name": "REDUCED FEE!!!!! Spacious open layout GEM in PRIME Riverdale Loc",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/reduced-fee-spacious-open/6495951203.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!!!! HUGE 3Bed/2Bath in BEAUTIFUL Pre-War Riverdale Building", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-huge-3bed-2bath-in/6495950297.html", 
+    "name": "NO FEE!!!!! HUGE 3Bed/2Bath in BEAUTIFUL Pre-War Riverdale Building",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-huge-3bed-2bath-in/6495950297.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2975.0, 
+      "name": "price",
+      "value": 2975.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!! LARGE STUDIO IN FORT GREENE / DOBRO", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-studio-in-fort/6495946291.html", 
+    "name": "NO FEE!! LARGE STUDIO IN FORT GREENE / DOBRO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-studio-in-fort/6495946291.html",
     "containedIn": {
-      "name": " (Boerum Hill)", 
+      "name": " (Boerum Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2395.0, 
+      "name": "price",
+      "value": 2395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Newly Renovated - Upper East Side - immediate move-in", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-upper-east/6495943868.html", 
+    "name": "Newly Renovated - Upper East Side - immediate move-in",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-upper-east/6495943868.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2689.0, 
+      "name": "price",
+      "value": 2689.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495926225.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495926225.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**SUNNY 2BR W/EXPOSED BRICK W 106 ST NEAR CENTRAL PARK & B/C TRAINS**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-exposed-brick-106/6495923009.html", 
+    "name": "**SUNNY 2BR W/EXPOSED BRICK W 106 ST NEAR CENTRAL PARK & B/C TRAINS**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-exposed-brick-106/6495923009.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2881.0, 
+      "name": "price",
+      "value": 2881.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "** ALL NEW 2BR ON BROADWAY & TIEMANN NEAR COLUMBIA & MSM - NO FEE **", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/all-new-2br-on-broadway/6495921088.html", 
+    "name": "** ALL NEW 2BR ON BROADWAY & TIEMANN NEAR COLUMBIA & MSM - NO FEE **",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/all-new-2br-on-broadway/6495921088.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2451.0, 
+      "name": "price",
+      "value": 2451.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495905881.html", 
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495905881.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3480.0, 
+      "name": "price",
+      "value": 3480.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495876435.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495876435.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2765.0, 
+      "name": "price",
+      "value": 2765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495875665.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495875665.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495874363.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495874363.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6495865916.html", 
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6495865916.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6495865347.html", 
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6495865347.html",
     "containedIn": {
-      "name": " (Nolita / Bowery)", 
+      "name": " (Nolita / Bowery)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6495865012.html", 
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6495865012.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6495864773.html", 
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6495864773.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6495864558.html", 
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6495864558.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Upper East Side Mint Condition 1 Bedroom No Fee Convenient Location", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/upper-east-side-mint/6495864182.html", 
+    "name": "Upper East Side Mint Condition 1 Bedroom No Fee Convenient Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/upper-east-side-mint/6495864182.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 1 Bed in UWS; Eat in Kitchen; Marble Bathroom; Walk in Closet", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bed-in-uws-eat-in/6495829178.html", 
+    "name": "Spacious 1 Bed in UWS; Eat in Kitchen; Marble Bathroom; Walk in Closet",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bed-in-uws-eat-in/6495829178.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495823211.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495823211.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OPEN HOUSE+++NO FEE+++E. 60's+++BEST DEAL UES+++CALL 646.247.6444!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-houseno-feee-60sbest/6495816286.html", 
+    "name": "OPEN HOUSE+++NO FEE+++E. 60's+++BEST DEAL UES+++CALL 646.247.6444!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-houseno-feee-60sbest/6495816286.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1595.0, 
+      "name": "price",
+      "value": 1595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495807285.html", 
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495807285.html",
     "containedIn": {
-      "name": " (midwood/ Sheepshead bay)", 
+      "name": " (midwood/ Sheepshead bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "newly renovated", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6495807260.html", 
+    "name": "newly renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6495807260.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2549.0, 
+      "name": "price",
+      "value": 2549.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bright, Clean, queen size bedrooms, Laundry, Dishwasher, J M Z L train", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-clean-queen-size/6495806967.html", 
+    "name": "Bright, Clean, queen size bedrooms, Laundry, Dishwasher, J M Z L train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-clean-queen-size/6495806967.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495806577.html", 
+    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495806577.html",
     "containedIn": {
-      "name": " (Kensington)", 
+      "name": " (Kensington)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous 1 Bedroom in Newly Renovated Apartment Available April 1st", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-1-bedroom-in-newly/6495800907.html", 
+    "name": "Gorgeous 1 Bedroom in Newly Renovated Apartment Available April 1st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-1-bedroom-in-newly/6495800907.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3150.0, 
+      "name": "price",
+      "value": 3150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495800346.html", 
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495800346.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3480.0, 
+      "name": "price",
+      "value": 3480.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "newly gut renovated", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-gut-renovated/6495800250.html", 
+    "name": "newly gut renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-gut-renovated/6495800250.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2449.0, 
+      "name": "price",
+      "value": 2449.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEWLY RENO MIDTOWN WEST 1BR*2FM|14MN*NO SEC.DEP.*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6495799908.html", 
+    "name": "NEWLY RENO MIDTOWN WEST 1BR*2FM|14MN*NO SEC.DEP.*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6495799908.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2875.0, 
+      "name": "price",
+      "value": 2875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udc9b\ud83d\udc9bAWESOME\ud83d\udc9b\ud83d\udc9b 3 BR W/ EXPOSED BRICK WALL IN PRIME", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6495791232.html", 
+    "name": "💛💛AWESOME💛💛 3 BR W/ EXPOSED BRICK WALL IN PRIME",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6495791232.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udd36BEAUTIFUL DEAL\ud83d\udd36 ! 2 Bedroom in Prime Bushwick Area! NO FEE !!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-deal-2-bedroom-in/6495788703.html", 
+    "name": "🔶BEAUTIFUL DEAL🔶 ! 2 Bedroom in Prime Bushwick Area! NO FEE !!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-deal-2-bedroom-in/6495788703.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6495787529.html", 
+    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6495787529.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4700.0, 
+      "name": "price",
+      "value": 4700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "A Crown Heights Pre-War Beauty | Fine Detailing | No Fee | Must See!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/crown-heights-pre-war-beauty/6495783330.html", 
+    "name": "A Crown Heights Pre-War Beauty | Fine Detailing | No Fee | Must See!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/crown-heights-pre-war-beauty/6495783330.html",
     "containedIn": {
-      "name": " (Pacific @ A,C train Franklin/Nostrand)", 
+      "name": " (Pacific @ A,C train Franklin/Nostrand)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2985.0, 
+      "name": "price",
+      "value": 2985.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 MONTH FREE******** W/D IN UNIT********  AMAZING WATER VIEWS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-d-in-unit/6495783130.html", 
+    "name": "1 MONTH FREE******** W/D IN UNIT********  AMAZING WATER VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-d-in-unit/6495783130.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3695.0, 
+      "name": "price",
+      "value": 3695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495780310.html", 
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495780310.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1932.0, 
+      "name": "price",
+      "value": 1932.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6495776062.html", 
+    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6495776062.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXE! MIDTOWN WEST*JR.1 ALC.STUD*W/D*2FM|14MN*PAY NET RENT*CALL BAMBI", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-westjr1-alcstudw/6495767209.html", 
+    "name": "LUXE! MIDTOWN WEST*JR.1 ALC.STUD*W/D*2FM|14MN*PAY NET RENT*CALL BAMBI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-westjr1-alcstudw/6495767209.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 70s_NO FEE_Luxury 1 Bedroom w/ Doorman_GYM_Roof Deck_Playroom_Val", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-70sno-feeluxury-1/6495763252.html", 
+    "name": "East 70s_NO FEE_Luxury 1 Bedroom w/ Doorman_GYM_Roof Deck_Playroom_Val",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-70sno-feeluxury-1/6495763252.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!...TRUE 3 BED...EAST 70TH...LAUNDRY...RENO...DW...LIVE IN SUPE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetrue-3-bedeast/6495762813.html", 
+    "name": "NO FEE!!...TRUE 3 BED...EAST 70TH...LAUNDRY...RENO...DW...LIVE IN SUPE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetrue-3-bedeast/6495762813.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXE! MIDTOWN WEST*STUDIO*WATER VIEW*2FM|14MN*PAY NET RENT*CALL BAMBI!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-weststudiowater/6495757738.html", 
+    "name": "LUXE! MIDTOWN WEST*STUDIO*WATER VIEW*2FM|14MN*PAY NET RENT*CALL BAMBI!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-weststudiowater/6495757738.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Bay Ridge 2 Bed w/ Laundry. Walk to Gym, Train, & Shops!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bay-ridge-2-bed/6495734947.html", 
+    "name": "NO FEE Bay Ridge 2 Bed w/ Laundry. Walk to Gym, Train, & Shops!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bay-ridge-2-bed/6495734947.html",
     "containedIn": {
-      "name": " (Bay Ridge)", 
+      "name": " (Bay Ridge)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huuuuge 2BR Stunner!!__{No Fee}__Unbelievable CLOSET SPACE!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huuuuge-2br-stunnerno/6495727313.html", 
+    "name": "Huuuuge 2BR Stunner!!__{No Fee}__Unbelievable CLOSET SPACE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huuuuge-2br-stunnerno/6495727313.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3476.0, 
+      "name": "price",
+      "value": 3476.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny UWS Studio - State of the Art RENO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-uws-studio-state-of-the/6495726302.html", 
+    "name": "Sunny UWS Studio - State of the Art RENO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-uws-studio-state-of-the/6495726302.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Beautiful renovated 2BR walk up - Available for Imm move in !!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-renovated/6495725600.html", 
+    "name": "NO FEE Beautiful renovated 2BR walk up - Available for Imm move in !!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-renovated/6495725600.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3822.0, 
+      "name": "price",
+      "value": 3822.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful One Bed (Upper East)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-one-bed-upper-east/6495718562.html", 
+    "name": "Beautiful One Bed (Upper East)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-one-bed-upper-east/6495718562.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning one bedroom  | Stainless Steel Appliances | Park & City Views", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-one-bedroom/6495707655.html", 
+    "name": "Stunning one bedroom  | Stainless Steel Appliances | Park & City Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-one-bedroom/6495707655.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3895.0, 
+      "name": "price",
+      "value": 3895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Renovated 3 Bed (Upper East)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-3-bed-upper-east/6495705893.html", 
+    "name": "Renovated 3 Bed (Upper East)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-3-bed-upper-east/6495705893.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3050.0, 
+      "name": "price",
+      "value": 3050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Tribeca NYC Luxury Apartment, 3B/2B/BAL + WD , 2 Free Months, No Fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-nyc-luxury-apartment/6495700105.html", 
+    "name": "Tribeca NYC Luxury Apartment, 3B/2B/BAL + WD , 2 Free Months, No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-nyc-luxury-apartment/6495700105.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5095.0, 
+      "name": "price",
+      "value": 5095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW ONE BED#####BEST VIEWS IN BROOKLYN____LIVE LIKE URBAN ROYALT", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-one-bedbest-views/6495692482.html", 
+    "name": "BRAND NEW ONE BED#####BEST VIEWS IN BROOKLYN____LIVE LIKE URBAN ROYALT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-one-bedbest-views/6495692482.html",
     "containedIn": {
-      "name": " (Downtown)", 
+      "name": " (Downtown)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3050.0, 
+      "name": "price",
+      "value": 3050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6495691981.html", 
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6495691981.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6495691943.html", 
+    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6495691943.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5250.0, 
+      "name": "price",
+      "value": 5250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - UWS 1BR Pre War Charm - P/T Doorman - Available Now", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-uws-1br-pre-war-charm/6495691793.html", 
+    "name": "NO FEE - UWS 1BR Pre War Charm - P/T Doorman - Available Now",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-uws-1br-pre-war-charm/6495691793.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2966.0, 
+      "name": "price",
+      "value": 2966.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MASSIVE++ 3Bed in Prime Washington Heights!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3bed-in-prime/6495688325.html", 
+    "name": "MASSIVE++ 3Bed in Prime Washington Heights!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3bed-in-prime/6495688325.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brownstone 2Bedroom with Private outdoor space - block is to die for!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brownstone-2bedroom-with/6495681374.html", 
+    "name": "Brownstone 2Bedroom with Private outdoor space - block is to die for!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brownstone-2bedroom-with/6495681374.html",
     "containedIn": {
-      "name": " (Stuyvesant Heights)", 
+      "name": " (Stuyvesant Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2195.0, 
+      "name": "price",
+      "value": 2195.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-THE CLOISTERS' BEST DEAL IN AREA-MASSIVE 2 BED- A EXPRESS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-cloisters-best/6495680440.html", 
+    "name": "NO FEE-THE CLOISTERS' BEST DEAL IN AREA-MASSIVE 2 BED- A EXPRESS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-cloisters-best/6495680440.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***RARE 4 BEDROOM IN ASTORIA***", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6495677740.html", 
+    "name": "***RARE 4 BEDROOM IN ASTORIA***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6495677740.html",
     "containedIn": {
-      "name": " (3415 9th street)", 
+      "name": " (3415 9th street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous Custom Studio at The Alabama! 11th & 5th Ave. No Broker Fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-custom-studio-at-the/6495676629.html", 
+    "name": "Gorgeous Custom Studio at The Alabama! 11th & 5th Ave. No Broker Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-custom-studio-at-the/6495676629.html",
     "containedIn": {
-      "name": " (Union Square)", 
+      "name": " (Union Square)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST OF WILLIAMSBURG!____AMAZING WATER VIEWS!____CANT BEAT THIS NEW BU", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/best-of-williamsburgamazing/6495676243.html", 
+    "name": "BEST OF WILLIAMSBURG!____AMAZING WATER VIEWS!____CANT BEAT THIS NEW BU",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/best-of-williamsburgamazing/6495676243.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6495669836.html", 
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6495669836.html",
     "containedIn": {
-      "name": " (13 Humboldt Street)", 
+      "name": " (13 Humboldt Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE  1 MONTH FREE SUNLIT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-sunlit/6495666381.html", 
+    "name": "NO FEE  1 MONTH FREE SUNLIT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-sunlit/6495666381.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 2 Months FREE RENT - Upper West Side Pre War Charm", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-rent/6495662913.html", 
+    "name": "NO FEE & 2 Months FREE RENT - Upper West Side Pre War Charm",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-rent/6495662913.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3192.0, 
+      "name": "price",
+      "value": 3192.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE* LARGE 2 Bed in Prospect Lefferts Gardens! 2 & 5 trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2-bed-in/6495662867.html", 
+    "name": "*NO FEE* LARGE 2 Bed in Prospect Lefferts Gardens! 2 & 5 trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2-bed-in/6495662867.html",
     "containedIn": {
-      "name": " (Prospect Lefferts Gardens / Nostrand Ave)", 
+      "name": " (Prospect Lefferts Gardens / Nostrand Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1895.0, 
+      "name": "price",
+      "value": 1895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495658646.html", 
+    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495658646.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS STUDIO IN PRIME CROWN HEIGHTS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-studio-in-prime/6495658177.html", 
+    "name": "GORGEOUS STUDIO IN PRIME CROWN HEIGHTS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-studio-in-prime/6495658177.html",
     "containedIn": {
-      "name": " (Franklin Ave)", 
+      "name": " (Franklin Ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**** NO FEE **** *** PRIME LOCATION *** ** 24 HOUR WHITE GLOVED ** **** GORGEOUS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-location-24-hour/6494364835.html", 
+    "name": "**** NO FEE **** *** PRIME LOCATION *** ** 24 HOUR WHITE GLOVED ** **** GORGEOUS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-location-24-hour/6494364835.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6495645865.html", 
+    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6495645865.html",
     "containedIn": {
-      "name": " (Red Hook)", 
+      "name": " (Red Hook)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495639723.html", 
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495639723.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3480.0, 
+      "name": "price",
+      "value": 3480.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6495634200.html", 
+    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6495634200.html",
     "containedIn": {
-      "name": " (Bedstuy @ A & C subway)", 
+      "name": " (Bedstuy @ A & C subway)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6495631810.html", 
+    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6495631810.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT DEAL**Prime Ditmas Park**No FEE**LAUNDRY&ELEVATOR!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-dealprime-ditmas-parkno/6495630991.html", 
+    "name": "GREAT DEAL**Prime Ditmas Park**No FEE**LAUNDRY&ELEVATOR!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-dealprime-ditmas-parkno/6495630991.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6495629678.html", 
+    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6495629678.html",
     "containedIn": {
-      "name": " (Crown Heights @ A & C Nostrand ave)", 
+      "name": " (Crown Heights @ A & C Nostrand ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2799.0, 
+      "name": "price",
+      "value": 2799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495629364.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495629364.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, **Brand New Kitchens & Gym!**", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495627825.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, **Brand New Kitchens & Gym!**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495627825.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, laundry, great location!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495626217.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, laundry, great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495626217.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2175.0, 
+      "name": "price",
+      "value": 2175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *spacious apts with amenities*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495623643.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *spacious apts with amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495623643.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2625.0, 
+      "name": "price",
+      "value": 2625.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**LUX BUILDING*TRUE 1 BR *100% NO FEE **24 DM **GYM/POOL/ROOFTOP*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingtrue-1-br-100-no/6495622948.html", 
+    "name": "**LUX BUILDING*TRUE 1 BR *100% NO FEE **24 DM **GYM/POOL/ROOFTOP*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingtrue-1-br-100-no/6495622948.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "****** NO FEE ****** *** GORGEOUS BUILDING *** ** SWIMMING POOL ** *** INSANE AP", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-building/6495621536.html", 
+    "name": "****** NO FEE ****** *** GORGEOUS BUILDING *** ** SWIMMING POOL ** *** INSANE AP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-building/6495621536.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3795.0, 
+      "name": "price",
+      "value": 3795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6495620491.html", 
+    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6495620491.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3695.0, 
+      "name": "price",
+      "value": 3695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6495619495.html", 
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6495619495.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***100 % NO FEE***2 MONTH FREE*XXL STUDIO***ROOFTOP**LOUNGE**HIGHLINE*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee2-month-freexxl/6495616786.html", 
+    "name": "***100 % NO FEE***2 MONTH FREE*XXL STUDIO***ROOFTOP**LOUNGE**HIGHLINE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee2-month-freexxl/6495616786.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MONTH FREE net effec.rent $2745 LG1 BR MBL BTH  UES Low 70s G", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free-net/6495611764.html", 
+    "name": "NO FEE+1 MONTH FREE net effec.rent $2745 LG1 BR MBL BTH  UES Low 70s G",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free-net/6495611764.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "24/7 DOORMAN__FREE BIKE STORAGE____WATER VIEWS____SEPARATED KITCHEN __", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/24-7-doormanfree-bike/6495611623.html", 
+    "name": "24/7 DOORMAN__FREE BIKE STORAGE____WATER VIEWS____SEPARATED KITCHEN __",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/24-7-doormanfree-bike/6495611623.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6495611625.html", 
+    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6495611625.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4400.0, 
+      "name": "price",
+      "value": 4400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PENTHOUSE PENTHOUSE PENTHOUSE____UNBEATABLE LOCATION____#VIEWS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-penthouse/6495611133.html", 
+    "name": "PENTHOUSE PENTHOUSE PENTHOUSE____UNBEATABLE LOCATION____#VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-penthouse/6495611133.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TONS OF NATURAL LIGHT~~~~~~~FULL SIZE W/D IN UNIT~~~~~~~STARBUCKS COFF", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/tons-of-natural-lightfull/6495597526.html", 
+    "name": "TONS OF NATURAL LIGHT~~~~~~~FULL SIZE W/D IN UNIT~~~~~~~STARBUCKS COFF",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/tons-of-natural-lightfull/6495597526.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2375.0, 
+      "name": "price",
+      "value": 2375.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - Charming 2bed located in Prime crown heights off Eastern Pkwy", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-charming-2bed-located/6495592434.html", 
+    "name": "NO FEE - Charming 2bed located in Prime crown heights off Eastern Pkwy",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-charming-2bed-located/6495592434.html",
     "containedIn": {
-      "name": " (crown heights)", 
+      "name": " (crown heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6495585618.html", 
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6495585618.html",
     "containedIn": {
-      "name": " (Ridgewood @ Seneca M)", 
+      "name": " (Ridgewood @ Seneca M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2609.0, 
+      "name": "price",
+      "value": 2609.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!  Unique, Gut-Reno Loft-style 3BR with 15' Ceilings, Exposed Brick &", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-unique-gut-reno-loft/6495560570.html", 
+    "name": "NO FEE!  Unique, Gut-Reno Loft-style 3BR with 15' Ceilings, Exposed Brick &",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-unique-gut-reno-loft/6495560570.html",
     "containedIn": {
-      "name": " (Greenpoint)", 
+      "name": " (Greenpoint)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3599.0, 
+      "name": "price",
+      "value": 3599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**TRUE 1 BEDROOM**100% NO FEE**LUX**24 HR DM**MONTH FREE**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom100-no-feelux24/6495553474.html", 
+    "name": "**TRUE 1 BEDROOM**100% NO FEE**LUX**24 HR DM**MONTH FREE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom100-no-feelux24/6495553474.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AMAZING CITY VIEWS -- OPEN KITCHEN -- TONS OF CLOSETS -- QUEEN SIZED B", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-city-views-open/6495553006.html", 
+    "name": "AMAZING CITY VIEWS -- OPEN KITCHEN -- TONS OF CLOSETS -- QUEEN SIZED B",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-city-views-open/6495553006.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2670.0, 
+      "name": "price",
+      "value": 2670.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495552132.html", 
+    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495552132.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - Spacious Layouts, Near Subway!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495551710.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Spacious Layouts, Near Subway!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495551710.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6495545252.html", 
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6495545252.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 BATHS!!! --- UNDER MARKET VALUE!!! --- HARDWOOD FLOORS --- HIGH CEIL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-under-market-value/6495543367.html", 
+    "name": "2 BATHS!!! --- UNDER MARKET VALUE!!! --- HARDWOOD FLOORS --- HIGH CEIL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-under-market-value/6495543367.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6495542273.html", 
+    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6495542273.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4680.0, 
+      "name": "price",
+      "value": 4680.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6495540582.html", 
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6495540582.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3590.0, 
+      "name": "price",
+      "value": 3590.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE LIVING AREA --- PLENTY OF CLOSET SPACE --- TONS OF LIGHT --- HIGH", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-living-area-plenty-of/6495540124.html", 
+    "name": "HUGE LIVING AREA --- PLENTY OF CLOSET SPACE --- TONS OF LIGHT --- HIGH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-living-area-plenty-of/6495540124.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2340.0, 
+      "name": "price",
+      "value": 2340.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny and large 1 Bedroom on the Upper East Side", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-and-large-1-bedroom-on/6495524581.html", 
+    "name": "Sunny and large 1 Bedroom on the Upper East Side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-and-large-1-bedroom-on/6495524581.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2275.0, 
+      "name": "price",
+      "value": 2275.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "MARCH MOVE IN ////////// 3 BEDROOM ====== CITY VIEWS=== BOUKLIS GROUP", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-3-bedroom-city/6495523685.html", 
+    "name": "MARCH MOVE IN ////////// 3 BEDROOM ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-3-bedroom-city/6495523685.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7450.0, 
+      "name": "price",
+      "value": 7450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "APRIL 15TH  MOVE IN ---- 20TH FLOOR ----- FULL SERVICE ----- CONDOMINI", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-20th-floor/6495522164.html", 
+    "name": "APRIL 15TH  MOVE IN ---- 20TH FLOOR ----- FULL SERVICE ----- CONDOMINI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-20th-floor/6495522164.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2775.0, 
+      "name": "price",
+      "value": 2775.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE BEAUTIFUL KITCHEN DISHWASHER LAUNDRY HUGE BEDROOM 3", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-beautiful/6495506268.html", 
+    "name": "NO BROKER FEE BEAUTIFUL KITCHEN DISHWASHER LAUNDRY HUGE BEDROOM 3",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-beautiful/6495506268.html",
     "containedIn": {
-      "name": " (ASTORIA)", 
+      "name": " (ASTORIA)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bay Windows, Dining Alcove, Oversized Windows, Wall of Windows, Washer", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/bay-windows-dining-alcove/6495506156.html", 
+    "name": "Bay Windows, Dining Alcove, Oversized Windows, Wall of Windows, Washer",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bay-windows-dining-alcove/6495506156.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 7745.0, 
+      "name": "price",
+      "value": 7745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXURY 1 BEDROOM (HUGE BEDROOM) (FREE UTILITIES) ) - SEE FLOOR PLAN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-1-bedroom-huge-bedroom/6495505785.html", 
+    "name": "LUXURY 1 BEDROOM (HUGE BEDROOM) (FREE UTILITIES) ) - SEE FLOOR PLAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-1-bedroom-huge-bedroom/6495505785.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3150.0, 
+      "name": "price",
+      "value": 3150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 1BR NO BROKER FEE DISHWASHER LAUNDRY SPACIOUS BEDROOM", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/huge-1br-no-broker-fee/6495505761.html", 
+    "name": "HUGE 1BR NO BROKER FEE DISHWASHER LAUNDRY SPACIOUS BEDROOM",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-1br-no-broker-fee/6495505761.html",
     "containedIn": {
-      "name": " (ASTORIA)", 
+      "name": " (ASTORIA)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXURY HUGE 2-BR (HUGE BEDROOMS) (FREE UTILITIES) (SEE FLOORPLAN)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-huge-2-br-huge/6495505323.html", 
+    "name": "LUXURY HUGE 2-BR (HUGE BEDROOMS) (FREE UTILITIES) (SEE FLOORPLAN)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-huge-2-br-huge/6495505323.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXURY 3 BEDROOM (NEW RENOVATION) (SEE FLOORPLAN) (FREE UTILITIES)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-3-bedroom-new/6495504840.html", 
+    "name": "LUXURY 3 BEDROOM (NEW RENOVATION) (SEE FLOORPLAN) (FREE UTILITIES)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-3-bedroom-new/6495504840.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4300.0, 
+      "name": "price",
+      "value": 4300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1000 SQ FT RENOVATED 2-BR * TONS OF CLOSET SPACE - SEE EXACT FLOORPLAN", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-sq-ft-renovated-2-br/6495504323.html", 
+    "name": "1000 SQ FT RENOVATED 2-BR * TONS OF CLOSET SPACE - SEE EXACT FLOORPLAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-sq-ft-renovated-2-br/6495504323.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENT STABILIZED $2,600 1br 1ba elevator dishwasher W/D in unit", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rent-stabilizedbr-1ba/6495503677.html", 
+    "name": "NO FEE RENT STABILIZED $2,600 1br 1ba elevator dishwasher W/D in unit",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rent-stabilizedbr-1ba/6495503677.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6495502923.html", 
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6495502923.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5100.0, 
+      "name": "price",
+      "value": 5100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand new finishes! 1 Bed in prime location at NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-finishes-1-bed-in/6495501886.html", 
+    "name": "Brand new finishes! 1 Bed in prime location at NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-finishes-1-bed-in/6495501886.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2855.0, 
+      "name": "price",
+      "value": 2855.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Prime Downtown Location! Spacious 2bed 2 ba..NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-downtown-location/6495501114.html", 
+    "name": "Prime Downtown Location! Spacious 2bed 2 ba..NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-downtown-location/6495501114.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3750.0, 
+      "name": "price",
+      "value": 3750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Walls Of Floor to Ceiling Glass Windows, Incredible city views, State", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6495499927.html", 
+    "name": "Walls Of Floor to Ceiling Glass Windows, Incredible city views, State",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6495499927.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5595.0, 
+      "name": "price",
+      "value": 5595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True No Fee 3BR w/ Yard! Heat &HW included! Great Location!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/true-no-fee-3br-yard-heat-hw/6495487689.html", 
+    "name": "True No Fee 3BR w/ Yard! Heat &HW included! Great Location!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-no-fee-3br-yard-heat-hw/6495487689.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey L)", 
+      "name": " (Bushwick @ Halsey L)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2570.0, 
+      "name": "price",
+      "value": 2570.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST DEAL IN MIDTOWN WEST NO BROKER FEE ELEVATOR BUILDING", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-in-midtown-west-no/6495477378.html", 
+    "name": "BEST DEAL IN MIDTOWN WEST NO BROKER FEE ELEVATOR BUILDING",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-in-midtown-west-no/6495477378.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495472223.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495472223.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2070.0, 
+      "name": "price",
+      "value": 2070.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STELLAR 3 BEDROOM 2 BATH. BALCONY! DISHWASHER. GREAT AREA. NO FEE!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stellar-3-bedroom-2-bath/6495466070.html", 
+    "name": "STELLAR 3 BEDROOM 2 BATH. BALCONY! DISHWASHER. GREAT AREA. NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stellar-3-bedroom-2-bath/6495466070.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New No Fee Two Bedroom Apartment with Amazing Views in Downtown", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-no-fee-two-bedroom/6495462761.html", 
+    "name": "Brand New No Fee Two Bedroom Apartment with Amazing Views in Downtown",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-no-fee-two-bedroom/6495462761.html",
     "containedIn": {
-      "name": " (DOWNTOWN BROOKLYN)", 
+      "name": " (DOWNTOWN BROOKLYN)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MO.FREEnet rent $3020 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-3020/6495462646.html", 
+    "name": "NO FEE+1 MO.FREEnet rent $3020 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-3020/6495462646.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6495462583.html", 
+    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6495462583.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW**NO FEE*Converted 2 BR TERRACE* ELEVATOR TOWNHOUSE 60th nr 3rd LND", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-feeconverted-2-br/6495462538.html", 
+    "name": "WOW**NO FEE*Converted 2 BR TERRACE* ELEVATOR TOWNHOUSE 60th nr 3rd LND",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-feeconverted-2-br/6495462538.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Renovated Apts *Near Shopping*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495457131.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Renovated Apts *Near Shopping*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495457131.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2095.0, 
+      "name": "price",
+      "value": 2095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "--->Mint New Dev--->Laundry in Unit--->Lux Amenities--->", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/mint-new-dev-laundry-in-unit/6495447297.html", 
+    "name": "--->Mint New Dev--->Laundry in Unit--->Lux Amenities--->",
+    "url": "https://newyork.craigslist.org/que/nfb/d/mint-new-dev-laundry-in-unit/6495447297.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6495435722.html", 
+    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6495435722.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4100.0, 
+      "name": "price",
+      "value": 4100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "___CORNER APT-- WATER & BRIDGE VIEWS -- W/D IN UNIT -- CHEF'S KIT", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-apt-water-bridge-views/6495425971.html", 
+    "name": "___CORNER APT-- WATER & BRIDGE VIEWS -- W/D IN UNIT -- CHEF'S KIT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-apt-water-bridge-views/6495425971.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3508.0, 
+      "name": "price",
+      "value": 3508.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee- 1 BR, 1BA. $2600/mo. Upscale Renovations. Avail now. Pets OK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-br-1ba-2600-mo/6495424824.html", 
+    "name": "No Fee- 1 BR, 1BA. $2600/mo. Upscale Renovations. Avail now. Pets OK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-br-1ba-2600-mo/6495424824.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495421004.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495421004.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 2 MONTH FREE - LARGE 4 BR / 2.5 BATH -- PRIVATE TERRACE- WASH", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-large-4/6495415885.html", 
+    "name": "NO FEE & 2 MONTH FREE - LARGE 4 BR / 2.5 BATH -- PRIVATE TERRACE- WASH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-large-4/6495415885.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6595.0, 
+      "name": "price",
+      "value": 6595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Extra Sunny UWS Charmer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/extra-sunny-uws-charmer/6495407694.html", 
+    "name": "Extra Sunny UWS Charmer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/extra-sunny-uws-charmer/6495407694.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3250.0, 
+      "name": "price",
+      "value": 3250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 1 MONTH FREE -- SPACIOUS 3 BR -- FULL LUXURY BLDG - GYM - ROO", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spacious/6495405482.html", 
+    "name": "NO FEE & 1 MONTH FREE -- SPACIOUS 3 BR -- FULL LUXURY BLDG - GYM - ROO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spacious/6495405482.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4520.0, 
+      "name": "price",
+      "value": 4520.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - 4 BR / 2 BATH - BRAND NEW BUILDING - FULL LUXURY AMENITIES -", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-4-br-2-bath-brand-new/6495401952.html", 
+    "name": "NO FEE - 4 BR / 2 BATH - BRAND NEW BUILDING - FULL LUXURY AMENITIES -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-4-br-2-bath-brand-new/6495401952.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6460.0, 
+      "name": "price",
+      "value": 6460.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE++ 2BR++MASSIVE LIVING ROOM++DOGS ALLOWED++ ELEVATOR++ LAUNDRY++", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2brmassive-living/6495398429.html", 
+    "name": "NO FEE++ 2BR++MASSIVE LIVING ROOM++DOGS ALLOWED++ ELEVATOR++ LAUNDRY++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2brmassive-living/6495398429.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 2 MONTH FREE -- BRAND NEW RENOVATED -- 3 BR -- DOORMAN -- GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-brand-new/6495389547.html", 
+    "name": "NO FEE & 2 MONTH FREE -- BRAND NEW RENOVATED -- 3 BR -- DOORMAN -- GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-brand-new/6495389547.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4564.0, 
+      "name": "price",
+      "value": 4564.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Duplex w/ Private Yard. March 1st!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-private-yard-march-1st/6495385855.html", 
+    "name": "Duplex w/ Private Yard. March 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-private-yard-march-1st/6495385855.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5995.0, 
+      "name": "price",
+      "value": 5995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6495380105.html", 
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6495380105.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4600.0, 
+      "name": "price",
+      "value": 4600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Fresh Renovations! 4 bed two bath! march 1st!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/fresh-renovations-4-bed-two/6495374131.html", 
+    "name": "Fresh Renovations! 4 bed two bath! march 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fresh-renovations-4-bed-two/6495374131.html",
     "containedIn": {
-      "name": " (23rd Street)", 
+      "name": " (23rd Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6795.0, 
+      "name": "price",
+      "value": 6795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS 3 BEDROOM APARTMENT! DISHWASHER! QUIET AREA! | NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-apartment/6495372663.html", 
+    "name": "SPACIOUS 3 BEDROOM APARTMENT! DISHWASHER! QUIET AREA! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-apartment/6495372663.html",
     "containedIn": {
-      "name": " (Bushwick @ Myrtle L)", 
+      "name": " (Bushwick @ Myrtle L)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2549.0, 
+      "name": "price",
+      "value": 2549.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SUNNY & GIGANTIC 4 BEDROOM BARGAIN! QUIET AREA! | NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-gigantic-4-bedroom/6495372297.html", 
+    "name": "SUNNY & GIGANTIC 4 BEDROOM BARGAIN! QUIET AREA! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-gigantic-4-bedroom/6495372297.html",
     "containedIn": {
-      "name": " (Prospect Lefferts Gardens @ Church 2/5)", 
+      "name": " (Prospect Lefferts Gardens @ Church 2/5)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3099.0, 
+      "name": "price",
+      "value": 3099.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6495371985.html", 
+    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6495371985.html",
     "containedIn": {
-      "name": " (Crown Heights @ Nostrand 2/3)", 
+      "name": " (Crown Heights @ Nostrand 2/3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2749.0, 
+      "name": "price",
+      "value": 2749.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6495371619.html", 
+    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6495371619.html",
     "containedIn": {
-      "name": " (Williamsburg @ Lorimer J/M/Z)", 
+      "name": " (Williamsburg @ Lorimer J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6495370728.html", 
+    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6495370728.html",
     "containedIn": {
-      "name": " (Bushwick @ Hasley J/M/Z)", 
+      "name": " (Bushwick @ Hasley J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3199.0, 
+      "name": "price",
+      "value": 3199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6495370403.html", 
+    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6495370403.html",
     "containedIn": {
-      "name": " (Williamsburg @ Flushing J/M/Z)", 
+      "name": " (Williamsburg @ Flushing J/M/Z)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6495369994.html", 
+    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6495369994.html",
     "containedIn": {
-      "name": " (Flatbush @ Newkirk Plaza B/Q)", 
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6495369591.html", 
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6495369591.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2375.0, 
+      "name": "price",
+      "value": 2375.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!! LARGE  STUDIO-- HIGH CELLINGS -- P-R-I-M-E LOCATION-- MUST T", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-high/6495368890.html", 
+    "name": "NO FEE!!! LARGE  STUDIO-- HIGH CELLINGS -- P-R-I-M-E LOCATION-- MUST T",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-high/6495368890.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2895.0, 
+      "name": "price",
+      "value": 2895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 3 bedroom on Upper East Side. No fee!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3-bedroom-on-upper/6495368065.html", 
+    "name": "Massive 3 bedroom on Upper East Side. No fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3-bedroom-on-upper/6495368065.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FOR RENT! 4BED 2BA // Avail March 1st!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/for-rent-4bed-2ba-avail-march/6495363289.html", 
+    "name": "FOR RENT! 4BED 2BA // Avail March 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/for-rent-4bed-2ba-avail-march/6495363289.html",
     "containedIn": {
-      "name": " (West 123rd Street)", 
+      "name": " (West 123rd Street)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4495.0, 
+      "name": "price",
+      "value": 4495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & FREE MONTH -- ELEVATOR / LAUNDRY / MUST TAKE ADVANTAGE QUICK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-free-month-elevator/6495363074.html", 
+    "name": "NO FEE & FREE MONTH -- ELEVATOR / LAUNDRY / MUST TAKE ADVANTAGE QUICK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-free-month-elevator/6495363074.html",
     "containedIn": {
-      "name": " (Flatiron)", 
+      "name": " (Flatiron)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5250.0, 
+      "name": "price",
+      "value": 5250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "March 1 ready!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-1-ready/6495362339.html", 
+    "name": "March 1 ready!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-1-ready/6495362339.html",
     "containedIn": {
-      "name": " (East 6th)", 
+      "name": " (East 6th)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4895.0, 
+      "name": "price",
+      "value": 4895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 1 MONTH FREE - LARGE PENTHOUSE - LUXURY BUILDING - GYM - ROOF", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-large/6495360579.html", 
+    "name": "NO FEE & 1 MONTH FREE - LARGE PENTHOUSE - LUXURY BUILDING - GYM - ROOF",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-large/6495360579.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6095.0, 
+      "name": "price",
+      "value": 6095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE--S-O-H-O!! FULLY RENO!!  LARGE 2 BR - SUPER SUNNY-- ELEV", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-o-o-fully-reno/6495355852.html", 
+    "name": "NO BROKER FEE--S-O-H-O!! FULLY RENO!!  LARGE 2 BR - SUPER SUNNY-- ELEV",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-o-o-fully-reno/6495355852.html",
     "containedIn": {
-      "name": " (SoHo)", 
+      "name": " (SoHo)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4595.0, 
+      "name": "price",
+      "value": 4595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!! TRUE 3 BR -- PRIME LOCATION -- 29 ST & 3 AVE !! ELEVATOR - LA", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-3-br-prime/6495352310.html", 
+    "name": "NO FEE!! TRUE 3 BR -- PRIME LOCATION -- 29 ST & 3 AVE !! ELEVATOR - LA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-3-br-prime/6495352310.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4495.0, 
+      "name": "price",
+      "value": 4495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & MONTH FREE // ULTRA HIGH RISE IN TIMES SQUARE // LAUNDRY IN U", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-month-free-ultra-high/6495341368.html", 
+    "name": "NO FEE & MONTH FREE // ULTRA HIGH RISE IN TIMES SQUARE // LAUNDRY IN U",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-month-free-ultra-high/6495341368.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2616.0, 
+      "name": "price",
+      "value": 2616.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6495336658.html", 
+    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6495336658.html",
     "containedIn": {
-      "name": " (Flatiron)", 
+      "name": " (Flatiron)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4295.0, 
+      "name": "price",
+      "value": 4295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 2 MONTHS FREE -- LARGE STUDIO -- RESIDENT LOUNGE -- HEALTH CL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large/6495333774.html", 
+    "name": "NO FEE & 2 MONTHS FREE -- LARGE STUDIO -- RESIDENT LOUNGE -- HEALTH CL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large/6495333774.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2447.0, 
+      "name": "price",
+      "value": 2447.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 2 MONTHS FREE -- LARGE 2 BR APT -- BRAND NEW BLDG -- 24 HR DM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large-2/6495332222.html", 
+    "name": "NO FEE & 2 MONTHS FREE -- LARGE 2 BR APT -- BRAND NEW BLDG -- 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large-2/6495332222.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2966.0, 
+      "name": "price",
+      "value": 2966.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE AMAZING LOFT 1 BR!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-loft-1-br/6495324629.html", 
+    "name": "NO FEE AMAZING LOFT 1 BR!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-loft-1-br/6495324629.html",
     "containedIn": {
-      "name": " (Flatiron)", 
+      "name": " (Flatiron)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6495323230.html", 
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6495323230.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1899.0, 
+      "name": "price",
+      "value": 1899.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Floor Thru Two Bedroom BRAND NEW KITCHEN - Short Walk To trains & Park", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-two-bedroom-brand/6495319597.html", 
+    "name": "Floor Thru Two Bedroom BRAND NEW KITCHEN - Short Walk To trains & Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-two-bedroom-brand/6495319597.html",
     "containedIn": {
-      "name": " (PROSPECT HEIGHTS)", 
+      "name": " (PROSPECT HEIGHTS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**No Fee** 1BR__Prime UES", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1brprime-ues/6495303185.html", 
+    "name": "**No Fee** 1BR__Prime UES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1brprime-ues/6495303185.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6495302161.html", 
+    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6495302161.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! PETS OK! Renovated 2 BEDROOM! Elevator/Laundry! 7 Trains/Shopp", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-renovated-2/6495293290.html", 
+    "name": "NO FEE! PETS OK! Renovated 2 BEDROOM! Elevator/Laundry! 7 Trains/Shopp",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-renovated-2/6495293290.html",
     "containedIn": {
-      "name": " (Flushing)", 
+      "name": " (Flushing)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2232.0, 
+      "name": "price",
+      "value": 2232.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNIQUE 3BR in Jackson Heights - MUST SEE!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/unique-3br-in-jackson-heights/6495288556.html", 
+    "name": "UNIQUE 3BR in Jackson Heights - MUST SEE!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/unique-3br-in-jackson-heights/6495288556.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6495283756.html", 
+    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6495283756.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2050.0, 
+      "name": "price",
+      "value": 2050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Triboro Bridge Views -- No Fee! -- Washer/Dryer in Unit -- Brand New L", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/triboro-bridge-views-no-fee/6495270517.html", 
+    "name": "Triboro Bridge Views -- No Fee! -- Washer/Dryer in Unit -- Brand New L",
+    "url": "https://newyork.craigslist.org/que/nfb/d/triboro-bridge-views-no-fee/6495270517.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6495267856.html", 
+    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6495267856.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495247130.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495247130.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2780.0, 
+      "name": "price",
+      "value": 2780.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! Gorgeous 1 Bedroom in JACKSON HEIGHTS by 7 Train! Pet Friendly", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-1-bedroom-in/6495223971.html", 
+    "name": "NO FEE! Gorgeous 1 Bedroom in JACKSON HEIGHTS by 7 Train! Pet Friendly",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-1-bedroom-in/6495223971.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1875.0, 
+      "name": "price",
+      "value": 1875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6495222241.html", 
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6495222241.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE__STUDIO BASEMENT___PETS ALLOWED__9 ST & 1 AVE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feestudio-basementpets/6495221482.html", 
+    "name": "NO FEE__STUDIO BASEMENT___PETS ALLOWED__9 ST & 1 AVE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feestudio-basementpets/6495221482.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6495218975.html", 
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6495218975.html",
     "containedIn": {
-      "name": " (Jackson Heights)", 
+      "name": " (Jackson Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495208950.html", 
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495208950.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495205701.html", 
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495205701.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6495204516.html", 
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6495204516.html",
     "containedIn": {
-      "name": " (Kew Gardens)", 
+      "name": " (Kew Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1500.0, 
+      "name": "price",
+      "value": 1500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6495202722.html", 
+    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6495202722.html",
     "containedIn": {
-      "name": " (Bed Stuy / Clinton Hill)", 
+      "name": " (Bed Stuy / Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6495202549.html", 
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6495202549.html",
     "containedIn": {
-      "name": " (Prospect heights @ 2,3,B,Q)", 
+      "name": " (Prospect heights @ 2,3,B,Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "------>The Penelope Luxury Rentals------->1 Month Free------->", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/the-penelope-luxury-rentals-1/6495202045.html", 
+    "name": "------>The Penelope Luxury Rentals------->1 Month Free------->",
+    "url": "https://newyork.craigslist.org/que/nfb/d/the-penelope-luxury-rentals-1/6495202045.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2469.0, 
+      "name": "price",
+      "value": 2469.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6495201763.html", 
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6495201763.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey J)", 
+      "name": " (Bushwick @ Halsey J)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3175.0, 
+      "name": "price",
+      "value": 3175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6495200419.html", 
+    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6495200419.html",
     "containedIn": {
-      "name": " (Woodside)", 
+      "name": " (Woodside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495199849.html", 
+    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495199849.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495197375.html", 
+    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495197375.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495196995.html", 
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495196995.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1932.0, 
+      "name": "price",
+      "value": 1932.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Studio/Separate Kitchen * Sunnyside * By 7 Train !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-studio/6495194474.html", 
+    "name": "No Fee * Renovated Studio/Separate Kitchen * Sunnyside * By 7 Train !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-studio/6495194474.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge 3 bedroom 3 full bath/ Parking/ Laundry hookup/ Balcony", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-3-bedroom-3-full-bath/6495192953.html", 
+    "name": "Huge 3 bedroom 3 full bath/ Parking/ Laundry hookup/ Balcony",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-3-bedroom-3-full-bath/6495192953.html",
     "containedIn": {
-      "name": " (Midwood)", 
+      "name": " (Midwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3699.0, 
+      "name": "price",
+      "value": 3699.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6495189651.html", 
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6495189651.html",
     "containedIn": {
-      "name": " (Rego Park / Forest Hills)", 
+      "name": " (Rego Park / Forest Hills)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6495174405.html", 
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6495174405.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6495172521.html", 
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6495172521.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE!!! Beautiful bright 1 bedroom. Lower East prime*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-bright-1/6495170414.html", 
+    "name": "*NO FEE!!! Beautiful bright 1 bedroom. Lower East prime*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-bright-1/6495170414.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2175.0, 
+      "name": "price",
+      "value": 2175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6495169671.html", 
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6495169671.html",
     "containedIn": {
-      "name": " (Elmhurst)", 
+      "name": " (Elmhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Brokers Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-brokers-fee-spacious-1/6495167505.html", 
+    "name": "No Brokers Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-brokers-fee-spacious-1/6495167505.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Location! Cute Studio in Beautiful Clinton Hill  | No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-cute-studio-in/6495164507.html", 
+    "name": "Great Location! Cute Studio in Beautiful Clinton Hill  | No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-cute-studio-in/6495164507.html",
     "containedIn": {
-      "name": " (Bedstuy @ Franklin C)", 
+      "name": " (Bedstuy @ Franklin C)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee & 1 Month Free!! Spacious 2 Bed 1 Bath + Yard!! By J/M/G/L Trai", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6495161872.html", 
+    "name": "No Fee & 1 Month Free!! Spacious 2 Bed 1 Bath + Yard!! By J/M/G/L Trai",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6495161872.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2818.0, 
+      "name": "price",
+      "value": 2818.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal! Large Classic Beautiful Bushwick 2 Bedroom with No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-large-classic/6495159740.html", 
+    "name": "Great Deal! Large Classic Beautiful Bushwick 2 Bedroom with No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-large-classic/6495159740.html",
     "containedIn": {
-      "name": " (bushwick @ Gates JMZ)", 
+      "name": " (bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Fully renovated 2 bedroom Apts-Inwood NYC", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/fully-renovated-2-bedroom/6495157586.html", 
+    "name": "Fully renovated 2 bedroom Apts-Inwood NYC",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fully-renovated-2-bedroom/6495157586.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bright Beautiful Bushwick 3 Bed with Back Yard Access || No Fee! ||", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-beautiful-bushwick-3/6495156968.html", 
+    "name": "Bright Beautiful Bushwick 3 Bed with Back Yard Access || No Fee! ||",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-beautiful-bushwick-3/6495156968.html",
     "containedIn": {
-      "name": " (Bushwick @ Halsey L train)", 
+      "name": " (Bushwick @ Halsey L train)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2570.0, 
+      "name": "price",
+      "value": 2570.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Location! Beautiful Bright 3 Bedroom in Crown Heights No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-beautiful/6495156017.html", 
+    "name": "Great Location! Beautiful Bright 3 Bedroom in Crown Heights No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-beautiful/6495156017.html",
     "containedIn": {
-      "name": " (Crown Heights @ Franklin Ave A,C)", 
+      "name": " (Crown Heights @ Franklin Ave A,C)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Bright Williamsburg 2 Bed with Laundry and Backyard! No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-bright-williamsburg/6495154001.html", 
+    "name": "Beautiful Bright Williamsburg 2 Bed with Laundry and Backyard! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-bright-williamsburg/6495154001.html",
     "containedIn": {
-      "name": " (Williamsburg @ Lorimer JMZ)", 
+      "name": " (Williamsburg @ Lorimer JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal! Bright Spacious Bedstuy 4 Bed In Unit Laundry!  No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-bright-spacious/6495152550.html", 
+    "name": "Great Deal! Bright Spacious Bedstuy 4 Bed In Unit Laundry!  No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-bright-spacious/6495152550.html",
     "containedIn": {
-      "name": " (bedstuy @ utica A,C)", 
+      "name": " (bedstuy @ utica A,C)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3275.0, 
+      "name": "price",
+      "value": 3275.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal! Massive Bright 3 Bedroom in Beautiful Ditmas Park No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-massive-bright-3/6495151178.html", 
+    "name": "Great Deal! Massive Bright 3 Bedroom in Beautiful Ditmas Park No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-massive-bright-3/6495151178.html",
     "containedIn": {
-      "name": " (Ditmas Park @ Newkirk Plaza B, Q)", 
+      "name": " (Ditmas Park @ Newkirk Plaza B, Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee, 3 Bed,  Free 40\" flat screen TV! Minutes From Manhattan!", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-3-bed-free-40-flat/6495147578.html", 
+    "name": "No Fee, 3 Bed,  Free 40\" flat screen TV! Minutes From Manhattan!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-3-bed-free-40-flat/6495147578.html",
     "containedIn": {
-      "name": " (Mott Haven)", 
+      "name": " (Mott Haven)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2015.0, 
+      "name": "price",
+      "value": 2015.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No fee, 1 month free and all Utilities included", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-and-all/6495146511.html", 
+    "name": "No fee, 1 month free and all Utilities included",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-and-all/6495146511.html",
     "containedIn": {
-      "name": " (East Harlem)", 
+      "name": " (East Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 4 Bedroom in Prime Bed-Stuy", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-4-bedroom-in-prime/6495146306.html", 
+    "name": "Beautiful 4 Bedroom in Prime Bed-Stuy",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-4-bedroom-in-prime/6495146306.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3599.0, 
+      "name": "price",
+      "value": 3599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Newly renovated 3 bedroom apartment! No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-3-bedroom/6495142366.html", 
+    "name": "Newly renovated 3 bedroom apartment! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-3-bedroom/6495142366.html",
     "containedIn": {
-      "name": " (Ridgewood)", 
+      "name": " (Ridgewood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495140369.html", 
+    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495140369.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Bensonhurst 1 Bedroom near N Train & 18th Ave Shops", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-1-bedroom/6495140072.html", 
+    "name": "NO FEE Bensonhurst 1 Bedroom near N Train & 18th Ave Shops",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-1-bedroom/6495140072.html",
     "containedIn": {
-      "name": " (Bensonhurst)", 
+      "name": " (Bensonhurst)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HOT DEAL___True 1 bedroom____PRIME Lenox Hill____Fireplace____SUNNY___", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/hot-dealtrue-1-bedroomprime/6495139508.html", 
+    "name": "HOT DEAL___True 1 bedroom____PRIME Lenox Hill____Fireplace____SUNNY___",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/hot-dealtrue-1-bedroomprime/6495139508.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Roommate Wanted!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/roommate-wanted/6495128953.html", 
+    "name": "Roommate Wanted!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/roommate-wanted/6495128953.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 122.0, 
+      "name": "price",
+      "value": 122.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AMAZING LOCATION*FOREST HILLS*ELEVATOR*LAUNDRY ROOM*A MUST SEE!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/amazing-locationforest/6495123590.html", 
+    "name": "AMAZING LOCATION*FOREST HILLS*ELEVATOR*LAUNDRY ROOM*A MUST SEE!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/amazing-locationforest/6495123590.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1725.0, 
+      "name": "price",
+      "value": 1725.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FABULOUS 4 bed/2 bath~Private Backyard + basement~W/D in unit!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/fabulous-4-bed-2-bathprivate/6495123047.html", 
+    "name": "FABULOUS 4 bed/2 bath~Private Backyard + basement~W/D in unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/fabulous-4-bed-2-bathprivate/6495123047.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2987.0, 
+      "name": "price",
+      "value": 2987.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Luxury 1 Bedroom in Great building", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/luxury-1-bedroom-in-great/6495122678.html", 
+    "name": "Luxury 1 Bedroom in Great building",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/luxury-1-bedroom-in-great/6495122678.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "DIRT CHEAP____Sunny Studio______ELEVATOR + LAUNDRY_____Prime UES______", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/dirt-cheapsunny/6495117511.html", 
+    "name": "DIRT CHEAP____Sunny Studio______ELEVATOR + LAUNDRY_____Prime UES______",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/dirt-cheapsunny/6495117511.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1875.0, 
+      "name": "price",
+      "value": 1875.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "New to Market, Large, Bright, Gym, Parking, Roof Deck, Beach B & Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-to-market-large-bright/6495116768.html", 
+    "name": "New to Market, Large, Bright, Gym, Parking, Roof Deck, Beach B & Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-to-market-large-bright/6495116768.html",
     "containedIn": {
-      "name": " (Manhattan Beach / Sheepshead bay)", 
+      "name": " (Manhattan Beach / Sheepshead bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3500.0, 
+      "name": "price",
+      "value": 3500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495116087.html", 
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495116087.html",
     "containedIn": {
-      "name": " (midwood/ Sheepshead bay)", 
+      "name": " (midwood/ Sheepshead bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3499.0, 
+      "name": "price",
+      "value": 3499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2.5 bedroom Washer Dryer hook up, Dishwasher F & G train", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-25-bedroom-washer/6495115631.html", 
+    "name": "Spacious 2.5 bedroom Washer Dryer hook up, Dishwasher F & G train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-25-bedroom-washer/6495115631.html",
     "containedIn": {
-      "name": " (Red hook)", 
+      "name": " (Red hook)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495113774.html", 
+    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495113774.html",
     "containedIn": {
-      "name": " (Kensington)", 
+      "name": " (Kensington)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Glass Walled 3 Bed w/ Private Balcony  -- No-Fee -- Luxury Building --", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-3-bed-private/6495111445.html", 
+    "name": "Glass Walled 3 Bed w/ Private Balcony  -- No-Fee -- Luxury Building --",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-3-bed-private/6495111445.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4460.0, 
+      "name": "price",
+      "value": 4460.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 Bed/2 Bath -- River Views -- Luxury Building -- No Fee -- Gym+Roof+L", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-2-bath-river-views/6495110674.html", 
+    "name": "3 Bed/2 Bath -- River Views -- Luxury Building -- No Fee -- Gym+Roof+L",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-2-bath-river-views/6495110674.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3681.0, 
+      "name": "price",
+      "value": 3681.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-Brand New Large 2 bed-Laundry/Backyard access-Near the G train", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-large-2-bed/6495110164.html", 
+    "name": "NO FEE-Brand New Large 2 bed-Laundry/Backyard access-Near the G train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-large-2-bed/6495110164.html",
     "containedIn": {
-      "name": " (Prime Bed-Stuy)", 
+      "name": " (Prime Bed-Stuy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6495109701.html", 
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6495109701.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2395.0, 
+      "name": "price",
+      "value": 2395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6495108639.html", 
+    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6495108639.html",
     "containedIn": {
-      "name": " (Bedford Stuyvesant)", 
+      "name": " (Bedford Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^SUN!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6495106466.html", 
+    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^SUN!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6495106466.html",
     "containedIn": {
-      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)", 
+      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6495099740.html", 
+    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6495099740.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Perfect 2 Bedroom Share - No FEE! Lower East Side  - Two Bridges", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-2-bedroom-share-no/6495096121.html", 
+    "name": "Perfect 2 Bedroom Share - No FEE! Lower East Side  - Two Bridges",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-2-bedroom-share-no/6495096121.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUNNING ****DOORMAN*****ROOFDECK*****GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-doormanroofdeckgym/6495095788.html", 
+    "name": "STUNNING ****DOORMAN*****ROOFDECK*****GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-doormanroofdeckgym/6495095788.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2606 Gorgeous Luxury 2BR \u2606 Full Service Bldg - NO FEE//MUST SEE!--11221", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-luxury-2br-full/6495094390.html", 
+    "name": "☆ Gorgeous Luxury 2BR ☆ Full Service Bldg - NO FEE//MUST SEE!--11221",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-luxury-2br-full/6495094390.html",
     "containedIn": {
-      "name": " (Prime Bushwick)", 
+      "name": " (Prime Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2610.0, 
+      "name": "price",
+      "value": 2610.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE-Newly renovated SUNNY 1 bed-Prime location near the D/N/R train", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-newly-renovated-sunny/6495089845.html", 
+    "name": "NO FEE-Newly renovated SUNNY 1 bed-Prime location near the D/N/R train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-newly-renovated-sunny/6495089845.html",
     "containedIn": {
-      "name": " (Prime Greenwood)", 
+      "name": " (Prime Greenwood)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! BRAND NEW GORGEOUS 2 BED W/ a washer dryer hookup-Near trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-gorgeous-2/6495089252.html", 
+    "name": "NO FEE! BRAND NEW GORGEOUS 2 BED W/ a washer dryer hookup-Near trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-gorgeous-2/6495089252.html",
     "containedIn": {
-      "name": " (Prime Crown Heights)", 
+      "name": " (Prime Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AWESOME 3 BEDROOM WITH PRIVATE BACKYARD AND GARAGE! NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-bedroom-with/6495068061.html", 
+    "name": "AWESOME 3 BEDROOM WITH PRIVATE BACKYARD AND GARAGE! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-bedroom-with/6495068061.html",
     "containedIn": {
-      "name": " (BUSHWICK)", 
+      "name": " (BUSHWICK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495063392.html", 
+    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495063392.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2200.0, 
+      "name": "price",
+      "value": 2200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!*WOW*!*RENOVATED 1 BED*NO FEE!NEAR PARK!*SUNLIGHT!*TRAINS!*STEAL DEAL", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wowrenovated-1-bedno-feenear/6495053924.html", 
+    "name": "!*WOW*!*RENOVATED 1 BED*NO FEE!NEAR PARK!*SUNLIGHT!*TRAINS!*STEAL DEAL",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowrenovated-1-bedno-feenear/6495053924.html",
     "containedIn": {
-      "name": " (Lefferts Garden/Prospect Park)", 
+      "name": " (Lefferts Garden/Prospect Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1575.0, 
+      "name": "price",
+      "value": 1575.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!^HOT^!GORGEOUS SPACIOUS 1 BED*STEPS TO PARK*NEAR TRAIN*STEAL DEAL!**", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/hotgorgeous-spacious-1/6495053066.html", 
+    "name": "!^HOT^!GORGEOUS SPACIOUS 1 BED*STEPS TO PARK*NEAR TRAIN*STEAL DEAL!**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hotgorgeous-spacious-1/6495053066.html",
     "containedIn": {
-      "name": " (Lefferts Garden/Prospect Park)", 
+      "name": " (Lefferts Garden/Prospect Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1695.0, 
+      "name": "price",
+      "value": 1695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6495052139.html", 
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6495052139.html",
     "containedIn": {
-      "name": " (Lefferts Garden/Prospect Park)", 
+      "name": " (Lefferts Garden/Prospect Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1595.0, 
+      "name": "price",
+      "value": 1595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495049806.html", 
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495049806.html",
     "containedIn": {
-      "name": " (PROSPECT LEFFERTS GARDENS)", 
+      "name": " (PROSPECT LEFFERTS GARDENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CLOSE TO CORTELYOU ROAD'S SHOPS AND CAFES*NEWLY RENOVATED AND SPACIOUS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-cortelyou-roads/6495048076.html", 
+    "name": "CLOSE TO CORTELYOU ROAD'S SHOPS AND CAFES*NEWLY RENOVATED AND SPACIOUS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-cortelyou-roads/6495048076.html",
     "containedIn": {
-      "name": " (DITMAS PARK-FLATBUSH)", 
+      "name": " (DITMAS PARK-FLATBUSH)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6495047266.html", 
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6495047266.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6495045809.html", 
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6495045809.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6495045310.html", 
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6495045310.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! BRAND NEW STUDIO + ELEVATOR!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-studio/6495044720.html", 
+    "name": "NO FEE! BRAND NEW STUDIO + ELEVATOR!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-studio/6495044720.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6495043859.html", 
+    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6495043859.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3750.0, 
+      "name": "price",
+      "value": 3750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Apts, Laundry, Amenities!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495042229.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Apts, Laundry, Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495042229.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2765.0, 
+      "name": "price",
+      "value": 2765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "priced to rent! Large Upper West Side 3 bedroom shares!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/priced-to-rent-large-upper/6495036355.html", 
+    "name": "priced to rent! Large Upper West Side 3 bedroom shares!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/priced-to-rent-large-upper/6495036355.html",
     "containedIn": {
-      "name": " (Riverside Park)", 
+      "name": " (Riverside Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495036147.html", 
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495036147.html",
     "containedIn": {
-      "name": " (PROSPECT LEFFERTS GARDENS)", 
+      "name": " (PROSPECT LEFFERTS GARDENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1650.0, 
+      "name": "price",
+      "value": 1650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495035344.html", 
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495035344.html",
     "containedIn": {
-      "name": " (PROSPECT PARK SOUTH)", 
+      "name": " (PROSPECT PARK SOUTH)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1550.0, 
+      "name": "price",
+      "value": 1550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, MASSIVE TRUE 3 BED! ELEVATOR/LAUNDRY! TOP FL!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-massive-true-3-bed/6495032445.html", 
+    "name": "NO FEE, MASSIVE TRUE 3 BED! ELEVATOR/LAUNDRY! TOP FL!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-massive-true-3-bed/6495032445.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6495031206.html", 
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6495031206.html",
     "containedIn": {
-      "name": " (Bushwick @ Gates JMZ)", 
+      "name": " (Bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 3BR in Prime Bushwick ~ NO FEE ~ Laundry |", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3br-in-prime/6495030691.html", 
+    "name": "Beautiful 3BR in Prime Bushwick ~ NO FEE ~ Laundry |",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3br-in-prime/6495030691.html",
     "containedIn": {
-      "name": " (Bushwick @ Myrtle Wycoff L/M)", 
+      "name": " (Bushwick @ Myrtle Wycoff L/M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2850.0, 
+      "name": "price",
+      "value": 2850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Cute Cozy Studio in Great Location! No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/cute-cozy-studio-in-great/6495029771.html", 
+    "name": "Cute Cozy Studio in Great Location! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/cute-cozy-studio-in-great/6495029771.html",
     "containedIn": {
-      "name": " (Crown Heights@ Nostrand 3)", 
+      "name": " (Crown Heights@ Nostrand 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1695.0, 
+      "name": "price",
+      "value": 1695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 4 bedroom 2 bathroom | No Fee | Laundry! Bed Suy Brooklyn!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/massive-4-bedroom-2-bathroom/6495028457.html", 
+    "name": "Massive 4 bedroom 2 bathroom | No Fee | Laundry! Bed Suy Brooklyn!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/massive-4-bedroom-2-bathroom/6495028457.html",
     "containedIn": {
-      "name": " (Bed Stuy@ Myrtle G/J/M)", 
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3449.0, 
+      "name": "price",
+      "value": 3449.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CLOSE TO BROOKLYN COLLEGE*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-brooklyn/6495024040.html", 
+    "name": "CLOSE TO BROOKLYN COLLEGE*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-brooklyn/6495024040.html",
     "containedIn": {
-      "name": " (PROSPECT LEFFERTS GARDENS)", 
+      "name": " (PROSPECT LEFFERTS GARDENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6495012861.html", 
+    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6495012861.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6495010537.html", 
+    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6495010537.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant)", 
+      "name": " (Bedford-Stuyvesant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Month Free & NO FEE!  Fort Greene/Downtown Brooklyn! Brand New!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee-fort/6495005970.html", 
+    "name": "1 Month Free & NO FEE!  Fort Greene/Downtown Brooklyn! Brand New!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee-fort/6495005970.html",
     "containedIn": {
-      "name": " (Fort Greene, Downtown BK)", 
+      "name": " (Fort Greene, Downtown BK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Month Free & NO FEE!  BALCONY!Fort Greene/Downtown Brooklyn! Bra", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee/6495005400.html", 
+    "name": "1 Month Free & NO FEE!  BALCONY!Fort Greene/Downtown Brooklyn! Bra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee/6495005400.html",
     "containedIn": {
-      "name": " (Fort Greene, Downtown BK)", 
+      "name": " (Fort Greene, Downtown BK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2871.0, 
+      "name": "price",
+      "value": 2871.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "CLEAN ONE BEDROOM APT LOCATED IN CORONA", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/clean-one-bedroom-apt-located/6495005016.html", 
+    "name": "CLEAN ONE BEDROOM APT LOCATED IN CORONA",
+    "url": "https://newyork.craigslist.org/que/nfb/d/clean-one-bedroom-apt-located/6495005016.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2165.0, 
+      "name": "price",
+      "value": 2165.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 2 BEDROOM, GREAT PRICE + LOCATION!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-great-price/6495004241.html", 
+    "name": "NO FEE, 2 BEDROOM, GREAT PRICE + LOCATION!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-great-price/6495004241.html",
     "containedIn": {
-      "name": " (Hamilton Heights)", 
+      "name": " (Hamilton Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "EASY COMMUTE TO MANHATTAN*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/easy-commute-to/6495003571.html", 
+    "name": "EASY COMMUTE TO MANHATTAN*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/easy-commute-to/6495003571.html",
     "containedIn": {
-      "name": " (PROSPECT LEFFERTS GARDENS)", 
+      "name": " (PROSPECT LEFFERTS GARDENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TRIBECA SOUTH ====AMPLE CLOSETS SPACE===CHEFS KITCHEN====2 MONTHS FREE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-south-ample-closets/6495001585.html", 
+    "name": "TRIBECA SOUTH ====AMPLE CLOSETS SPACE===CHEFS KITCHEN====2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-south-ample-closets/6495001585.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3400.0, 
+      "name": "price",
+      "value": 3400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, Beautifully Renovated 1 Bedroom!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6495000355.html", 
+    "name": "NO FEE, Beautifully Renovated 1 Bedroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6495000355.html",
     "containedIn": {
-      "name": " (Hamilton Heights)", 
+      "name": " (Hamilton Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6495000049.html", 
+    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6495000049.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***SUN-DRENCHED***2 HUGE WINDOWS***ITALIAN MARBLE***CHEFS KITCHEN***RE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/sun-drenched2-huge/6494997921.html", 
+    "name": "***SUN-DRENCHED***2 HUGE WINDOWS***ITALIAN MARBLE***CHEFS KITCHEN***RE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sun-drenched2-huge/6494997921.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6494997370.html", 
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6494997370.html",
     "containedIn": {
-      "name": " (Ditmas Park)", 
+      "name": " (Ditmas Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "UNDER-MARKET*NEWLY RENOVATED* SPACIOUS APARTMENT CLOSE TO TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/under-marketnewly-renovated/6494997350.html", 
+    "name": "UNDER-MARKET*NEWLY RENOVATED* SPACIOUS APARTMENT CLOSE TO TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/under-marketnewly-renovated/6494997350.html",
     "containedIn": {
-      "name": " (PROSPECT LEFFERTS GARDENS)", 
+      "name": " (PROSPECT LEFFERTS GARDENS)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1600.0, 
+      "name": "price",
+      "value": 1600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6494988353.html", 
+    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6494988353.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494983318.html", 
+    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494983318.html",
     "containedIn": {
-      "name": " (Carroll Gardens, Gowanus)", 
+      "name": " (Carroll Gardens, Gowanus)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3092.0, 
+      "name": "price",
+      "value": 3092.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494982711.html", 
+    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494982711.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3250.0, 
+      "name": "price",
+      "value": 3250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494982020.html", 
+    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494982020.html",
     "containedIn": {
-      "name": " (Carroll Gardens, Gowanus)", 
+      "name": " (Carroll Gardens, Gowanus)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL 2 BED TRIBECA STEPS TO BROADWAY - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-2-bed-tribeca-steps-to/6494968040.html", 
+    "name": "XL 2 BED TRIBECA STEPS TO BROADWAY - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-2-bed-tribeca-steps-to/6494968040.html",
     "containedIn": {
-      "name": " (TriBeCa)", 
+      "name": " (TriBeCa)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3800.0, 
+      "name": "price",
+      "value": 3800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Walls Of Floor to Ceiling Glass! Stunning ! #Downtown #Luxury #Views #", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6494964320.html", 
+    "name": "Walls Of Floor to Ceiling Glass! Stunning ! #Downtown #Luxury #Views #",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6494964320.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3000.0, 
+      "name": "price",
+      "value": 3000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Huge Luxury Loft with Sleeping Alcove, Separate Kitchen with Breakfast", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-luxury-loft-with/6494959976.html", 
+    "name": "Huge Luxury Loft with Sleeping Alcove, Separate Kitchen with Breakfast",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-luxury-loft-with/6494959976.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2850.0, 
+      "name": "price",
+      "value": 2850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Brand New LIC Full Service Luxury Apartments!! NO FEE + 2 MO FREE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-lic-full-service/6494939543.html", 
+    "name": "Brand New LIC Full Service Luxury Apartments!! NO FEE + 2 MO FREE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-lic-full-service/6494939543.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3934.0, 
+      "name": "price",
+      "value": 3934.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6494928442.html", 
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6494928442.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6494927324.html", 
+    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6494927324.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Gorgeous Large Studio, Expose Brick, 1 Block to Train, NO FEE!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-large-studio-expose/6494926476.html", 
+    "name": "Gorgeous Large Studio, Expose Brick, 1 Block to Train, NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-large-studio-expose/6494926476.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1895.0, 
+      "name": "price",
+      "value": 1895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6494923511.html", 
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6494923511.html",
     "containedIn": {
-      "name": " (Prospect Heights)", 
+      "name": " (Prospect Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2175.0, 
+      "name": "price",
+      "value": 2175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494902932.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494902932.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Laundry, Great Location, Spacious!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494901597.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Laundry, Great Location, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494901597.html",
     "containedIn": {
-      "name": " (Astoria)", 
+      "name": " (Astoria)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494900754.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494900754.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2765.0, 
+      "name": "price",
+      "value": 2765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AMAZING 1 Bedroom Apartment! *MUST SEE*", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-1-bedroom-apartment/6494895715.html", 
+    "name": "AMAZING 1 Bedroom Apartment! *MUST SEE*",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-1-bedroom-apartment/6494895715.html",
     "containedIn": {
-      "name": " (Mt. Vernon)", 
+      "name": " (Mt. Vernon)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1575.0, 
+      "name": "price",
+      "value": 1575.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful Studio Apartment Available for Immediate Move-in!", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/beautiful-studio-apartment/6494891581.html", 
+    "name": "Beautiful Studio Apartment Available for Immediate Move-in!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/beautiful-studio-apartment/6494891581.html",
     "containedIn": {
-      "name": " (Bronx Park East)", 
+      "name": " (Bronx Park East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1525.0, 
+      "name": "price",
+      "value": 1525.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494886774.html", 
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494886774.html",
     "containedIn": {
-      "name": " (Ditmas park / Cortelyou Rd)", 
+      "name": " (Ditmas park / Cortelyou Rd)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u25baSoho/LOFTSTYLE$1665,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1665hi-ceilngwk/6494874792.html", 
+    "name": "►Soho/LOFTSTYLE$1665,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1665hi-ceilngwk/6494874792.html",
     "containedIn": {
-      "name": " (STAMFORD, CT)", 
+      "name": " (STAMFORD, CT)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1665.0, 
+      "name": "price",
+      "value": 1665.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u25ba\u25ba\u25baHarborpoint,Concierge,  1BR $1798,HRDWD,W/D,Pool,Gym,Gar,", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/harborpointconcierge-1br/6494873652.html", 
+    "name": "►►►Harborpoint,Concierge,  1BR $1798,HRDWD,W/D,Pool,Gym,Gar,",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/harborpointconcierge-1br/6494873652.html",
     "containedIn": {
-      "name": " (Stamford)", 
+      "name": " (Stamford)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1798.0, 
+      "name": "price",
+      "value": 1798.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE ! Spacious 3 Bedroom All utilities included UES / Harlem", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-spacious-3-bedroom-all/6494873144.html", 
+    "name": "NO FEE ! Spacious 3 Bedroom All utilities included UES / Harlem",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-spacious-3-bedroom-all/6494873144.html",
     "containedIn": {
-      "name": " (East Harlem)", 
+      "name": " (East Harlem)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1830,SS Kit,HRDWD,Gym,W/D,Gar,Terr", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6494872684.html", 
+    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1830,SS Kit,HRDWD,Gym,W/D,Gar,Terr",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6494872684.html",
     "containedIn": {
-      "name": " (Stamford)", 
+      "name": " (Stamford)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1830.0, 
+      "name": "price",
+      "value": 1830.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6494866375.html", 
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6494866375.html",
     "containedIn": {
-      "name": " (Rego Park)", 
+      "name": " (Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2150.0, 
+      "name": "price",
+      "value": 2150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494861013.html", 
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494861013.html",
     "containedIn": {
-      "name": " (FLUSHING)", 
+      "name": " (FLUSHING)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Avail March 1~ Newly renovated True 2 bed/1bath~ Near Subway~Wont Last", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-newly-renovated/6494854889.html", 
+    "name": "Avail March 1~ Newly renovated True 2 bed/1bath~ Near Subway~Wont Last",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-newly-renovated/6494854889.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2595.0, 
+      "name": "price",
+      "value": 2595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1MONTH FREE,1BEDR CLOSE TO MURRAY HILL LIRR STATION, FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1month-free1bedr-close/6494850081.html", 
+    "name": "NO FEE+1MONTH FREE,1BEDR CLOSE TO MURRAY HILL LIRR STATION, FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1month-free1bedr-close/6494850081.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6494846751.html", 
+    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6494846751.html",
     "containedIn": {
-      "name": " (East Flatbush)", 
+      "name": " (East Flatbush)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1475.0, 
+      "name": "price",
+      "value": 1475.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WoW! Prime Location !!Rite off Central PARK!Renovated!!NO BROKER FEEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-prime-location-rite-off/6494846361.html", 
+    "name": "WoW! Prime Location !!Rite off Central PARK!Renovated!!NO BROKER FEEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-prime-location-rite-off/6494846361.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV, 2BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6494842091.html", 
+    "name": "NO FEE! NEWLY RENOV, 2BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6494842091.html",
     "containedIn": {
-      "name": " (Flushing)", 
+      "name": " (Flushing)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2232.0, 
+      "name": "price",
+      "value": 2232.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "AWESOME NO FEE !!!  3 BR W/ EXPOSED BRICK WALL AND HIGH CEILINGS !!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-3-br-exposed/6494841522.html", 
+    "name": "AWESOME NO FEE !!!  3 BR W/ EXPOSED BRICK WALL AND HIGH CEILINGS !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-3-br-exposed/6494841522.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6494839888.html", 
+    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6494839888.html",
     "containedIn": {
-      "name": " (holywood ave)", 
+      "name": " (holywood ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1638.0, 
+      "name": "price",
+      "value": 1638.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494838449.html", 
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494838449.html",
     "containedIn": {
-      "name": " (Flushing)", 
+      "name": " (Flushing)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6494829728.html", 
+    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6494829728.html",
     "containedIn": {
-      "name": " (Prospect Lffert Gardens)", 
+      "name": " (Prospect Lffert Gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2124.0, 
+      "name": "price",
+      "value": 2124.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!   1672 E 22 Street. 2 bed/2 bath unit with balconies", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feestreet-2-bed-2-bath/6494822740.html", 
+    "name": "NO FEE!   1672 E 22 Street. 2 bed/2 bath unit with balconies",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feestreet-2-bed-2-bath/6494822740.html",
     "containedIn": {
-      "name": " (Madison)", 
+      "name": " (Madison)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Room available in a comfortable 3br LES apt with great roommates", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-room-available-in/6494804220.html", 
+    "name": "1 Room available in a comfortable 3br LES apt with great roommates",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-room-available-in/6494804220.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1665.0, 
+      "name": "price",
+      "value": 1665.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***IMMACULATE RIVERDALE 1 BEDS ***AVAILABLE NOW!***", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-1-beds/6494802093.html", 
+    "name": "***IMMACULATE RIVERDALE 1 BEDS ***AVAILABLE NOW!***",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-1-beds/6494802093.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1950.0, 
+      "name": "price",
+      "value": 1950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUNNING ONE BEDROOM APARTMENT!", 
-    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6494799559.html", 
+    "name": "STUNNING ONE BEDROOM APARTMENT!",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6494799559.html",
     "containedIn": {
-      "name": " (staten island)", 
+      "name": " (staten island)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1200.0, 
+      "name": "price",
+      "value": 1200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494798495.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494798495.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***IMMACULATE RIVERDALE 2 BEDS // ***LOW PRICES AND HUGE LAYOUTS", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-2-beds/6494797714.html", 
+    "name": "***IMMACULATE RIVERDALE 2 BEDS // ***LOW PRICES AND HUGE LAYOUTS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-2-beds/6494797714.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2225.0, 
+      "name": "price",
+      "value": 2225.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6494796937.html", 
+    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6494796937.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS 1 BEDS [FORT WASHINGTON AREA] -- GREAT RENOVATIONS {NO FEE}", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-beds-fort/6494792695.html", 
+    "name": "SPACIOUS 1 BEDS [FORT WASHINGTON AREA] -- GREAT RENOVATIONS {NO FEE}",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-beds-fort/6494792695.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Private balcony,Corner Apt,Amazing amenities,Wash&dry*Lots of clos", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/private-balconycorner/6494792448.html", 
+    "name": "Private balcony,Corner Apt,Amazing amenities,Wash&dry*Lots of clos",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/private-balconycorner/6494792448.html",
     "containedIn": {
-      "name": " (Downtown Brooklyn)", 
+      "name": " (Downtown Brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4142.0, 
+      "name": "price",
+      "value": 4142.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6494792500.html", 
+    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6494792500.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494792437.html", 
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494792437.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5349.0, 
+      "name": "price",
+      "value": 5349.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6494792370.html", 
+    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6494792370.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6494792314.html", 
+    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6494792314.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "STUDIOS FOR RENT -- GREATER HARLEM AREAS *NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/studios-for-rent-greater/6494792168.html", 
+    "name": "STUDIOS FOR RENT -- GREATER HARLEM AREAS *NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studios-for-rent-greater/6494792168.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***EXCLUSIVE RIVERDALE 1 BEDS *** HUGE LAYOUTS -- GREAT RENOVATIONS", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-1-beds/6494792013.html", 
+    "name": "***EXCLUSIVE RIVERDALE 1 BEDS *** HUGE LAYOUTS -- GREAT RENOVATIONS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-1-beds/6494792013.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***EXCLUSIVE RIVERDALE 2 BEDS *** HUGE SUNLIT LAYOUTS", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-2-beds/6494791848.html", 
+    "name": "***EXCLUSIVE RIVERDALE 2 BEDS *** HUGE SUNLIT LAYOUTS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-2-beds/6494791848.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6494788697.html", 
+    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6494788697.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5097.0, 
+      "name": "price",
+      "value": 5097.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 100th St - 3 Bed 1.5 Bath - Laundry - FREE UTILITIES - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-100th-st-3-bed-15-bath/6494786507.html", 
+    "name": "East 100th St - 3 Bed 1.5 Bath - Laundry - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-100th-st-3-bed-15-bath/6494786507.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3095.0, 
+      "name": "price",
+      "value": 3095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6494786203.html", 
+    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6494786203.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4395.0, 
+      "name": "price",
+      "value": 4395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "East 91st & York Ave - 1 BED - Luxury, Gym - ONE FREE MONTH - NO F", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-york-ave-1-bed/6494785843.html", 
+    "name": "East 91st & York Ave - 1 BED - Luxury, Gym - ONE FREE MONTH - NO F",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-york-ave-1-bed/6494785843.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2929.0, 
+      "name": "price",
+      "value": 2929.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6494784257.html", 
+    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6494784257.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE//59th&1st**QUEEN BEDS<<AWESOME LIGHT!!ELEVATOR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-59th1stqueen/6494777085.html", 
+    "name": "NO FEE//59th&1st**QUEEN BEDS<<AWESOME LIGHT!!ELEVATOR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-59th1stqueen/6494777085.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2800.0, 
+      "name": "price",
+      "value": 2800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE**45th&Lex//MASSIVE STUDIO<3open House!!NEW.RENO.", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee45thlex-massive/6494773800.html", 
+    "name": "NO FEE**45th&Lex//MASSIVE STUDIO<3open House!!NEW.RENO.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee45thlex-massive/6494773800.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6494712081.html", 
+    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6494712081.html",
     "containedIn": {
-      "name": " (GREENPOINT)", 
+      "name": " (GREENPOINT)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3599.0, 
+      "name": "price",
+      "value": 3599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494706179.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494706179.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494700308.html", 
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494700308.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5349.0, 
+      "name": "price",
+      "value": 5349.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udd25\ud83d\udd25\ud83d\udd25 STUNNING 2 BR APARTMENT IN GREAT LOCATION", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-br-apartment-in/6494697693.html", 
+    "name": "🔥🔥🔥 STUNNING 2 BR APARTMENT IN GREAT LOCATION",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-br-apartment-in/6494697693.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udd25\ud83d\udd25\ud83d\udd25 STUNNING 3 BR APARTMENT IN PRIME LOCATION", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3-br-apartment-in/6494693656.html", 
+    "name": "🔥🔥🔥 STUNNING 3 BR APARTMENT IN PRIME LOCATION",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3-br-apartment-in/6494693656.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5000.0, 
+      "name": "price",
+      "value": 5000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***NO FEE*** SPACIOUS 1 BED W/ EXPOSED BRICK & GREAT NATURAL SUNLIGHT", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bed-exposed/6494677446.html", 
+    "name": "***NO FEE*** SPACIOUS 1 BED W/ EXPOSED BRICK & GREAT NATURAL SUNLIGHT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bed-exposed/6494677446.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2175.0, 
+      "name": "price",
+      "value": 2175.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE SPACIOUS 2 BEDROOM IN CROWN HEIGHTS W/ BEAUTIFUL FRENCH DOORS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-2-bedroom-in/6494667328.html", 
+    "name": "NO FEE SPACIOUS 2 BEDROOM IN CROWN HEIGHTS W/ BEAUTIFUL FRENCH DOORS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-2-bedroom-in/6494667328.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2400.0, 
+      "name": "price",
+      "value": 2400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494665306.html", 
+    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494665306.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494662655.html", 
+    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494662655.html",
     "containedIn": {
-      "name": " (Crown Heights)", 
+      "name": " (Crown Heights)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1870.0, 
+      "name": "price",
+      "value": 1870.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large One Bedroom/Furnished/ King bed/2 Murphy beds (double & single)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-one-bedroom-furnished/6494616829.html", 
+    "name": "Large One Bedroom/Furnished/ King bed/2 Murphy beds (double & single)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-one-bedroom-furnished/6494616829.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE + 1 Month fee* Real pictures !!! Real 2BR", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-fee-real/6494605791.html", 
+    "name": "NO FEE + 1 Month fee* Real pictures !!! Real 2BR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-fee-real/6494605791.html",
     "containedIn": {
-      "name": " (Lower East Side)", 
+      "name": " (Lower East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6494595797.html", 
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6494595797.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3250.0, 
+      "name": "price",
+      "value": 3250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, VIEWS, LARGE SPACE, DOORMAN, POOL, GYM, SAUNA", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-views-large-space/6494594502.html", 
+    "name": "NO FEE, VIEWS, LARGE SPACE, DOORMAN, POOL, GYM, SAUNA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-views-large-space/6494594502.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4400.0, 
+      "name": "price",
+      "value": 4400.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6494579504.html", 
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6494579504.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2795.0, 
+      "name": "price",
+      "value": 2795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6494578837.html", 
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6494578837.html",
     "containedIn": {
-      "name": " (Nolita / Bowery)", 
+      "name": " (Nolita / Bowery)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6494578300.html", 
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6494578300.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6494577810.html", 
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6494577810.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3295.0, 
+      "name": "price",
+      "value": 3295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6494577386.html", 
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6494577386.html",
     "containedIn": {
-      "name": " (Gramercy)", 
+      "name": " (Gramercy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bright and sunny 1 bedroom duplex apartment in Union Sq elevator build", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/bright-and-sunny-1-bedroom/6494567274.html", 
+    "name": "Bright and sunny 1 bedroom duplex apartment in Union Sq elevator build",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bright-and-sunny-1-bedroom/6494567274.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4150.0, 
+      "name": "price",
+      "value": 4150.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Nice Bushwick Studio \u2022 Perfect for Single or Couple {No Fee} Must See", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-bushwick-studio-perfect/6494565490.html", 
+    "name": "Nice Bushwick Studio • Perfect for Single or Couple {No Fee} Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-bushwick-studio-perfect/6494565490.html",
     "containedIn": {
-      "name": " (Broadway @ J,M,Z train Halsey)", 
+      "name": " (Broadway @ J,M,Z train Halsey)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy", 
-    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6494565369.html", 
+    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6494565369.html",
     "containedIn": {
-      "name": " (Riverdale)", 
+      "name": " (Riverdale)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Astonishing 2 Bed with a Terrace", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/astonishing-2-bed-with-terrace/6494559982.html", 
+    "name": "Astonishing 2 Bed with a Terrace",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/astonishing-2-bed-with-terrace/6494559982.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3995.0, 
+      "name": "price",
+      "value": 3995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Month Free + No Broker Fee 1 Bedroom Upper East Side", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-no-broker-fee-1/6494555259.html", 
+    "name": "1 Month Free + No Broker Fee 1 Bedroom Upper East Side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-no-broker-fee-1/6494555259.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "OPEN HOUSE(S)~~NO FEE!  E. 60'S~~E. 70's~~BEST DEALS UES~~646.247.6444", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-housesno-fee-60se/6494536832.html", 
+    "name": "OPEN HOUSE(S)~~NO FEE!  E. 60'S~~E. 70's~~BEST DEALS UES~~646.247.6444",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-housesno-fee-60se/6494536832.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1695.0, 
+      "name": "price",
+      "value": 1695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful 2 Bed", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-2-bed/6494530514.html", 
+    "name": "Beautiful 2 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-2-bed/6494530514.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL 1-BR + 2 MONTHS FREE RENT + KING-SIZED BR + ELEVATOR/LAUNDRY", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-br-2-months-free/6494528170.html", 
+    "name": "BEAUTIFUL 1-BR + 2 MONTHS FREE RENT + KING-SIZED BR + ELEVATOR/LAUNDRY",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-br-2-months-free/6494528170.html",
     "containedIn": {
-      "name": " (Cobble Hill)", 
+      "name": " (Cobble Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! TREU 2 BED APT W VIEWS!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6494525169.html", 
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! TREU 2 BED APT W VIEWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6494525169.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3445.0, 
+      "name": "price",
+      "value": 3445.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW!!! ----NO BROKER FEE--2BR 1bt APT!!!!! NEW LUXURY BUILDING!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-no-broker-fee-2br-1bt-apt/6494493983.html", 
+    "name": "WOW!!! ----NO BROKER FEE--2BR 1bt APT!!!!! NEW LUXURY BUILDING!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-no-broker-fee-2br-1bt-apt/6494493983.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3090.0, 
+      "name": "price",
+      "value": 3090.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE STUDIO CITY VIEW WATERFRONT BALCONY 1STOP TO GRD CENTRAL LUXURY", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-studio-city-view/6494492433.html", 
+    "name": "NO FEE STUDIO CITY VIEW WATERFRONT BALCONY 1STOP TO GRD CENTRAL LUXURY",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-studio-city-view/6494492433.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE BRAND NEW BLDG  24HR CONCIERGE ROOF DECK GYM AMAZING VIEWS WATE", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-brand-new-bldg-24hr/6494490413.html", 
+    "name": "NO FEE BRAND NEW BLDG  24HR CONCIERGE ROOF DECK GYM AMAZING VIEWS WATE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-brand-new-bldg-24hr/6494490413.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LUXURY BLDG-24HR CONCIERGE-ROOF DECK-GYM AMAZING VIEWS WATERFRONT 5min", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-bldg-24hr-concierge/6494488063.html", 
+    "name": "LUXURY BLDG-24HR CONCIERGE-ROOF DECK-GYM AMAZING VIEWS WATERFRONT 5min",
+    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-bldg-24hr-concierge/6494488063.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2900.0, 
+      "name": "price",
+      "value": 2900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No fee - Large studio for 1 yr lease, best street in Manhattan!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-for-1-yr/6494475615.html", 
+    "name": "No fee - Large studio for 1 yr lease, best street in Manhattan!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-for-1-yr/6494475615.html",
     "containedIn": {
-      "name": " (Nolita / Bowery)", 
+      "name": " (Nolita / Bowery)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3135.0, 
+      "name": "price",
+      "value": 3135.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**NO FEE!!**LUX 24HR DM**GYM / POOL / SUNDECK**PRIME E 86th LOCATION**", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelux-24hr-dmgym-pool/6494460481.html", 
+    "name": "**NO FEE!!**LUX 24HR DM**GYM / POOL / SUNDECK**PRIME E 86th LOCATION**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelux-24hr-dmgym-pool/6494460481.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3790.0, 
+      "name": "price",
+      "value": 3790.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True 4 bed with Balcony and lots of closets space, For no brokers fee", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-4-bed-with-balcony-and/6494460233.html", 
+    "name": "True 4 bed with Balcony and lots of closets space, For no brokers fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-4-bed-with-balcony-and/6494460233.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6200.0, 
+      "name": "price",
+      "value": 6200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*3BR/2BA DUPLEX WITH 2PVT ROOFTOP SPACE E89TH BETWEEN 2ND AND 3RD AVE*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/3br-2ba-duplex-with-2pvt/6494456185.html", 
+    "name": "*3BR/2BA DUPLEX WITH 2PVT ROOFTOP SPACE E89TH BETWEEN 2ND AND 3RD AVE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3br-2ba-duplex-with-2pvt/6494456185.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6494455428.html", 
+    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6494455428.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***NO FEE*** GORGEOUS!!!! *BRAND NEW* Inwood 1 BEDROOM!!!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-brand-new/6494455347.html", 
+    "name": "***NO FEE*** GORGEOUS!!!! *BRAND NEW* Inwood 1 BEDROOM!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-brand-new/6494455347.html",
     "containedIn": {
-      "name": " (Inwood / Wash Hts)", 
+      "name": " (Inwood / Wash Hts)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!!! GUT RENOVATED STUDIO ***Sick DEAl***", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gut-renovated-studio/6494455062.html", 
+    "name": "NO FEE!!!! GUT RENOVATED STUDIO ***Sick DEAl***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gut-renovated-studio/6494455062.html",
     "containedIn": {
-      "name": " (new york)", 
+      "name": " (new york)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1450.0, 
+      "name": "price",
+      "value": 1450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494452065.html", 
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494452065.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 5349.0, 
+      "name": "price",
+      "value": 5349.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494447936.html", 
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494447936.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 27000.0, 
+      "name": "price",
+      "value": 27000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6494443347.html", 
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6494443347.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6494425727.html", 
+    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6494425727.html",
     "containedIn": {
-      "name": " (Crown Heights C,S at Franklin Av)", 
+      "name": " (Crown Heights C,S at Franklin Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Nice studio apartment-Prospect park-Great area- NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-studio-apartment/6494424927.html", 
+    "name": "Nice studio apartment-Prospect park-Great area- NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-studio-apartment/6494424927.html",
     "containedIn": {
-      "name": " (Crown Heights 3 at Nostrand Av)", 
+      "name": " (Crown Heights 3 at Nostrand Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1699.0, 
+      "name": "price",
+      "value": 1699.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6494424371.html", 
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6494424371.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)", 
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1999.0, 
+      "name": "price",
+      "value": 1999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6494423544.html", 
+    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6494423544.html",
     "containedIn": {
-      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)", 
+      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2295$ Large 1 bedroom!! Upper east side!!no Fee!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/2295-large-1-bedroom-upper/6494421662.html", 
+    "name": "2295$ Large 1 bedroom!! Upper east side!!no Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2295-large-1-bedroom-upper/6494421662.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6494421267.html", 
+    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6494421267.html",
     "containedIn": {
-      "name": " (Bedstuy @ A & C subway)", 
+      "name": " (Bedstuy @ A & C subway)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3099.0, 
+      "name": "price",
+      "value": 3099.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6494419762.html", 
+    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6494419762.html",
     "containedIn": {
-      "name": " (park slope @ F,G,R at 4 Av-9 St)", 
+      "name": " (park slope @ F,G,R at 4 Av-9 St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2599.0, 
+      "name": "price",
+      "value": 2599.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beneficial, awesome 4bd apartment  in UES!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/beneficial-awesome-4bd/6494419308.html", 
+    "name": "Beneficial, awesome 4bd apartment  in UES!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beneficial-awesome-4bd/6494419308.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3300.0, 
+      "name": "price",
+      "value": 3300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6494416757.html", 
+    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6494416757.html",
     "containedIn": {
-      "name": " (Ditmas Park @B,Q at Newkirk Av)", 
+      "name": " (Ditmas Park @B,Q at Newkirk Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6494411427.html", 
+    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6494411427.html",
     "containedIn": {
-      "name": " (Crown Heights @ A & C Nostrand ave)", 
+      "name": " (Crown Heights @ A & C Nostrand ave)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2799.0, 
+      "name": "price",
+      "value": 2799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6494409028.html", 
+    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6494409028.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Awesome studio with open, cute balcony!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-with-open-cute/6494408695.html", 
+    "name": "Awesome studio with open, cute balcony!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-with-open-cute/6494408695.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2226.0, 
+      "name": "price",
+      "value": 2226.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious Brownstone Floorthru", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-brownstone-floorthru/6494406551.html", 
+    "name": "Spacious Brownstone Floorthru",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-brownstone-floorthru/6494406551.html",
     "containedIn": {
-      "name": " (Park Slope)", 
+      "name": " (Park Slope)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6494403288.html", 
+    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6494403288.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO fee Biggie Mural building apartment for rent! 3BR 2Bath", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-biggie-mural-building/6494399640.html", 
+    "name": "NO fee Biggie Mural building apartment for rent! 3BR 2Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-biggie-mural-building/6494399640.html",
     "containedIn": {
-      "name": " (Bedford Stuyvasant)", 
+      "name": " (Bedford Stuyvasant)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2999.0, 
+      "name": "price",
+      "value": 2999.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE, 2 BED, UES!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bed-ues/6494396798.html", 
+    "name": "NO FEE, 2 BED, UES!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bed-ues/6494396798.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2050.0, 
+      "name": "price",
+      "value": 2050.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 bedroom in prime Bushwick-Large Living room-1 Month Broker fee", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-in-prime-bushwick/6494392833.html", 
+    "name": "2 bedroom in prime Bushwick-Large Living room-1 Month Broker fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-in-prime-bushwick/6494392833.html",
     "containedIn": {
-      "name": " (Bushwick @ L at DeKalb Av)", 
+      "name": " (Bushwick @ L at DeKalb Av)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "TRUE 2 BEDROOM AT 61ST AND 2ND GORGEOUS APARTMENT ** NO BROKER FEE **", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroom-at-61st-and/6494380706.html", 
+    "name": "TRUE 2 BEDROOM AT 61ST AND 2ND GORGEOUS APARTMENT ** NO BROKER FEE **",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroom-at-61st-and/6494380706.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494378582.html", 
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494378582.html",
     "containedIn": {
-      "name": " (Ditmas park / Cortelyou Rd)", 
+      "name": " (Ditmas park / Cortelyou Rd)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKERS FEE * HUGE Renovated Studio Apartment in SUNNYSIDE *7 Train", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-huge-renovated/6494376727.html", 
+    "name": "NO BROKERS FEE * HUGE Renovated Studio Apartment in SUNNYSIDE *7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-huge-renovated/6494376727.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful renovated 3 bedroom. Great for shares!!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-renovated-3-bedroom/6494375896.html", 
+    "name": "Beautiful renovated 3 bedroom. Great for shares!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-renovated-3-bedroom/6494375896.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Beautiful and cozy studio apartment! Great Area! Heat & Hot Water inc", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-and-cozy-studio/6494375207.html", 
+    "name": "Beautiful and cozy studio apartment! Great Area! Heat & Hot Water inc",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-and-cozy-studio/6494375207.html",
     "containedIn": {
-      "name": " (Crownheights @2,3 subway)", 
+      "name": " (Crownheights @2,3 subway)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1699.0, 
+      "name": "price",
+      "value": 1699.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "2 bedroom! Great area! Wont last!Williamsburg! NO FEE", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-great-area-wont/6494372773.html", 
+    "name": "2 bedroom! Great area! Wont last!Williamsburg! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-great-area-wont/6494372773.html",
     "containedIn": {
-      "name": " (Williamsburg @ L at Grand St)", 
+      "name": " (Williamsburg @ L at Grand St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Subway!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494369154.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Subway!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494369154.html",
     "containedIn": {
-      "name": " (Queens)", 
+      "name": " (Queens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "FULLY RENOVATED 3.5 BEDROOM HEAT AND HOT WATER INCL. PARKING EXTRA", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/fully-renovated-35-bedroom/6494366755.html", 
+    "name": "FULLY RENOVATED 3.5 BEDROOM HEAT AND HOT WATER INCL. PARKING EXTRA",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/fully-renovated-35-bedroom/6494366755.html",
     "containedIn": {
-      "name": " (BAY 26 STREET)", 
+      "name": " (BAY 26 STREET)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2395.0, 
+      "name": "price",
+      "value": 2395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6494366513.html", 
+    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6494366513.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3695.0, 
+      "name": "price",
+      "value": 3695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, renovated apts in a great location!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494366095.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, renovated apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494366095.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2095.0, 
+      "name": "price",
+      "value": 2095.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u239dNO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6494364172.html", 
+    "name": "⎝NO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6494364172.html",
     "containedIn": {
-      "name": " (Upper East Side / Roosevelt Island)", 
+      "name": " (Upper East Side / Roosevelt Island)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2265.0, 
+      "name": "price",
+      "value": 2265.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6494363016.html", 
+    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6494363016.html",
     "containedIn": {
-      "name": " (Red Hook)", 
+      "name": " (Red Hook)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2499.0, 
+      "name": "price",
+      "value": 2499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494361711.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494361711.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2745.0, 
+      "name": "price",
+      "value": 2745.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "1BD in Downtown Stamford + Large Closets & Parking Available!!!", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/1bd-in-downtown-stamford/6494344871.html", 
+    "name": "1BD in Downtown Stamford + Large Closets & Parking Available!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1bd-in-downtown-stamford/6494344871.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1499.0, 
+      "name": "price",
+      "value": 1499.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE, RENOVATED 3 BDR.  STEPS TO D TRAIN, BALCONY, 1.5 BATH  PARKING", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-renovated-3-bdr-steps-to/6494336802.html", 
+    "name": "HUGE, RENOVATED 3 BDR.  STEPS TO D TRAIN, BALCONY, 1.5 BATH  PARKING",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-renovated-3-bdr-steps-to/6494336802.html",
     "containedIn": {
-      "name": " (bensonhurst. brooklyn)", 
+      "name": " (bensonhurst. brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2295.0, 
+      "name": "price",
+      "value": 2295.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Enormous 1BD in Quiet Neighborhood + Washer/Dryer Inside the Unit!!!", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/enormous-1bd-in-quiet/6494325050.html", 
+    "name": "Enormous 1BD in Quiet Neighborhood + Washer/Dryer Inside the Unit!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/enormous-1bd-in-quiet/6494325050.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1695.0, 
+      "name": "price",
+      "value": 1695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6494317234.html", 
+    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6494317234.html",
     "containedIn": {
-      "name": " (Greenwood / 4th Ave & 27th St)", 
+      "name": " (Greenwood / 4th Ave & 27th St)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1795.0, 
+      "name": "price",
+      "value": 1795.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO BROKER FEE | Newly Renovated 1 Bed On Tree Lined Block", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-newly-renovated/6494314454.html", 
+    "name": "NO BROKER FEE | Newly Renovated 1 Bed On Tree Lined Block",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-newly-renovated/6494314454.html",
     "containedIn": {
-      "name": " (Bed Stuy)", 
+      "name": " (Bed Stuy)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "RIVER VIEWS___ 13ft HIGH CEILINGS___W/D IN UNIT___SWIMMING POOL", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/river-views-13ft-high/6494304885.html", 
+    "name": "RIVER VIEWS___ 13ft HIGH CEILINGS___W/D IN UNIT___SWIMMING POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/river-views-13ft-high/6494304885.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3550.0, 
+      "name": "price",
+      "value": 3550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6494303725.html", 
+    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6494303725.html",
     "containedIn": {
-      "name": " (Chelsea)", 
+      "name": " (Chelsea)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\ud83d\udd11AMAZING 2 Bed / Perfect share!_Live-in super_\ud83d\udc36PetOK\ud83d\udc31", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-2-bed-perfect/6494290463.html", 
+    "name": "🔑AMAZING 2 Bed / Perfect share!_Live-in super_🐶PetOK🐱",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-2-bed-perfect/6494290463.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3600.0, 
+      "name": "price",
+      "value": 3600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "===STUDIO APT RENOVATED=== UES===$1800==1 MONTH FREE!!===", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-apt-renovated-ues18001/6494290341.html", 
+    "name": "===STUDIO APT RENOVATED=== UES===$1800==1 MONTH FREE!!===",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-apt-renovated-ues18001/6494290341.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1800.0, 
+      "name": "price",
+      "value": 1800.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494289747.html", 
+    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494289747.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3475.0, 
+      "name": "price",
+      "value": 3475.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! massive 1 bedroom in \"PRIME P.L.G\" off the B,Q trains", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-massive-1-bedroom-in/6494286088.html", 
+    "name": "NO FEE! massive 1 bedroom in \"PRIME P.L.G\" off the B,Q trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-massive-1-bedroom-in/6494286088.html",
     "containedIn": {
-      "name": " (brooklyn)", 
+      "name": " (brooklyn)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1895.0, 
+      "name": "price",
+      "value": 1895.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494283335.html", 
+    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494283335.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3475.0, 
+      "name": "price",
+      "value": 3475.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6494277994.html", 
+    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6494277994.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2995.0, 
+      "name": "price",
+      "value": 2995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, Oversized Closets *Near Subways*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494266748.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, Oversized Closets *Near Subways*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494266748.html",
     "containedIn": {
-      "name": " (Sheepshead Bay)", 
+      "name": " (Sheepshead Bay)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens *Natural Light* & *Near Subway*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494265832.html", 
+    "name": "NO FEE RENTALS, Kings & Queens *Natural Light* & *Near Subway*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494265832.html",
     "containedIn": {
-      "name": " (Sunnyside)", 
+      "name": " (Sunnyside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City - Terrace, New Amenities!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494264729.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Terrace, New Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494264729.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3010.0, 
+      "name": "price",
+      "value": 3010.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing 1BR apt on E 30th St w. shared outdoor space in elev bldg!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-1br-apt-on-30th-st/6494253538.html", 
+    "name": "Amazing 1BR apt on E 30th St w. shared outdoor space in elev bldg!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-1br-apt-on-30th-st/6494253538.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!!!!!!!!!!!!!!!LOOK !!!REAL NO FEE AMAZING MIDTOWN TWO BEDROOM MUST SE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/look-real-no-fee-amazing/6494253086.html", 
+    "name": "!!!!!!!!!!!!!!!LOOK !!!REAL NO FEE AMAZING MIDTOWN TWO BEDROOM MUST SE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/look-real-no-fee-amazing/6494253086.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6494252595.html", 
+    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6494252595.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1750.0, 
+      "name": "price",
+      "value": 1750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6494251877.html", 
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6494251877.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6494249169.html", 
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6494249169.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6494248598.html", 
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6494248598.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4500.0, 
+      "name": "price",
+      "value": 4500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Room For Rent", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent/6494247819.html", 
+    "name": "Room For Rent",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent/6494247819.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 750.0, 
+      "name": "price",
+      "value": 750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Very large 1BR apt on 89th & 1st in elevator & laundry bldg ~ $2,300!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-1br-apt-on-89th/6494243370.html", 
+    "name": "Very large 1BR apt on 89th & 1st in elevator & laundry bldg ~ $2,300!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-1br-apt-on-89th/6494243370.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing No Fee+1Mnth Free 3 Bed/2Bth In Drmn/Elev/Gym/Lndry Building!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-3/6494233911.html", 
+    "name": "Amazing No Fee+1Mnth Free 3 Bed/2Bth In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-3/6494233911.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 6230.0, 
+      "name": "price",
+      "value": 6230.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!!!!!!!!!!!!TOTAL SCORE REAL TWO BED NO FEE MIDTOWN EAST!!!!!!!!!!!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/total-score-real-two-bed-no/6494230108.html", 
+    "name": "!!!!!!!!!!!!TOTAL SCORE REAL TWO BED NO FEE MIDTOWN EAST!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/total-score-real-two-bed-no/6494230108.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6494226614.html", 
+    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6494226614.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2756GORGEOUS TWO  BD\u2756 \u25c6NO FEE\u25c6NEW RENO\u25c6PetOK", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-two-bd-no-feenew/6494225609.html", 
+    "name": "❖GORGEOUS TWO  BD❖ ◆NO FEE◆NEW RENO◆PetOK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-two-bd-no-feenew/6494225609.html",
     "containedIn": {
-      "name": " (East Village)", 
+      "name": " (East Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3700.0, 
+      "name": "price",
+      "value": 3700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "ASAP MOVE IN__GOURMET KITCHEN__LUXURY BATHROOM__29X13 LIVING ROOM", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-ingourmet/6494222069.html", 
+    "name": "ASAP MOVE IN__GOURMET KITCHEN__LUXURY BATHROOM__29X13 LIVING ROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-ingourmet/6494222069.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2908.0, 
+      "name": "price",
+      "value": 2908.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6494219626.html", 
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6494219626.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3495.0, 
+      "name": "price",
+      "value": 3495.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Spacious NO FEE 1BR Lincoln Suqare Doorman Dishwasher TRADER JOES", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-no-fee-1br-lincoln/6494217643.html", 
+    "name": "Spacious NO FEE 1BR Lincoln Suqare Doorman Dishwasher TRADER JOES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-no-fee-1br-lincoln/6494217643.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2605\u2605\u2605HUGE DUPLEX 2BR(flex3)/1.5ba off DEKALB L!\u2605\u2605", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-duplex-2brflex3-15ba-off/6494212771.html", 
+    "name": "★★★HUGE DUPLEX 2BR(flex3)/1.5ba off DEKALB L!★★",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-duplex-2brflex3-15ba-off/6494212771.html",
     "containedIn": {
-      "name": " (Bushwick)", 
+      "name": " (Bushwick)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2825.0, 
+      "name": "price",
+      "value": 2825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "$$$$  NO FEE  $$$$ (2) BEDROOM $$$$  ONLY 2,100  $$$$ UPPER EAST SIDE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-only-2100/6494201721.html", 
+    "name": "$$$$  NO FEE  $$$$ (2) BEDROOM $$$$  ONLY 2,100  $$$$ UPPER EAST SIDE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-only-2100/6494201721.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2100.0, 
+      "name": "price",
+      "value": 2100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Mint studio in luxury downtown brooklyn building full service", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/mint-studio-in-luxury/6494199703.html", 
+    "name": "Mint studio in luxury downtown brooklyn building full service",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/mint-studio-in-luxury/6494199703.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Live in Prime Clinton Hill - Steps to  A/C Trains!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-clinton-hill/6494196018.html", 
+    "name": "Live in Prime Clinton Hill - Steps to  A/C Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-clinton-hill/6494196018.html",
     "containedIn": {
-      "name": " (Clinton Hill)", 
+      "name": " (Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1900.0, 
+      "name": "price",
+      "value": 1900.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Close to Transport, Laundry*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494192102.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Close to Transport, Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494192102.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2125.0, 
+      "name": "price",
+      "value": 2125.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "20th FLOOR______OVERSIZED WINDOWS_____WATER VIEWS____NEW RENOVATION", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/20th-flooroversized/6494186521.html", 
+    "name": "20th FLOOR______OVERSIZED WINDOWS_____WATER VIEWS____NEW RENOVATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/20th-flooroversized/6494186521.html",
     "containedIn": {
-      "name": " (Battery Park)", 
+      "name": " (Battery Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2550.0, 
+      "name": "price",
+      "value": 2550.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6494178081.html", 
+    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6494178081.html",
     "containedIn": {
-      "name": " (Bed Stuy / Clinton Hill)", 
+      "name": " (Bed Stuy / Clinton Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1799.0, 
+      "name": "price",
+      "value": 1799.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "$$$$  1825  $$$$$ NO FEE $$$$ LARGE (1) BEDROOM $$$$ Upper East Side (", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/1825-no-fee-large-1-bedroom/6494178008.html", 
+    "name": "$$$$  1825  $$$$$ NO FEE $$$$ LARGE (1) BEDROOM $$$$ Upper East Side (",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1825-no-fee-large-1-bedroom/6494178008.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1825.0, 
+      "name": "price",
+      "value": 1825.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Awesome No Fee Studio with Original Details in Great Location! No Fee!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-studio-with/6494176573.html", 
+    "name": "Awesome No Fee Studio with Original Details in Great Location! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-studio-with/6494176573.html",
     "containedIn": {
-      "name": " (Crown Heights@ Nostrand 3)", 
+      "name": " (Crown Heights@ Nostrand 3)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1699.0, 
+      "name": "price",
+      "value": 1699.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sweet 2BR in Great Bushwick Location | No Fee | Great Deal!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sweet-2br-in-great-bushwick/6494174049.html", 
+    "name": "Sweet 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sweet-2br-in-great-bushwick/6494174049.html",
     "containedIn": {
-      "name": " (Bushwick @ Gates JMZ)", 
+      "name": " (Bushwick @ Gates JMZ)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1995.0, 
+      "name": "price",
+      "value": 1995.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Large 3BR close to the B/Q Trains! Great Deal! No Fee ~ Must See!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3br-close-to-the-q/6494171210.html", 
+    "name": "Large 3BR close to the B/Q Trains! Great Deal! No Fee ~ Must See!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3br-close-to-the-q/6494171210.html",
     "containedIn": {
-      "name": " (Ditmas Park @ Newkirk B/Q)", 
+      "name": " (Ditmas Park @ Newkirk B/Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2199.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Excellent No Fee Studio | Exposed Brick | Great Area | Easy Commute!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/excellent-no-fee-studio/6494164489.html", 
+    "name": "Excellent No Fee Studio | Exposed Brick | Great Area | Easy Commute!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/excellent-no-fee-studio/6494164489.html",
     "containedIn": {
-      "name": " (Crown Heights@ Franklin 2,3,4,5)", 
+      "name": " (Crown Heights@ Franklin 2,3,4,5)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1700.0, 
+      "name": "price",
+      "value": 1700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BRAND NEW HIGH END LUXURY BUILDING, COMPLIMENTARY AMENITIES, PERFECT L", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-high-end-luxury/6494160084.html", 
+    "name": "BRAND NEW HIGH END LUXURY BUILDING, COMPLIMENTARY AMENITIES, PERFECT L",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-high-end-luxury/6494160084.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2390.0, 
+      "name": "price",
+      "value": 2390.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "$2950 / 1br - GORGEOUS Luxury waterfront 1br Greenpoint", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/2950-1br-gorgeous-luxury/6494157117.html", 
+    "name": "$2950 / 1br - GORGEOUS Luxury waterfront 1br Greenpoint",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2950-1br-gorgeous-luxury/6494157117.html",
     "containedIn": {
-      "name": null, 
+      "name": null,
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2950.0, 
+      "name": "price",
+      "value": 2950.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6494136366.html", 
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6494136366.html",
     "containedIn": {
-      "name": " (Forest Hills / Rego Park)", 
+      "name": " (Forest Hills / Rego Park)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3200.0, 
+      "name": "price",
+      "value": 3200.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Delightfully Gorgeous 1BD in Downtown Stamford + Washer/Dryer in Unit!", 
-    "url": "https://newyork.craigslist.org/fct/nfb/d/delightfully-gorgeous-1bd-in/6494134581.html", 
+    "name": "Delightfully Gorgeous 1BD in Downtown Stamford + Washer/Dryer in Unit!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/delightfully-gorgeous-1bd-in/6494134581.html",
     "containedIn": {
-      "name": " (Stamford)", 
+      "name": " (Stamford)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1625.0, 
+      "name": "price",
+      "value": 1625.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Make Your Friends Jealous!!! NO FEE!! LARGE TRUE 1BR Tennis Courts Gym", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/make-your-friends-jealous-no/6494124639.html", 
+    "name": "Make Your Friends Jealous!!! NO FEE!! LARGE TRUE 1BR Tennis Courts Gym",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/make-your-friends-jealous-no/6494124639.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2700.0, 
+      "name": "price",
+      "value": 2700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE & 1 MONTH FREE/ 2 BEDROOM WITH OCEAN VIEWS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-2-bedroom/6494119294.html", 
+    "name": "NO FEE & 1 MONTH FREE/ 2 BEDROOM WITH OCEAN VIEWS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-2-bedroom/6494119294.html",
     "containedIn": {
-      "name": " (Brighton Beach)", 
+      "name": " (Brighton Beach)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2600.0, 
+      "name": "price",
+      "value": 2600.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Broker Fee & Free Rent in Gorgeous & Sunny UWS Studio", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-free-rent-in/6494111476.html", 
+    "name": "No Broker Fee & Free Rent in Gorgeous & Sunny UWS Studio",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-free-rent-in/6494111476.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2300.0, 
+      "name": "price",
+      "value": 2300.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "newly renovated", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6494095590.html", 
+    "name": "newly renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6494095590.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Harlem / Morningside)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2695.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494095051.html", 
+    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494095051.html",
     "containedIn": {
-      "name": " (Carroll Gardens, Gowanus)", 
+      "name": " (Carroll Gardens, Gowanus)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3092.0, 
+      "name": "price",
+      "value": 3092.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494094518.html", 
+    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494094518.html",
     "containedIn": {
-      "name": " (Carroll Gardens, Gowanus)", 
+      "name": " (Carroll Gardens, Gowanus)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494093888.html", 
+    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494093888.html",
     "containedIn": {
-      "name": " (Williamsburg)", 
+      "name": " (Williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3250.0, 
+      "name": "price",
+      "value": 3250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6494089369.html", 
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6494089369.html",
     "containedIn": {
-      "name": " (Upper West Side)", 
+      "name": " (Upper West Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6494088123.html", 
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6494088123.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2500.0, 
+      "name": "price",
+      "value": 2500.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6494087221.html", 
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6494087221.html",
     "containedIn": {
-      "name": " (Murray Hill)", 
+      "name": " (Murray Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "PRIME LOCATION. BRAND NEW APT, NO BROKER FEE + 1 MONTH FREE, AMAZING D", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-location-brand-new-apt/6494082498.html", 
+    "name": "PRIME LOCATION. BRAND NEW APT, NO BROKER FEE + 1 MONTH FREE, AMAZING D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-location-brand-new-apt/6494082498.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2857.0, 
+      "name": "price",
+      "value": 2857.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE - TOP FLOOR LOFT SPACE - Manhattan View- DM, Garage, Roof Deck", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-top-floor-loft-space/6494071187.html", 
+    "name": "NO FEE - TOP FLOOR LOFT SPACE - Manhattan View- DM, Garage, Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-top-floor-loft-space/6494071187.html",
     "containedIn": {
-      "name": " (Clinton Hill/Wallabout/Navy Yard)", 
+      "name": " (Clinton Hill/Wallabout/Navy Yard)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3093.0, 
+      "name": "price",
+      "value": 3093.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6494068587.html", 
+    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6494068587.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2650.0, 
+      "name": "price",
+      "value": 2650.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6494067822.html", 
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6494067822.html",
     "containedIn": {
-      "name": " (Upper East Side)", 
+      "name": " (Upper East Side)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "!!!!!!!!JUST LOOK AT THIS AMAZING NO FEE REAL TWO BEDROOM !!!!!!!!!!!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-look-at-this-amazing-no/6494067318.html", 
+    "name": "!!!!!!!!JUST LOOK AT THIS AMAZING NO FEE REAL TWO BEDROOM !!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-look-at-this-amazing-no/6494067318.html",
     "containedIn": {
-      "name": " (Midtown West)", 
+      "name": " (Midtown West)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2250.0, 
+      "name": "price",
+      "value": 2250.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494059637.html", 
+    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494059637.html",
     "containedIn": {
-      "name": " (Bay Ridge)", 
+      "name": " (Bay Ridge)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1395.0, 
+      "name": "price",
+      "value": 1395.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bright, King Size 1 Bedroom in Cobble Hill w/ Floor to Ceiling Windows", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-king-size-1-bedroom-in/6494054510.html", 
+    "name": "Bright, King Size 1 Bedroom in Cobble Hill w/ Floor to Ceiling Windows",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-king-size-1-bedroom-in/6494054510.html",
     "containedIn": {
-      "name": " (Cobble Hill)", 
+      "name": " (Cobble Hill)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2750.0, 
+      "name": "price",
+      "value": 2750.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NEW LARGE ONE BED..A,C,G TRAIN..ReNOVaTED..PRIME LOCATION..NEAR ALL..", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/new-large-one-bedacg/6494053552.html", 
+    "name": "NEW LARGE ONE BED..A,C,G TRAIN..ReNOVaTED..PRIME LOCATION..NEAR ALL..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-large-one-bedacg/6494053552.html",
     "containedIn": {
-      "name": " (Clinton hill / ft Greene)", 
+      "name": " (Clinton hill / ft Greene)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1850.0, 
+      "name": "price",
+      "value": 1850.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494048572.html", 
+    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494048572.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1675.0, 
+      "name": "price",
+      "value": 1675.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "LARGE STUDIO 1 MIN WALK TO FULTON SUBWAY - NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-1-min-walk-to/6494046659.html", 
+    "name": "LARGE STUDIO 1 MIN WALK TO FULTON SUBWAY - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-1-min-walk-to/6494046659.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2377.0, 
+      "name": "price",
+      "value": 2377.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6494043743.html", 
+    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6494043743.html",
     "containedIn": {
-      "name": " (Financial District)", 
+      "name": " (Financial District)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3100.0, 
+      "name": "price",
+      "value": 3100.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive 1 BR Luxury in Greenwich Village!!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6494040700.html", 
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6494040700.html",
     "containedIn": {
-      "name": " (Greenwich Village)", 
+      "name": " (Greenwich Village)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 4000.0, 
+      "name": "price",
+      "value": 4000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494040704.html", 
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494040704.html",
     "containedIn": {
-      "name": " (Corona)", 
+      "name": " (Corona)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2765.0, 
+      "name": "price",
+      "value": 2765.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE+1 Month Free - RARE LOFT SPACE - Doorman, Garage, Roof Deck", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee1-month-free-rare-loft/6494032892.html", 
+    "name": "NO FEE+1 Month Free - RARE LOFT SPACE - Doorman, Garage, Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee1-month-free-rare-loft/6494032892.html",
     "containedIn": {
-      "name": " (Clinton Hill/Wallabout/Navy Yard)", 
+      "name": " (Clinton Hill/Wallabout/Navy Yard)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3025.0, 
+      "name": "price",
+      "value": 3025.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "NO FEE--- If you find a better deal, Ill quit real estate", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-if-you-find-better/6494032380.html", 
+    "name": "NO FEE--- If you find a better deal, Ill quit real estate",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-if-you-find-better/6494032380.html",
     "containedIn": {
-      "name": " (williamsburg)", 
+      "name": " (williamsburg)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3700.0, 
+      "name": "price",
+      "value": 3700.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Bedroom for rent in 3 bedroom duplex!", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/bedroom-for-rent-in-3-bedroom/6494025957.html", 
+    "name": "Bedroom for rent in 3 bedroom duplex!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bedroom-for-rent-in-3-bedroom/6494025957.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1350.0, 
+      "name": "price",
+      "value": 1350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "BEAUTIFUL LARGE 1BD - CLOSE WALK TO PROSPECT PARK AND 2,5,B,Q TRAINS", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1bd-close/6494024948.html", 
+    "name": "BEAUTIFUL LARGE 1BD - CLOSE WALK TO PROSPECT PARK AND 2,5,B,Q TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1bd-close/6494024948.html",
     "containedIn": {
-      "name": " (prospect lefferts gardens)", 
+      "name": " (prospect lefferts gardens)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 1595.0, 
+      "name": "price",
+      "value": 1595.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Cold Spring apartment, Close to Town!", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/cold-spring-apartment-close/6494023978.html", 
+    "name": "Cold Spring apartment, Close to Town!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/cold-spring-apartment-close/6494023978.html",
     "containedIn": {
-      "name": " (1698 Route 9D)", 
+      "name": " (1698 Route 9D)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 2000.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Massive Prime Midtown East One Bedroom Gem! Doorman/Gym/Laundry NO FEE", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-prime-midtown-east/6494018177.html", 
+    "name": "Massive Prime Midtown East One Bedroom Gem! Doorman/Gym/Laundry NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-prime-midtown-east/6494018177.html",
     "containedIn": {
-      "name": " (Midtown East)", 
+      "name": " (Midtown East)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 3255.0, 
+      "name": "price",
+      "value": 3255.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "Hudson Views: 1hr to GCT, walk 2 train, close to West Point, trails", 
-    "url": "https://newyork.craigslist.org/wch/nfb/d/hudson-views-1hr-to-gct-walk/6494018059.html", 
+    "name": "Hudson Views: 1hr to GCT, walk 2 train, close to West Point, trails",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/hudson-views-1hr-to-gct-walk/6494018059.html",
     "containedIn": {
-      "name": " (Garrison)", 
+      "name": " (Garrison)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2350.0, 
+      "name": "price",
+      "value": 2350.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\u2764 Wonderful Deal on 3BR off Myrtle-Wyckoff L,M \u2764 NO FEE!--11237", 
-    "url": "https://newyork.craigslist.org/brk/nfb/d/wonderful-deal-on-3br-off/6494016544.html", 
+    "name": "❤ Wonderful Deal on 3BR off Myrtle-Wyckoff L,M ❤ NO FEE!--11237",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wonderful-deal-on-3br-off/6494016544.html",
     "containedIn": {
-      "name": " (BUSHWICK)", 
+      "name": " (BUSHWICK)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2450.0, 
+      "name": "price",
+      "value": 2450.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee", 
-    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6493985946.html", 
+    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee",
+    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6493985946.html",
     "containedIn": {
-      "name": " (Long Island City)", 
+      "name": " (Long Island City)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2668.0, 
+      "name": "price",
+      "value": 2668.0,
       "currency": "USD"
     }
   }

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -6,14 +6,14 @@
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },
-  "dataPath": "/map/QmPT7t4GQaBN4uxCdv3PD8A5vWaJ1ELCKCaZEjYYvUhe4W",
+  "dataPath": "/map/QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",
   "qri": "ds:0",
   "structure": {
-    "checksum": "QmPT7t4GQaBN4uxCdv3PD8A5vWaJ1ELCKCaZEjYYvUhe4W",
-    "entries": 30,
+    "checksum": "QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",
+    "entries": 1200,
     "errCount": 1,
     "format": "json",
-    "length": 512676,
+    "length": 520254,
     "qri": "st:0",
     "schema": {
       "definitions": {

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -19,38 +19,38 @@ func TestJSONReader(t *testing.T) {
 		count     int
 		err       string
 	}{
-		// {&dataset.Structure{}, "testdata/city_data.json", 0, "schema required for JSON reader"},
-		// {&dataset.Structure{Schema: jsonschema.Must(`false`)}, "testdata/city_data.json", 0, "invalid schema for JSON data format. root must be either an array or object type"},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONArray,
-		// },
-		// 	"testdata/city_data.json", 6, ""},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONObject,
-		// },
-		// 	"testdata/sitemap_object.json", 7, ""},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONObject,
-		// }, "testdata/links_object.json", 20, ""},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONArray,
-		// }, "testdata/links_array.json", 20, ""},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONArray,
-		// }, "testdata/json_array.json", 10, ""},
-		// {&dataset.Structure{
-		// 	Format: dataset.JSONDataFormat,
-		// 	Schema: detect.BaseSchemaJSONObject,
-		// }, "testdata/json_object.json", 10, ""},
+		{&dataset.Structure{}, "testdata/city_data.json", 0, "schema required for JSON reader"},
+		{&dataset.Structure{Schema: jsonschema.Must(`false`)}, "testdata/city_data.json", 0, "invalid schema for JSON data format. root must be either an array or object type"},
 		{&dataset.Structure{
 			Format: dataset.JSONDataFormat,
 			Schema: detect.BaseSchemaJSONArray,
-		}, "testdata/craigslist.json", 2, ""},
+		},
+			"testdata/city_data.json", 6, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONObject,
+		},
+			"testdata/sitemap_object.json", 7, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONObject,
+		}, "testdata/links_object.json", 20, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONArray,
+		}, "testdata/links_array.json", 20, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONArray,
+		}, "testdata/json_array.json", 10, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONObject,
+		}, "testdata/json_object.json", 10, ""},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: detect.BaseSchemaJSONArray,
+		}, "testdata/craigslist.json", 1200, ""},
 	}
 
 	for i, c := range cases {

--- a/dsio/testdata/craigslist.json
+++ b/dsio/testdata/craigslist.json
@@ -1,31 +1,18002 @@
 [
   {
-    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6496082858.html", 
+    "name": "Gorgeous 3 Bedroom in Prime Area! Amazing Deal! | No Fee",
+    "data": "This is a really long string that'll screw with the bytes.Scanner of a reader. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis vulputate turpis sed convallis. Cras vel lorem rhoncus, volutpat mauris quis, malesuada mi. Etiam ultrices, velit non convallis sollicitudin, tellus mauris tempus turpis, laoreet semper quam felis quis tellus. Integer quam tellus, lobortis sit amet ligula sed, hendrerit placerat ex. Curabitur eu justo vitae sem auctor elementum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Etiam efficitur magna aliquet congue feugiat.In quis ultricies tortor. Nulla eget viverra sapien, a feugiat sem. Praesent cursus ultrices magna, eu pellentesque sem pharetra ut. Nulla ut gravida nunc. Integer laoreet ex id metus laoreet imperdiet. Donec dignissim elementum lacus, quis faucibus justo tincidunt ac. Duis sit amet urna ornare, hendrerit magna quis, congue nisl.Praesent eget urna mollis, ultricies metus ultricies, pharetra sapien. Proin blandit imperdiet enim vel dapibus. Cras ornare ultrices lorem a interdum. Proin at eros porta, scelerisque nunc non, mollis nulla. Maecenas pellentesque euismod hendrerit. Donec lobortis ullamcorper massa, vitae eleifend est condimentum quis. Aliquam luctus suscipit justo, ac rhoncus lorem luctus a. Curabitur vel nibh lectus. Integer lobortis scelerisque augue at rutrum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam suscipit porttitor neque quis ultricies. Donec vulputate tellus nibh, vel consectetur ex blandit nec. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Suspendisse commodo odio in tellus varius, sed congue erat ultricies.Etiam aliquam a ligula molestie maximus. In sagittis, urna at cursus malesuada, erat nunc bibendum mauris, ut elementum turpis felis eu tortor. Curabitur egestas diam et elementum pellentesque. Sed auctor pulvinar neque. Sed pellentesque tortor at dolor interdum fermentum. Morbi porttitor posuere auctor. Nam accumsan consequat magna, at venenatis nunc eleifend vitae. Ut ac scelerisque mi. Maecenas dictum tortor in erat aliquam tincidunt.Nullam iaculis nec diam vitae vehicula. Morbi lobortis urna ut nisl volutpat, nec ultricies sem gravida. Duis sed maximus tellus. Aliquam felis risus, faucibus porttitor est vel, suscipit commodo sapien. Fusce dictum velit in velit accumsan suscipit. Phasellus quis ex vitae augue viverra hendrerit. Ut vulputate risus ut tortor vulputate sagittis. Donec tincidunt libero vel neque efficitur condimentum. Mauris feugiat est vitae risus rutrum, in interdum sapien condimentum. Fusce tortor lectus, iaculis auctor bibendum eget, tempus quis justo.Quisque varius, massa vitae cursus efficitur, elit mauris molestie erat, nec tempus ipsum turpis vitae augue. Duis lacus velit, imperdiet non euismod in, venenatis in arcu. Sed pellentesque vulputate ipsum, ac fringilla est tristique eu. Praesent porttitor dignissim maximus. Quisque sodales, lectus eget imperdiet mollis, leo nibh faucibus mauris, quis scelerisque ex augue nec felis. Donec purus urna, placerat sit amet finibus ac, feugiat eget enim. Nam elementum id eros sed tincidunt.Fusce a convallis erat, ac suscipit enim. Nunc bibendum mi ornare, faucibus lorem nec, fermentum dolor. Cras ante dui, blandit et enim in, rutrum viverra mauris. Proin pretium nibh enim, et commodo ipsum condimentum consectetur. Vivamus tempor dignissim urna id tempus. Vivamus volutpat, libero vel sagittis vulputate, odio nisl vestibulum leo, eleifend molestie metus ligula id turpis. Quisque id quam gravida, feugiat sem in, cursus diam. Pellentesque quis metus sit amet ligula dignissim molestie a eu turpis. Phasellus quis rhoncus justo.Vestibulum eget velit eu libero pulvinar luctus quis ac felis. Donec ultrices ac risus efficitur eleifend. Nulla lobortis tellus hendrerit imperdiet finibus. Maecenas tincidunt volutpat sapien tristique pharetra. Vivamus efficitur ultrices semper. Vestibulum id ex enim. Sed eleifend pulvinar dui a fermentum. Curabitur tincidunt quam id tortor imperdiet pulvinar. Quisque nibh turpis, luctus non volutpat quis, hendrerit quis lectus. In facilisis mollis arcu, in ultricies arcu fringilla id. Nullam in neque tortor. Mauris ultrices felis quis consectetur imperdiet. Vestibulum eleifend eros eget hendrerit porta.Fusce suscipit nulla nec diam tempor viverra. Nullam vehicula, lectus non elementum pretium, mi ipsum mattis mauris, ac aliquet orci turpis at libero. Vestibulum imperdiet sapien eu felis consequat, sit amet porttitor enim ornare. Curabitur eu bibendum sem. Pellentesque congue ultricies hendrerit. Maecenas eget urna orci. Maecenas dignissim, dui sit amet volutpat molestie, metus enim interdum enim, eget gravida leo arcu id nisl. Aenean vitae euismod nisi. Nullam sed sapien ac metus porta tincidunt nec in tortor. Aliquam ultrices volutpat pretium. Vivamus et sagittis elit, eu vestibulum lacus. Aenean lacus enim, volutpat ac mauris et, ornare molestie ligula.Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nulla fringilla efficitur est at auctor. Etiam venenatis tempus lorem, at consectetur augue maximus in. Donec semper sem sit amet sapien congue interdum. Aenean consequat elementum sapien, porta volutpat mi hendrerit vitae. Ut sit amet maximus magna. Sed pulvinar nisl nulla, eu fermentum enim finibus in.Etiam sed luctus mauris. Vestibulum felis dui, ullamcorper non metus nec, ultricies viverra lacus. Proin quis iaculis lectus. Morbi quis nulla vel augue mattis faucibus quis sit amet arcu. Ut posuere vitae massa eu sagittis. Vivamus pellentesque orci tristique molestie luctus. Nullam et lacinia lorem. Sed vestibulum ut dui vitae tristique. Nullam eget quam ante. Pellentesque quis dolor ac mauris viverra fringilla bibendum eget odio. Cras consectetur posuere tempor. Nunc nec diam eget ante ullamcorper pellentesque nec eget libero. Vivamus pretium elit non ipsum rutrum dignissim.Suspendisse consequat, arcu a vestibulum tempus, eros sem luctus purus, ut laoreet purus nisi at nulla. Curabitur semper dui a consequat consectetur. Cras dignissim est sodales feugiat ullamcorper. Nam at convallis diam. Cras efficitur, felis vitae elementum egestas, nulla diam semper ex, at faucibus arcu neque sit amet mi. Duis justo magna, eleifend id pulvinar a, placerat at tortor. Pellentesque vitae tincidunt eros. Phasellus varius turpis id purus aliquet, id congue ipsum rutrum. Nulla ut erat ac purus interdum sollicitudin non ac felis. Maecenas egestas venenatis eros vel facilisis. In et tortor ante. Cras ullamcorper elit sit amet diam tempus vestibulum. Aliquam erat volutpat. Suspendisse quis laoreet ipsum, ut luctus augue.Vivamus quis placerat diam. Suspendisse ultricies non enim at ornare. Cras et quam vel libero ultrices congue id ut ante. Nam facilisis ipsum maximus, lacinia odio eu, semper orci. Duis ut elementum massa, non consectetur arcu. Nullam ligula mauris, viverra vehicula venenatis et, luctus quis nunc. Nam sit amet lobortis libero. Sed sed commodo velit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer et magna ac metus sollicitudin posuere. Nulla pulvinar sem id nisl posuere, vitae mattis ante gravida. Nulla quis tellus pellentesque quam blandit ultrices ullamcorper quis tortor. Sed libero velit, rhoncus sed arcu vel, blandit aliquet neque. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.Donec egestas blandit tincidunt. Sed aliquam turpis quam, sed condimentum nibh sodales a. Pellentesque finibus metus sit amet mattis dignissim. Nullam euismod odio non ullamcorper imperdiet. Proin quis viverra tortor. Nullam et bibendum lectus, nec facilisis nisl. Vestibulum pellentesque auctor ipsum quis euismod. Aliquam libero nisi, feugiat quis mauris ac, tristique fermentum elit. Phasellus velit lectus, rhoncus ac augue sed, tincidunt ornare purus. Nulla faucibus odio leo, sed tincidunt felis tempor a. Proin magna lacus, dictum at mattis vel, mattis a nisl. Aliquam dolor felis, pharetra at lacinia venenatis, ullamcorper vel nisi. Mauris blandit ligula hendrerit laoreet blandit.Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam at dolor sit amet ex blandit congue. Suspendisse congue felis a sapien fermentum, a accumsan purus fringilla. Donec vitae elit ac enim sodales feugiat. Mauris luctus gravida ante, et sagittis lacus condimentum rhoncus. Proin ullamcorper velit eu mi malesuada varius. Phasellus sit amet pretium est, sit amet placerat nunc. Vivamus eget interdum lacus, rhoncus porta tellus. Nam vulputate sapien at dui suscipit, in fringilla enim cursus. Sed malesuada nec tortor eget accumsan. Sed pellentesque ac massa at rutrum. Duis elementum lacus quis ante varius consectetur. Sed iaculis nisi urna, a ultricies nisl suscipit non.Vivamus nulla nulla, venenatis sed dictum eget, lacinia non turpis. Proin eu vehicula eros, vel cursus tortor. Ut commodo convallis velit, vitae scelerisque est condimentum sodales. Aliquam convallis massa in libero euismod, vitae euismod mauris tempor. Duis elit mi, ornare quis purus pretium, aliquet sagittis sem. Morbi dapibus, felis sit amet faucibus facilisis, nisl nisi malesuada eros, a dignissim lorem neque non dolor. Sed lectus est, ultrices in placerat id, ullamcorper at augue. Nam sem erat, blandit et arcu a, posuere lobortis tellus.Nam non augue luctus, vulputate nisl eu, ornare turpis. Curabitur vehicula est vitae urna vestibulum pretium. Proin mollis, nulla et pretium euismod, arcu quam molestie nunc, in facilisis dolor nunc eu mauris. Nunc vulputate urna eu mi pulvinar consequat. Suspendisse tristique vel turpis eget molestie. Duis lorem ante, luctus in pellentesque a, volutpat quis dolor. Praesent ornare massa eros, eget porttitor ante consequat vitae. Aliquam molestie massa id libero blandit, a tincidunt lacus iaculis. Aenean id lacus et tellus viverra tempus. Donec sit amet efficitur diam. Mauris condimentum neque sed augue feugiat, a facilisis nisi convallis. Phasellus a arcu consequat, ullamcorper nisl vel, pretium tellus. Sed venenatis pretium turpis id semper. In gravida nunc rhoncus interdum elementum. Quisque quis orci orci. Cras suscipit efficitur nisl nec congue.Donec mollis, mi eget semper feugiat, magna neque pulvinar libero, in dictum tellus enim ut enim. Proin vel ex eleifend, porttitor risus sit amet, pellentesque mauris. Cras at mi et neque pellentesque cursus a at justo. Vestibulum tristique egestas lacus vel scelerisque. Phasellus vehicula pretium lorem, quis imperdiet ipsum interdum eget. Aliquam non purus pharetra, elementum eros eu, vestibulum erat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse ut risus in velit pellentesque sagittis ut non lacus. In porta ut nisl at mattis. Cras odio libero, hendrerit quis massa a, ultrices vestibulum nunc. Suspendisse volutpat, mauris nec iaculis cursus, odio mi laoreet arcu, eu feugiat urna augue non est. Duis tincidunt est sem, id sollicitudin enim fermentum quis.Nullam porta libero lacus, elementum ullamcorper lacus feugiat ac. Duis pulvinar, velit quis elementum dignissim, lorem neque tincidunt est, quis ultricies felis velit sit amet quam. In nec purus in quam vulputate venenatis eu quis velit. Morbi convallis tellus in nulla euismod semper. Aenean feugiat pharetra rhoncus. Nulla convallis efficitur convallis. Pellentesque finibus vehicula lectus vitae fermentum. Cras et egestas sapien, at vulputate magna. In tempus risus vitae tincidunt finibus. Integer non est eget nunc rutrum accumsan. Donec gravida, est sit amet pretium facilisis, lorem est dignissim diam, vel pretium lectus nisi ut arcu. Maecenas odio leo, fermentum eu turpis a, fermentum pulvinar magna. Praesent suscipit nibh mauris, dapibus suscipit libero maximus sed. Donec hendrerit a quam sed cursus. Aenean rhoncus nec ipsum nec pellentesque.Etiam blandit molestie purus, sed ultricies tortor malesuada a. Pellentesque eu porta purus, non consequat leo. Morbi ultricies fermentum mi a tincidunt. Praesent sodales metus quis elit feugiat faucibus. Etiam feugiat nulla in massa posuere, a molestie orci tincidunt. Cras venenatis tincidunt sodales. Quisque laoreet neque vitae sagittis convallis. Aliquam dictum mauris vitae lacus viverra sollicitudin.Morbi pretium vestibulum gravida. Sed leo arcu, volutpat vestibulum finibus vel, consectetur sit amet nisl. Maecenas a fermentum metus, et dignissim justo. Nullam quis metus ut sapien vulputate blandit. Aenean euismod mattis est. Fusce augue lectus, faucibus non velit at, lacinia commodo massa. Proin posuere, tellus eget malesuada faucibus, lectus nunc auctor sapien, et fermentum erat elit at leo. Vestibulum pellentesque rutrum tempor. Pellentesque scelerisque tortor ac dapibus cursus. Fusce aliquet ex in dictum laoreet. Proin porta consequat erat nec consequat. Maecenas posuere elit eget lacus pharetra, non facilisis velit dictum. Sed ornare mattis fringilla.Vestibulum pellentesque, odio a suscipit dictum, elit orci ultrices mi, rutrum porta nulla mi eget libero. Aliquam est lacus, sagittis eu ultrices sed, ullamcorper id lectus. Sed dignissim et velit ut fringilla. Nulla aliquet, nunc quis faucibus mollis, mauris diam finibus turpis, eget fermentum nibh elit quis lorem. Pellentesque aliquam pharetra erat sit amet consectetur. Vivamus et velit quis purus ullamcorper cursus quis at nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Morbi mauris justo, porttitor vitae leo vel, rhoncus elementum arcu. Donec aliquam enim sollicitudin libero posuere vestibulum. Sed mi tortor, molestie sed auctor vitae, faucibus id ipsum. Aliquam erat volutpat. Praesent non diam est. Etiam vehicula dui eu eros commodo, ut porta magna tempus. Morbi dapibus faucibus suscipit. Aenean eget accumsan magna. Etiam ut neque auctor, mollis nunc nec, sagittis diam.Integer et urna vulputate, eleifend lectus sed, placerat magna. Sed ornare libero et lectus varius, vehicula euismod sapien hendrerit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed quis tempus sapien. Ut quis gravida sapien, quis varius leo. Duis malesuada purus id magna sollicitudin interdum. Vestibulum tempor eros eget bibendum luctus. Nulla nec efficitur ligula. Nullam ipsum dui, rutrum eu ligula ac, dictum porta arcu. Quisque ut enim porta, posuere turpis quis, elementum felis. Sed eget massa mauris. Phasellus luctus est eget lacinia mattis. Integer eget neque felis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam congue congue leo, eu bibendum mi ornare et.Sed quis tempus urna. Etiam sodales mauris id risus ornare rhoncus. Aenean sed egestas nisl. Ut at commodo tortor. Vestibulum feugiat nunc leo, eget tempus odio vehicula et. Donec feugiat leo risus, ac ultricies ex bibendum nec. In hac habitasse platea dictumst. Duis malesuada sem vitae felis accumsan, at dignissim risus eleifend. Donec accumsan quam non bibendum finibus. Nulla euismod tellus eu lectus eleifend bibendum. Morbi at libero orci. Phasellus arcu enim, hendrerit laoreet ullamcorper sed, interdum non turpis. Suspendisse cursus nibh vitae odio mattis tempor. Donec at tincidunt tellus. Etiam at velit pellentesque, ornare mi blandit, elementum nunc.Maecenas egestas volutpat mi, in dictum augue mollis nec. Aenean massa mi, porta at laoreet vel, viverra ac erat. Fusce dictum sodales libero at dapibus. Praesent id magna vel dui molestie porttitor. In sed orci a felis iaculis congue sed consectetur elit. Nulla efficitur diam eu lacus vehicula, et tempor ex venenatis. Integer eleifend tellus ac orci venenatis auctor. Aenean neque dui, ultricies at commodo et, convallis eget metus. Mauris at felis consequat, sollicitudin velit eu, ultricies sapien. Vestibulum eget volutpat nulla, non sodales est. Etiam dignissim est vel metus mollis facilisis. Donec at mollis urna, quis venenatis neque. Nullam aliquam, nisl et porta elementum, ante neque condimentum mauris, eu volutpat ante lorem vitae orci. Suspendisse vel suscipit est, ut aliquet urna.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-in-prime/6498995602.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2695.0, 
+      "name": "price",
+      "value": 2199.0,
       "currency": "USD"
     }
-  }, 
+  },
   {
-    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)", 
-    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6496082551.html", 
+    "name": "w/ Large outdoor space. For April 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-outdoor-space-for-april/6498985027.html",
     "containedIn": {
-      "name": " (Harlem / Morningside)", 
+      "name": " (Clinton Steet)",
       "containedInPlace": {
         "name": "New York City"
       }
-    }, 
+    },
     "additionalProperty": {
-      "name": "price", 
-      "value": 2000.0, 
+      "name": "price",
+      "value": 5495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny // Two Baths // large apartment!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-two-baths-large/6498982528.html",
+    "containedIn": {
+      "name": " (Tompkins Square Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE***PETS OK*** NICE VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feepets-ok-nice-views/6498982168.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3749.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE 1BEDROOM DISHWASHER LAUNDRY ALOT OF CLOSETS NW TRAIN",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-1bedroom/6498981871.html",
+    "containedIn": {
+      "name": " (ASTORIA)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "New bathroom features granite sink top and marble flooring",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-bathroom-features-granite/6498981701.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3439.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "granite countertops and updated bathroom",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-countertops-and/6498981233.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 Levels - Located between Lexington and 3rd Ave!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-levels-located-between/6498980850.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3749.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Microwave, granite countertops and new cabinets",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/microwave-granite-countertops/6498980336.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3439.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OWNER MANAGED***PETS OK***GUARANTORS WELCOME***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/owner-managedpets/6498979904.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498975608.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1815.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Construction // in mint condition // elevator.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6498973989.html",
+    "containedIn": {
+      "name": " (East 100th // 2nd Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4785.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Construction! Two Bed Two Bath.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6498972014.html",
+    "containedIn": {
+      "name": " (East 100th // 2nd Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Light-Filled, Brand New 4 BR Box Apt - 2 Full Baths, Washer/Dryer",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/light-filled-brand-new-4-br/6498964517.html",
+    "containedIn": {
+      "name": " (Bedford Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498962943.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1945.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUNNING 2 BED IN PRIME LOCATION W/ SHARED BACKYARD / WASHER-DRYER!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-bed-in-prime/6498962900.html",
+    "containedIn": {
+      "name": " (WILLIAMSBURG)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6498961195.html",
+    "containedIn": {
+      "name": " (Prospect Lffert Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2124.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "💛💛AWESOME💛💛 3 BR W/ EXPOSED BRICK WALL IN PRIME",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6498960149.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunset Park__NO FEE_3 BR_2 BALCONIES___SUNSET_PARK_SLOPE_INDUSTRY_CITY",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-parkno-fee3-br2/6497270914.html",
+    "containedIn": {
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Prime Clinton Hill*Renovated 1BR*Next To C MTA*No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/prime-clinton-hillrenovated/6498957326.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Park Slope__NO FEE_3 BR_6 WEEKS FREE___PARK_SLOPE_INDUSTRY_CITY_SUNSET",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/park-slopeno-fee3-br6-weeks/6497284422.html",
+    "containedIn": {
+      "name": " (PARK SLOPE____EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498937696.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1785.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUDIO ON UPPER WEST SIDE 1 Block from Central Park - $2095 (NO FEE)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-on-upper-west-side-1/6498932210.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE \"Luxury Boutique\"+ Free Verizon FIOS, GYM & Amenities",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-luxury-boutique-free/6498928130.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "****________!!_NO_FEE_!!_______LARGE____Two__Bedroom__Apartment___****",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nofeelargetwobedroomapartment/6498923597.html",
+    "containedIn": {
+      "name": " (______BAY RIDGE____TEMUR___________)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE APT!! Spacious/Modern 1 Bedroom, Pvt Balcony!!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-apt-spacious-modern-1/6498922177.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "==IMMACULATE 1 BEDROOM D/W RENOVATED=DOORMAN==NO FEE 1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/immaculate-1-bedroom-w/6498921725.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3071.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE** \"Price REDUCTION\"+Free Gym & 24 HR Sky-Roof",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-price-reductionfree/6498921019.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2376.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee",
+    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6498920130.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2668.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge Closets, Extra Storage & Parking\"120,000 sq. ft of Amenities for",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-closets-extra-storage/6498918779.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3868.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6498912277.html",
+    "containedIn": {
+      "name": " (Ridgewood @ Seneca M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2609.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6498910879.html",
+    "containedIn": {
+      "name": " (Prospect heights @ 2,3,B,Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6498910009.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey J)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Centrally Located Forest Hills Luxury rental",
+    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6498894685.html",
+    "containedIn": {
+      "name": " (Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6498873503.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498868016.html",
+    "containedIn": {
+      "name": " (Crown Heights Utica)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE++LAUNDRY++ ELEVATOR++ PETS++ AMAZING LAYOUT++ BEEKMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelaundry-elevator-pets/6498867633.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498866952.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2195.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498866233.html",
+    "containedIn": {
+      "name": " (Fort Green)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498864997.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Small Cozy 2 Bed apt-Good light- Full Size Kit-Good closet space-Quiet",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/small-cozy-2-bed-apt-good/6498862076.html",
+    "containedIn": {
+      "name": " (Upper East Side - Private Owner)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6498856602.html",
+    "containedIn": {
+      "name": " (Washington Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6498854776.html",
+    "containedIn": {
+      "name": " (Washington Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6498853982.html",
+    "containedIn": {
+      "name": " (Washington Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, Beautifully Renovated 1 Bedroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6498851787.html",
+    "containedIn": {
+      "name": " (Hamilton Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6498850395.html",
+    "containedIn": {
+      "name": " (Washington Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 MONTHS FREE! Rooftop Pool, Concierge, Free Gym - Seaport/FiDi, Immd!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-free-rooftop-pool/6498841423.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4533.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PENTHOUSE 1BR - Rooftop Pool, Concierge, Gym Seaport/FiDi - 2 MOS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-1br-rooftop-pool/6498840614.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3880 Orloff Ave, NEW RENO, SS Kit, DW, FREE Gym, Pets, Pkg - 1 MO FREE",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/3880-orloff-ave-new-reno-ss/6498839263.html",
+    "containedIn": {
+      "name": " (KINGSBRIDGE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1463.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautifully renovated 2bed in prime area Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautifully-renovated-2bed-in/6498835446.html",
+    "containedIn": {
+      "name": " (Crown Heights Utica)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Charming Duplex in Cos Cob Call Joe Huley 203-253-5399",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/charming-duplex-in-cos-cob/6498818298.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "⭐NO FEE! Awesome 3BR/2BA-Upper E Side-24HR DM/ELEV/LNDRY-W/D-GYM-6/Q",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-3br-2ba-upper/6498815681.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498812267.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Old Greenwich 6 Bdrm Victorian South of Village|CALL DENISE 622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/old-greenwich-6-bdrm/6498805223.html",
+    "containedIn": {
+      "name": " (Old Greenwich/Greenwich/Cos Cob)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Central Greenwich 4 Bdrm 2 1/2 Bath| 3 Levels | Denise 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/central-greenwich-4-bdrmbath/6498804409.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Like New (Built 2014) Large 2 Bdrm/2Bthrm Apt: Kathie@203.554.7237",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/like-new-built-2014-large-2/6498801953.html",
+    "containedIn": {
+      "name": " (Greenwich, Cos Cob)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge 2 Bed Apt-Good light- Full Size Kit-Good Closet Space-Dishwasher",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-2-bed-apt-good-light/6498790755.html",
+    "containedIn": {
+      "name": " (Upper East Side - Private Owner)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2725.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK WITH LAUNDRY IN APT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6498778866.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6498778010.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6498777394.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6498776779.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498769352.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498769276.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "⭐NO FEE Awesome 1BR-beautiful MIDTOWN E-ELEV/LNDRY-SS-DW-MW-4/5/6/7/S",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-awesome-1br-beautiful/6498751900.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE PRIME MURRAY HILL FLEX 2 BEDROOM IN ELEVATOR BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-murray-hill-flex/6498748001.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "REAL SPACIOUS STUDIO IN HARLEM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/real-spacious-studio-in-harlem/6498745705.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Big studio with WIC - City Hall / Brklyn Brdge, NO Fee, Prime Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-with-wic-city-hall/6498732596.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OPEN HOUSE 2 BR in Kew Gardens by Atlantic Management 718-726-0003",
+    "url": "https://newyork.craigslist.org/que/nfb/d/open-house-2-br-in-kew/6498730928.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Great Views, Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498724139.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW*NO FEE+1 MO. FREE net rent $3020** 2 BR 2 MBL BTHS DRMN GYM GARAGE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-fee1-mo-free-net-rentbr/6498720233.html",
+    "containedIn": {
+      "name": " (East Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+ 1 MO.FREE UES  LG 2 BR 1 BTH Eat in KIT DW Dining Area LG Livi",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-mofree-ues-lg-2-br-1/6498720153.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MO.FREEnet rent $2837 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2837/6498720027.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AMAZING STUDIO FOR CHEAP NEAR MIDTOWN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-studio-for-cheap-near/6498710616.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1870.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "$1100 / 100ft2 - 1 of 2 Rooms in Factory Loft (Bushwick)",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ft2-1-of-2-rooms-in-factory/6498707790.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Private & shared rooftop deck and a premium Bosch washer and dryer",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/private-shared-rooftop-deck/6498707607.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3749.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "New Two Bedroom, Duplex apartment with a large patio and nice views!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-two-bedroom-duplex/6498707185.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3439.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large Studio with exposed brick!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-with-exposed/6498706768.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Big Studio Flex 1Bdr close to City Hall - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/big-studio-flex-1bdr-close-to/6498704315.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2672.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT SHARE! RENOVATED 2BR HOME+SS APPL+EXPOSED BRICK+REAL PICS!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-share-renovated-2br/6498690433.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!HUGE!!DONT MISS THIS ONE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one/6498687244.html",
+    "containedIn": {
+      "name": " (williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6498686797.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6498682346.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! Bensonhurst Spacious 1 Bedroom with On-site Laundry. See Pics!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-spacious-1/6498681491.html",
+    "containedIn": {
+      "name": " (Bensonhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6498681466.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!HUGE!!DONT MISS THIS ONE !!! HEAT HOT   WATER INC! PRIVATE GARDEN!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hugedont-miss-this-one-heat/6498675955.html",
+    "containedIn": {
+      "name": " (east williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 2 BEDROOMS RAILROOD HEAT HOT   WATER INC!!!!!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-2-bedrooms-railrood-heat/6498673252.html",
+    "containedIn": {
+      "name": " (east williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Floor Thru Top Floor Of Townhouse-Fireplace Mantle-Laundry+Storage-New",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-top-floor-of/6498666869.html",
+    "containedIn": {
+      "name": " (Park Slope)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEWLY RENO MIDTOWN WEST 1BR*BALC*NO SEC.DEP.*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6498666158.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE ON PRIME PRISTINE 1 BEDROOM STEPS FROM PARK 2,3,Q,B",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-prime/6498665060.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6498646837.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6498646646.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6498642758.html",
+    "containedIn": {
+      "name": " (Prospect Lefferts Vicinity)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6498642036.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely Pad with  Extra Room& Gas included Today!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-pad-with-extra-room/6498641547.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OVERSIZED STABILIZED 2 BEDROOM STEPS FROM CHILDREN'S MUSEUM A&C TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/oversized-stabilized-2/6498641457.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PRIME Greenwich Village! ~~ Univ. Place! ~~ Elevator / Laundry!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-greenwich-village-univ/6498634528.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498631879.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Close to Transport & Entertainment!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6498628687.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2125.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6498621662.html",
+    "containedIn": {
+      "name": " (Sheepshead Bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LARGE NEW CONSTRUCTION ONE BEDROOM!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-new-construction-one/6498614591.html",
+    "containedIn": {
+      "name": " (East 10th Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6498613168.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6498612627.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS_________HUGE LIVING SPACE___________OVERSIZED WINDOWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacioushuge-living/6498612198.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6498611933.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6498610936.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW | Massive Bed-Stuy 5+ BR Duplex | Yard | Laundry | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-massive-bed-stuy-5/6498609723.html",
+    "containedIn": {
+      "name": " (Bedstuy | Somers St | Near C & J Trains)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Unique & Spacious Bushwick 2 Bedroom | Pre-War Gem | Perfect Location!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/unique-spacious-bushwick-2/6498608943.html",
+    "containedIn": {
+      "name": " (Bushwick | Dekalb L Train)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunlit Bedroom in East Williamsburg",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunlit-bedroom-in-east/6498608148.html",
+    "containedIn": {
+      "name": " (East Williamsburg, Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1073.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE! 3bed/2bath with laundry, a block from the park & B,Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-3bed-2bath-with/6498586278.html",
+    "containedIn": {
+      "name": " (prospect lefferts gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Attention All Sacred Heart Students! Bright & Sunny 4 Bedroom 2 Bath",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/attention-all-sacred-heart/6498584063.html",
+    "containedIn": {
+      "name": " (Bridgeport,Trumbull,Fairfield)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! BRAND NEW 3 BED, 2 BATH!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-3-bed-2-bath/6498579283.html",
+    "containedIn": {
+      "name": " (Hamilton Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^HOT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6498576979.html",
+    "containedIn": {
+      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6498572411.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6498571397.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV JUNIOR1 BEDR PRIME  REGO PARK/FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior1/6498568067.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6498567597.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html",
+    "containedIn": {
+      "name": " (Rego Park / Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6498565807.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6498562636.html",
+    "containedIn": {
+      "name": " (Rego Park / Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6498556833.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-sunnyside-renovated/6498555645.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6498551401.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6498550179.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUX Tower~LOFT LIKE ALCOVE STUDIO+WASHER/DRY~Pool~Gym~2 MO FREE+NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-towerloft-like-alcove/6498550023.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6498548966.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6498546043.html",
+    "containedIn": {
+      "name": " (Kew Gardens / Richmond Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6498544710.html",
+    "containedIn": {
+      "name": " (Elmhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6498542864.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2819.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great & Convenient 1BR in Full Service Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-convenient-1br-in-full/6498542639.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Huge 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-huge-1-bedroom/6498541438.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6498539403.html",
+    "containedIn": {
+      "name": " (New Rochelle)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2145.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE*FEB/MARCH*TERRACE*Heat,Wtr,Gas INC*DW*Elv*Lundry*TRAIN*Poo",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb/6498537164.html",
+    "containedIn": {
+      "name": " (Port Chester/ BORDER RYE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1689.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+2 MNTS FREE__FLEX 4BR, 2BATHS__LUX DOORMAN BLD__GYM & POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee2-mnts-freeflex-4br/6498534395.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5417.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6498531509.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2375.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6498529423.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6498528581.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4457.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6498528219.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6498527328.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6498526041.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1000% NO FEE**GORGEOUS STUDIO** XL** MURRAY HILL**GYM** ROOF DECK** LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-no-feegorgeous-studio-xl/6498523989.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6498523571.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Studio \\ Gravesend \\ Sheepshead bay \\ No Broker's Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-gravesend-sheepshead/6498523471.html",
+    "containedIn": {
+      "name": " (Sheepsheadbay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1365.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6498521758.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL _Flex 3_24_Lux_ Drmn_Gym/Pool/_HiFloor_ No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-flex-324lux-drmngym-pool/6498519665.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 2BD Townhouse + Washer & Dryer with Covered Parking!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-townhouse-washer/6498518575.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6498517229.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Fabulous All Renov Spacious 1 Bd Rm + Den, New Eat In Kitch + Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/fabulous-all-renov-spacious-1/6498509466.html",
+    "containedIn": {
+      "name": " (Fleetwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498504527.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498503946.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1br-JUST HIT THE MARKET-TWO MONTHS FREE--LUXURY LIVING--MUST SEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1br-just-hit-the-market-two/6498499774.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6498481410.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**2 MONTHS FREE**STUNNING 1BR**24HR DM**LUX**W/D IN UNIT!!**100% NOFEE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freestunning-1br24hr/6498481098.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Condo Finishes~~~Chefs Kitchen~~~Corner Home~~$2500 Move In Bonus~~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/condo-finisheschefs/6498476398.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8336.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 Real King BRs__Luxury Building__Endless Amenities__Floor-to-Ceiling",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-brsluxury/6498476328.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8945.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Duplex PENTHOUSE~~W/D~~3 BED/3 BATH~~CORNER UNIT~~WRAP AROUND TERRACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-penthousew-d3-bed-3/6498475966.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 9250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Elegant 4 Bedroom Home__W/D in Unit__Sun-Drenched__Exquisite Amenities",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/elegant-4-bedroom-homew-in/6498475913.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 15420.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Hudson River Views~~Walk In Closet~~Month Free~Sun-Drenched~~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/hudson-river-viewswalk-in/6498475807.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Jaw Dropping Views__Luxury Bldg__Wall-of-Windows__Sun Drenched__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/jaw-dropping-viewsluxury/6498475739.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5789.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "69th Floor Living__Water Views__*Huge Living Room & Dining Room*__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/69th-floor-livingwater/6498475677.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5880.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Tribeca Townhouse__Wall of Windows__Sun Flooded__2 Bath__Luxury Bldg",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-townhousewall-of/6498475596.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5887.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Center of Tribeca__Impressive Amenities__Luxury Loft Building__2Bath__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribecaimpressive/6498475540.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5936.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 Real King Size BR's__Jaw Dropping Views of Manhattan__Sun Flood",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-real-king-size-brsjaw/6498475481.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6339.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Now to April Move In~~Endless Amenities~~~River/City Views~~King Sized",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/now-to-april-move-inendless/6498475413.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6910.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CORNER UNIT~~PH Living~~Huge Rooftop~~Sunflooded~~Amazing Views!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-unitph-livinghuge/6498475359.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7370.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Triple Exposure~~Sun-Lit~~Exquisite Finishes~~Magnificent City Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/triple-exposuresun/6498475280.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7380.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CHIC FINISHES~~POOL~~~WALK IN CLOSET~~CHEFS KITCHEN~~SPLIT BEDS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/chic-finishespoolwalk-in/6498475211.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7845.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious Tribeca Townhouse~~ 5 Queen Sized Beds~~2 Full Baths~~W/D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-tribeca-townhouse-5/6498475087.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7965.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Center of Tribeca__5 BR__Impressive Amenities__Luxury Loft Building__",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/center-of-tribeca5/6498475007.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8210.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse Living~57th Fl~Triple Exposure~King Sized BRs~Serene Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-living57th-fltriple/6498474954.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 11730.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUNNING ONE BEDROOM APARTMENT!",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6498474365.html",
+    "containedIn": {
+      "name": " (staten island)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FREE UTILITIES * TRUE 3 BED * 1000 SQFT * ELEVATOR + LAUNDRY * NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-3-bed/6498462843.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FREE UTILITIES * TRUE 2 BED * 800 SQFT * ELEVATOR + LAUNDRY * NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/free-utilities-true-2-bed-800/6498461930.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "~NO FEE~1 BR with Manhattan views**Chefs Kitchen**ELEV + LAUNDRY!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1-br-with-manhattan/6498419226.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2399.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ROOM FOR RENT $1008 - Morning Side  - West 114 - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent-1008-morning/6498404717.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1008.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498404239.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6498404162.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4996.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498403698.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "121st St & Lexington - 2 Bed 1 Bath 690 SF - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/121st-st-lexington-2-bed-1/6498403241.html",
+    "containedIn": {
+      "name": " (East Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498403104.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6498402777.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 85th - CONV 1 Bed 1 Bath - Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-85th-conv-1-bed-1-bath/6498400499.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2654.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 91st St  - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6498397751.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6498397569.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6498395407.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2837.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GIGANTIC AUTHENTIC Williamsburg Loft DUPLEX - LIVE / WORK Dream!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gigantic-authentic/6498293318.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 8000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SUNNY AUTHENTIC Williamsburg Loft 2BR Elevator Building w. ROOF DECK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-authentic-williamsburg/6498292544.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6498291432.html",
+    "containedIn": {
+      "name": " (GREENPOINT)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Fab Renov, Balcony, w/ W&D! 2 blks from 4,5,6&MetroN. No Bkr Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fab-renov-balcony-wd-2-blks/6498277344.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2979.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498277007.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7410.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW STUDIOS! In a Beautiful Luxury Build - F/G Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studios-in/6498270185.html",
+    "containedIn": {
+      "name": " (Gowanus)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2270.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 BEDROOM WALK UP",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/1-bedroom-walk-up/6498266031.html",
+    "containedIn": {
+      "name": " (HUGHES AVE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "⎝NO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6498261497.html",
+    "containedIn": {
+      "name": " (Upper East Side / Roosevelt Island)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2265.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FREE Month! Luxury Studio w/Open Kitchen A/C/G/2/3/4/5/B/Q/R",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/free-month-luxury-studio-open/6498258331.html",
+    "containedIn": {
+      "name": " (Downtown BK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Live in Prime Fort Greene | Steps to 2/3/4/5/B/Q/R/G | NO BROKER FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-fort-greene/6498256377.html",
+    "containedIn": {
+      "name": " (Fort Greene)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2470.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MAJOR DEAL! Jr 1 Bed in Luxury Building 2/3/4/5/B/Q/R Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/major-deal-jr-1-bed-in-luxury/6498251029.html",
+    "containedIn": {
+      "name": " (Fort Greene)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2590.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **UNREAL 1BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-1bed/6498234922.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **UNREAL 2BED TRIPLEX !!! PRIME LOCATION PARK AVE/ EAST 54!!!  NEW",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-unreal-2bed/6498227019.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**100% NO FEE**GORGEOUS  1 BED** RENOVATED** 24 HR/Dm** POOL**GYM**ROOF DECK**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-feegorgeous-1-bed/6498208185.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 2 Bedroom-Renovated in Williamsburg-Laundry in building",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-2-bedroom-renovated-in/6498200418.html",
+    "containedIn": {
+      "name": " (Williamsburg @ JM at Lorimer St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL 1 BEDROOM LOFT - HUGE WINDOWS, AMAZING LIGHT.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-loft-huge/6498199658.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6498198848.html",
+    "containedIn": {
+      "name": " (Crown Heights Utica)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6498198491.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2195.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6498198122.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6498197502.html",
+    "containedIn": {
+      "name": " (Fort Green)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6498191692.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6498182163.html",
+    "containedIn": {
+      "name": " (Crown Heights @ Nostrand 2/3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2749.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6498181679.html",
+    "containedIn": {
+      "name": " (Williamsburg @ Lorimer J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6498181134.html",
+    "containedIn": {
+      "name": " (Bushwick @ Hasley J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6498180765.html",
+    "containedIn": {
+      "name": " (Williamsburg @ Flushing J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6498180259.html",
+    "containedIn": {
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS , HUGE 2 BEDROOM",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/gorgeous-huge-2-bedroom/6498175281.html",
+    "containedIn": {
+      "name": " (NEEDHAM AVE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6498169775.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6498169422.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Two bedroom/1.5 Bathroom Duplex with Private Courtyard in Williamsburg",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/two-bedroom-15-bathroom/6498169276.html",
+    "containedIn": {
+      "name": " (Williamsburg L at Grand St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6498168629.html",
+    "containedIn": {
+      "name": " (Nolita / Bowery)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6498168028.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6498167733.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6498167087.html",
+    "containedIn": {
+      "name": " (Ditmas Park @B,Q at Newkirk Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6498165676.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant @ c ralph ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2399.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6498164423.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "newly renovated 3 Queen Bedroom-2 bath-11 foot ceilings-NOFEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/newly-renovated-3-queen/6498163978.html",
+    "containedIn": {
+      "name": " (ridgewood @ M at Seneca Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2bedroom 2bath-heart of Bushwick-Laundry in Building -no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2bedroom-2bath-heart-of/6498162629.html",
+    "containedIn": {
+      "name": " (Bushwick @ M at Central Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "studio in a glorious Brownstone-Excellent block - no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-in-glorious-brownstone/6498161901.html",
+    "containedIn": {
+      "name": " (Bedford-StuyvesantC,S at Franklin Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FULL SERVICE WHITE GLOVE SERVICE *BRAND NEW* All No Fee - Free Rent -",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/full-service-white-glove/6498155877.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2907.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely Studio in Clinton Hill • No Fee • Great Apartment • Must See!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-studio-in-clinton-hill/6498124257.html",
+    "containedIn": {
+      "name": " (Brevoort @ Franklin Ave C, S Train)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE***PRIME GRAMERCY***3BD***ELEVATOR***LAUNDRY***LIVE IN SUPER***CENTRAL AIR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeprime/6498122884.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE***TRIBECA** LUX***STUDIO***24/DM***GYM***POOL***STEPS FROM TRAINS***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetribeca-luxstudio24/6498111618.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous 2 Bedroom w Balcony- Luxury Doorman Buildings- Gym Roof Top",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-2-bedroom-balcony/6498102958.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3023.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE & 1 MONTH FREE** LUXURY DEAL ALERT! SPACIOUS 2 BED ON W 33RD!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-luxury/6498102521.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6498102257.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Iconic Bed-Stuy 3BR Classic •B.I.G. Mural Building • NO FEE • Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/iconic-bed-stuy-3br-classic/6498100758.html",
+    "containedIn": {
+      "name": " (Bedford @ Franklin ave C, S train)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious & Lovely • w/ Backyard \\\\ Prime Bushwick // No Fee • Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-lovely-backyard/6498098336.html",
+    "containedIn": {
+      "name": " (Bushwick - L @ Halsey M @ Myrt-Wykoff)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6498097905.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW**NO FEE**PENTHOUSE_2BR_HUGE TERRACE ->Manhattan views!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/newno-feepenthouse2brhuge/6498078069.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6498074137.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No fee! - 2 Months Free - 40 s and Lex - Gut Renovated Doorman Luxury",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-40-and/6498074068.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6498074001.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Very high Ceilings, queen size bedrooms, washer dryer, skylight, J M Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-high-ceilings-queen-size/6498064349.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 3 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6498063196.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6498062984.html",
+    "containedIn": {
+      "name": " (midwood/ Sheepshead bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6498058934.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★COLUMBUS CIRCLE NO FEE! XL LIVING ~KING-SIZE BR ~Dman ~FREE GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-no-fee-xl/6498043593.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★LINCOLN CENTER NO FEE! MODERN FINISHES ~Dman ~GYM+POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lincoln-center-no-fee-modern/6498043480.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★NO FEE!  DMAN ~IRVING PLACE ~KING BR ~NEW KIT. ~HUGE WINDOWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-dman-irving-place-king/6498043418.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★NO FEE!!! E 20 st. ~TRUE 2BR/2BA ~DMAN ~KING BRs ~NEW KIT.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-20-st-true-2br-2ba/6498043376.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6498043395.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7410.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous Studio with Balcony- Luxury Doorman Buildings- Gym Roof Top",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-studio-with-balcony/6498043281.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1937.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Doorman Building, Gym, Brand new renovations - NO FEE Plus Free",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-gym/6498027279.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2672.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*BRAND NEW* FULL WHITE GLOVE SERVICE All No Fee - Free Rent - Luxury -",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-white-glove/6498010869.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2266.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ASAP MOVE IN__27TH FLOOR___21'X19' LIVING AREA___NEW RENOVAT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-in27th-floor21x19/6498007800.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "34th FLOOR___FLOOR-TO-CEILING WINDOWS__WATER & CITY VIEW____MASSIVE CL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/34th-floorfloor-to-ceiling/6498005910.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3510.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6498005808.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6498001365.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW *FULL SERVICE LUXURY BUILDING  All No Fee - Free Rent - Luxu",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-full-service-luxury/6497994917.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3778.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LONG ISLAND CITY'S NEWEST ADDRESS LOWEST PRICING *Free RENT * NO FEE *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-citys-newest/6497994835.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3185.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Top-of-the-Line Large 3 Bed/3 Bath Penthouse Apartment in Tribeca - Pr",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/top-of-the-line-large-3-bed-3/6497994557.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 12600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6497994517.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "High Fl. 922 sq/ft loft, kitchen island, brand new reno, amazing deal",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-fl-922-sq-ft-loft/6497984214.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "$1675,Close to DWNTWN,Mod Kit,HugeTerr,Inc.Heat,gas,water,Prkng",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1675close-to-dwntwnmod/6497981297.html",
+    "containedIn": {
+      "name": " (stamford downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LARGE LIVING ROOM, True Two Bed. Houston and 2nd Ave",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-living-room-true-two/6497978476.html",
+    "containedIn": {
+      "name": " (East 1st and 2nd Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Construction! Two Bed Two Bath.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-two/6497975821.html",
+    "containedIn": {
+      "name": " (East 100th // 2nd Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Construction // in mint condition // elevator.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-construction-in/6497970356.html",
+    "containedIn": {
+      "name": " (East 100th // 2nd Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4785.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "THREE BEDROOM MIDTOWN WEST NO FEE EQUAL SIZED ROOMS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/three-bedroom-midtown-west-no/6497961395.html",
+    "containedIn": {
+      "name": " (MIDTOWN WEST)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CONVERTIBLE TO TWO! ELEVATOR BUILDING!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-to-two-elevator/6497958782.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "█ ▶NICE FLOOR THRU 1BR*short walk to 4th Ave F,G,R*NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-floor-thru-1brshort-walk/6497956221.html",
+    "containedIn": {
+      "name": " (Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated 3 bedroom apt check it out!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-3-bedroom-apt-check/6497947842.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2290.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**Pre Construction in Fidi / Seaport **Ultra Lux Rental Tower**Rooftop",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/pre-construction-in-fidi/6497928391.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FANATSTIC 3 BEDROOMS APARTMENT - EXTRA LARGE - 2 FULL BATHS - W/4",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fanatstic-3-bedrooms/6497922709.html",
+    "containedIn": {
+      "name": " (Greenwich Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury 3 bedroom (dog owner's dream)",
+    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-3-bedroom-dog-owners/6497920129.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3857.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**New Year New Deal**Sun Drenched**Spacious**Chefs Kitchen**Basketball",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-year-new-dealsun/6497911092.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- 1 MONTH FREE - MTW - GYM -  POOL -TRUE 1 BED-  LUXURY 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-mtw-gym/6497910848.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, Beautiful Renovated 2 Bedroom!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-beautiful-renovated-2/6497909986.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! LARGE STUDIO W/ SEPARATE KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-separate/6497908890.html",
+    "containedIn": {
+      "name": " (Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS STUDIO IN A FULL SERVICE BUILDING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/spacious-studio-in-full/6497905458.html",
+    "containedIn": {
+      "name": " (QUEENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2331.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**HIGH CEILINGS**OVERSIZED WINDOWS**SPACIOUS**TONS OF CLOSET SPACE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/high-ceilingsoversized/6497905048.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens *Spacious, Kitchens & Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497903676.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge Converted 2 Bed w/ Wall up!! Luxury Doorman, 1 Free Month and NO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-converted-2-bed-wall-up/6497903757.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3160.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6497903278.html",
+    "containedIn": {
+      "name": " (Flatiron)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497902633.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Below Market West Village 1BR/1BA!! No Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6497902383.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6497901967.html",
+    "containedIn": {
+      "name": " (Greenwich Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning 2BR! Best Deal Available! No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-2br-best-deal/6497901501.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497898950.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**Last Chance Winter Deals** Chefs Kitchen** Sun Drenched** Rent Stabi",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/last-chance-winter-deals/6497896907.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens. *Near Transport* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497888597.html",
+    "containedIn": {
+      "name": " (Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 2BR/1.5 Duplex!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-15-duplex/6497879524.html",
+    "containedIn": {
+      "name": " (Union Square)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEBRUARY MOVE IN ////////// UNIT 16D ====== WATER VIEWS  === BOUKLIS G",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-16d/6497865119.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2275.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6497861778.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6497861275.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 2BD in Downtown Stamford + Washer & Dryer and Covered Parking!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/large-2bd-in-downtown/6497861139.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6497860902.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6497860509.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**LUX BUILDING **JR 1**100% NO FEE **24 DM **GYM/POOL/ROOFTOP **LIMITE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-building-jr-1100-no-fee/6497852638.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6497850002.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS STUDIO IN IDEAL LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-ideal/6497848860.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FABULOUS ONE BEDROOM APARTMENT- HELL KITCHEN- NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fabulous-one-bedroom/6497843914.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- RENOVATED TWO BEDROOM OVERLOOKING THE PARK: Amazing price, large.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-two-bedroom/6497827534.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Granite counter tops and a premium Bosch washer and dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/granite-counter-tops-and/6497825109.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2689.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Just a block from the 1 train at Lincoln Center",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-block-from-the-1-train/6497824555.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3179.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RENOVATED Kitchen and Bathroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-kitchen-and-bathroom/6497824096.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2229.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- Right on the park: Gut renovated: amazing layout, big rooms!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/right-on-the-park-gut/6497823221.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing Large Studio Rare Availibility On Jane Street!!! NO FEE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-large-studio-rare/6497819997.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- NO FEE: Gut renovated spacious three bedrooms! Across from the park!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-spacious/6497818015.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- Beautiful - New - Renovated. Minutes to prospect park. No fee at all",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-new-renovated/6497815491.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- NO FEE. BRAND NEW. EXPOSED BRISKS. MASSIVE. FANCY RENO - STUNNING!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-exposed/6497814505.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- MODERN STYLE: Dishwasher, Microwave. ACROSS FROM THE PARK!! *NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-style-dishwasher/6497813805.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497812984.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- NO FEE: Gut renovated real three spacious bedrooms! MUST SEE! ^HOT!^",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-renovated-real/6497812961.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- *BRAND NEW DEVELOPMENT: ROOF DECK - GYM - LAUNDRY - BIKE ROOM*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-development-roof/6497811173.html",
+    "containedIn": {
+      "name": " (brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST 2 BEDROOM ON THE MARKET TODAY!! O.H ALL WEEK!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-2-bedroom-on-the-market/6497807895.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "- WOW!! No fee Stunning  BRAND NEW 3 BEDS! Renovated building!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-no-fee-stunning-brand-new/6497806924.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497806765.html",
+    "containedIn": {
+      "name": " (prospect heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "All Brand New - All Everything - Be The First - Hot Area!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/all-brand-new-all-everything/6497799242.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2245.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 2 Bedroom In The Heart Of Greenwich (Elevator / Laundry Buildi",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2-bedroom-in-the/6497789772.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497782902.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE GIGANTIC CONV3/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-conv3-2bath/6497782918.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6497780698.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WASHER AND DRYER*****GARAGE PARKING******GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washer-and-dryergarage/6497771611.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3041.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM---()---TONS OF LIGHT---",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497759907.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2630.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "667 Grand Street - Duplex 2 Br. Views of Manhattan skyline, No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/667-grand-street-duplex-2-br/6497753491.html",
+    "containedIn": {
+      "name": " (Williamsburg, BK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6497751134.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST DEAL BY FAR -WASHER / DRYER -TWO MONTHS FREE-",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-by-far-washer-dryer/6497744509.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497736405.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2065.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, New Amenities & Laundry on Site!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497734357.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2490.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497731180.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 1 Bedroom, 1 Bath, Flex 3 Bedroom w/ Balcony and Tons of Clos",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bedroom-1-bath/6497730750.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "New New New - Everything Is Brand New - Be The First To Live Here!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-new-new-everything-is/6497720413.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 3 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-3-bed/6497694768.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Apartment In Brand New Building w/Great Bldg Amenities",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-apartment-in-brand/6497687090.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE** CHELSEA_TOTAL BARGAIN $1,900_BELOW MARKET PRICE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-chelseatotal-bargain/6497684936.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 BED STEPS TO FULTON  - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-steps-to-fulton-no-fee/6497669695.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE**61&2nd  //NATURAL light%separate kitchen<3",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee612nd-natural/6497650366.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE 1 Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bedroom-apartment/6497639390.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1925.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Columbus Circle - Glorious 4.5BR / 3BA ~~ Classic NYC ~~ Doorman",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/columbus-circle-glorious-45br/6497637371.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 10750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand new renovations along with an updated bathroom and kitchen",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-renovations-along/6497634994.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2689.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Located in the most iconic section of the upper west side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/located-in-the-most-iconic/6497634024.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3179.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6497633972.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Newly Refinished Flooring Throughout The Apartment!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-refinished-flooring/6497633515.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2229.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee_ Large 2BR, Sep Kitchen, Stainless Steel Appliances, A/C Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2br-sep-kitchen/6497620457.html",
+    "containedIn": {
+      "name": " (Crown Heights, Pacific St: NO FEE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE HUGE  PRIVATE BALCONY  INDOOR POOL ROOF DECK DM LUXURY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-huge-private-balcony/6497607866.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6497593263.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1932.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6497591219.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6497589825.html",
+    "containedIn": {
+      "name": " (Elmhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6497587073.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Suburbs size home and living In the heart of the city*Modern Finishes*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/suburbs-size-home-and-living/6497576886.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7410.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Terrace, Spacious, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497576705.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2780.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Richmond Hill * By E & J Trains",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio/6497576075.html",
+    "containedIn": {
+      "name": " (Kew Gardens / Richmond Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW LUXURY BUILDING LOCATED IN LONG ISLAND CITY",
+    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-luxury-building/6497575511.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2215.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6497566209.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW RENOV. APART-ELEVATOR BUILD. $1795/ P-MONTH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-renov-apart-elevator/6497565312.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Centrally Located Forest Hills Luxury rental",
+    "url": "https://newyork.craigslist.org/que/nfb/d/centrally-located-forest/6497564496.html",
+    "containedIn": {
+      "name": " (Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3075.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6497564418.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2819.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Avail March 1~ Renovated True 2 bed/1bath~ Near Subway~No Broker fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-renovated-true/6497562578.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6497561810.html",
+    "containedIn": {
+      "name": " (Rego Park / Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6497558839.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6497558183.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*****ENORMOUS WINDOWS_______NO FEE____SPACIOUS_______PET FRIENDLY (Fin",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/enormous-windowsno/6497552555.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2520.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Convenient to the subway (4, 5, and 6 Trains)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convenient-to-the-subway-4-5/6497551277.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2689.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "One of the best school districts!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-of-the-best-school/6497550743.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3179.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Faux Fireplace Mantle_Hardwood Floors_Updated Appliances",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-faux-fireplace/6497550250.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2229.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6497550206.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE** GUT RENO** SS APPLIANCES** GORGEOUS**HARDWOOD FLOORS**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-gut-reno-ss-appliances/6497546236.html",
+    "containedIn": {
+      "name": " (sheepshead bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New Studio with Walk-In Closet",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-studio-with-walk-in/6497540432.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2415.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stratford 3 bedroom 1.5 bath Near Train Station",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/stratford-3-bedroom-15-bath/6497526631.html",
+    "containedIn": {
+      "name": " (Stratford)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Cozy 2 bedroom/ Stainless Steel Appliances/ Lots of Sunlight/ J/M/Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/cozy-2-bedroom-stainless/6497526265.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★Delancey/Clinton★Bright, Renovated 2BR, Exp Brk, MAR 1",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/delancey-clintonbright/6497519550.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 BED FIDI PRIME LOCATION - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-fidi-prime-location-no/6497505951.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 3 Bed 2bth New Kitchen/Bath On-site parking Close to Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-3-bed-2bth-new-kitchen/6497500542.html",
+    "containedIn": {
+      "name": " (New Rochelle NY)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Doorman Building, Prime Location   - No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-doorman-building-prime/6497499021.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***Lux Building***Brand new Renovations***W/D in Unit***100% No Fee ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingbrand-new/6497489333.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 2 Bed New Kitchen and Bath London Terrace No FEE",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-new-kitchen-and/6497487626.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 1 Bed New Kitchen and Bath London Terrace No FEE",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bed-new-kitchen-and/6497482725.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 2 Bed 1b New Kitchen/Bath On-site parking Close to Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-2-bed-1b-new-kitchen/6497479679.html",
+    "containedIn": {
+      "name": " (New Rochelle NY)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2145.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6497477013.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! - 1100sf 2 BED - STAINLESS STEEL KITCHEN, CENTRAL AIR, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1100sf-2-bed-stainless/6497476460.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6497476413.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE 1 Bedroom New Kitchen and Bath on-site Parking Walk To Train",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-1-bedroom-new-kitchen/6497475292.html",
+    "containedIn": {
+      "name": " (port chester, ny)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1690.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "---->> Empire State Building View! --- 10 Min to Lex/59 --- Penthouse!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/empire-state-building-view-10/6497475184.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Condo by the Harbor - the perfect location!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/condo-by-the-harbor-the/6497475115.html",
+    "containedIn": {
+      "name": " (Mamaroneck)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6497474143.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "_____Ultra Luxurious LAYOUT_________Walk In Closet___Great Location___",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxurious-layoutwalk-in/6497472254.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2949.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "__>>LIVE ON WALL ST______CONDO FINISHES____W / D IN YOUR UNIT<_",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/live-on-wall-stcondo/6497472210.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2979.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "--PENTHOUSE--Amazing Water Views--GUT RENOVATIONS--Back on the Market",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-amazing-water-views/6497472135.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "___________BACK ON THE MARKET____FIDI/BATTERY PARK________DOORMAN+GYM+",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/back-on-the-marketfidi/6497471971.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2679.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MODERN FINISHES===AMPLE AMOUNTS OF CLOSET SPACE===GRANITE COUNTER TOPS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/modern-finishesample-amounts/6497460307.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2660.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunset Park_1 BR__NO FEE__$1650__LAUNDRY___Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park1-brno/6497459429.html",
+    "containedIn": {
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM------TONS OF LIGHT-----",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497458960.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2580.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated four bedroom unit located in Ossining!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/renovated-four-bedroom-unit/6497457113.html",
+    "containedIn": {
+      "name": " (Main Street, Ossining)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE **CRAZY DEAL**COZY STUDIO**24HR DM** GORGEOUS**2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-crazy-dealcozy/6497456396.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "VERY BRIGHT and COZY 4Br with Shared Yard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-bright-and-cozy-4br-with/6497456374.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6497452554.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6497449547.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6497447070.html",
+    "containedIn": {
+      "name": " (Bedford Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Top floor renovated 3 bedroom for rent in Katonah!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/top-floor-renovated-3-bedroom/6497444049.html",
+    "containedIn": {
+      "name": " (Anderson Road, Katonah)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "⭐NO FEE Beautiful Mint Cond STUDIO-ELEV/LAUNDRY-DW-MW-2 Min A Express",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-mint-cond/6497440048.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Very large one bedroom TRIPLEX LOFT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-one-bedroom/6497432953.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL Large 1 Br apartment with Private Backyard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1-br/6497431598.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497431348.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3490.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497430638.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3490.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497427931.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6497427194.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3490.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunset Park_2 BR__NO FEE__NEAR MAIMONEDES__Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feenear/6497426450.html",
+    "containedIn": {
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNDER MARKET VALUE!!!!!!! SPACIOUS LIVING ROOM----WINDOW IN EVERY ROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-market-value-spacious/6497424993.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4545.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Convertible 2 Bed/Large 1 Bed in Luxury Building - NO FEE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/convertible-2-bed-large-1-bed/6497423470.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunset Park__2 BR_NO FEE__EXPRESS TRAINS___Sunset Park Slope Boro Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunset-park2-brno-feeexpress/6497418725.html",
+    "containedIn": {
+      "name": " (SUNSET PARK___EDWIN___3 - 4 - 7 -- 4 - 3 - 2 -- 6 - 4 - 6- 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6497416942.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6497411834.html",
+    "containedIn": {
+      "name": " (Lefferts Garden/Prospect Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Boutique Apt in Central Greenwich DENISE ROSATO 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-boutique-apt-in/6497411671.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6497410221.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6497409714.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6497409341.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 1206 Square Foot 2 Bed/2 Bath w/ Terrace and Views!! - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-1206-square-foot-2-bed-2/6497406933.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Private Byram Shore Estate |Stunning Apt |Call Patricia 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/private-byram-shore-estate/6497404749.html",
+    "containedIn": {
+      "name": " (Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Residence on Private Belle Haven Estate CALL PAT 914-830-8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-residence-on-private/6497403982.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated 3Bdrm 2Bath Central Greenwich*Walk 2Train*Pat@ 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-3bdrm-2bath-central/6497402048.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE** CRAZY AMENITIES** BRAND NEW**SPACIOUS**GYM**LAUNDRY**THEATER",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-crazy-amenities-brand/6497401243.html",
+    "containedIn": {
+      "name": " (Bedford-stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2383.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated 2 Bdrm|Dwntn Greenwich|Walk  to Train|CALL PAT 914.830.8191",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/renovated-2-bdrmdwntn/6497400908.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated, Microwave, Dishwasher, Laundry on Site.",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-microwave/6497389879.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE*FEB/MAR*Heat/Wtr/Gas Inc*WTR VU*Elv*DW*WD*Gym*Parking",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feefeb-marheat-wtr-gas/6497389076.html",
+    "containedIn": {
+      "name": " (New Rochelle)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2145.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6497388119.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge Living Room, Big Bedrooms, Master Bedroom w/ Private Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-living-room-big-bedrooms/6497386909.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large Living Space, Lots Of Closet Space, Close to 2 5",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-living-space-lots-of/6497386384.html",
+    "containedIn": {
+      "name": " (East Flatbush)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE 1 MONTH FREE// 38TH FLOOR  // HUGE 4 BED/2 BATH // 24H D/M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-1-month-free-38th/6497384779.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6497379795.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2375.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6497377455.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-Walls of Windows, Condo Finishes, Bright; Hardwood Floors, High",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walls-of-windows-condo/6497372933.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6497366682.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2861.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6497366232.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6497360993.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Bdrm Apt in Springdale Section of Stamford  Call Joe 203.253.5399",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1-bdrm-apt-in-springdale/6497358908.html",
+    "containedIn": {
+      "name": " (Stamford/Springdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! XL Studio, Doorman",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-xl-studio-doorman/6497354594.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2585.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "A newly renovated gorgeous three-bedroom apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-gorgeous/6497354337.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Spacious Kitchens *Near Shopping*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6497352416.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6497345393.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey J)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6497344698.html",
+    "containedIn": {
+      "name": " (Prospect heights @ 2,3,B,Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6497342655.html",
+    "containedIn": {
+      "name": " (Ridgewood @ Seneca M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2609.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6497339453.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! LARGE STUDIO IN PRIME AREA SUNNYSIDE, 1BLOCK TO TRAIN STATION",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-in-prime/6497338007.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS +++ HIGH CEILINGS +++ OVERSIZED WINDOWS +++ OPEN KITCHEN +++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-high-ceilings/6497332326.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3855.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6497331073.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2670.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 75th St - CONV 1 BED - Luxury, Doorman, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-75th-st-conv-1-bed/6497318561.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2654.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE + 3 MNTS FREE***24H_LUX_DRMN_GYM~WASHER/DRYER**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-mnts/6497317475.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4457.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE + 2 MNTS FREE**FLEX 3**24H_LUX_DRMN_GYM**GREAT LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freeflex/6497313827.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3934.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***NO FEE_AMAZING FLEX 3_24H_ LUX_DRMN_ BLDG***GYM/POOL/LOUNGE~HiFLR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-324h/6497309550.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "West 60th St. - CONV 3 BED 2 BATH - Luxury ,Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-conv-3-bed-2/6497307279.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5798.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE***AMAZING FLEX 2BR**REAL WALL**24_LUX_ DRM_ BLDG**GYM/POOL**LO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeamazing-flex-2brreal/6497306152.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW REAL LaRGE ONE BED..S,C,2,3,4,5,B,Q TRAIN..ReNOVATD..4 RooMS..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-real-large-one/6497305494.html",
+    "containedIn": {
+      "name": " (prospect heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE + 2 MNTS FREE***24h_LUX_ DRMN _BLDG***GYM/LOUNGE_ WASHER/DRYER",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-free24hlux-drmn/6497302567.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEES!! - Super Large Apt Glendale/2 bedrooms- Private Deck & Yard",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fees-super-large-apt/6497300585.html",
+    "containedIn": {
+      "name": " (79th Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6497297297.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 88th St - CONV 3 Bed 2 Bath - Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-conv-3-bed-2/6497296574.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5862.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6497288539.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee +2 Mnts Free_XL_Flex 2_24H Lux Drmn_Gym/Rooftop",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-mnts-freexlflex-224h/6497286013.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 72nd St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-72nd-st-1-bed-white/6497283850.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee_XL_ Flex 2_Real Wall_ 24h_Lux_Drmn_Gym/Pool_HiFloor",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feexl-flex-2real-wall/6497278969.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Oversized_Flex 4_24_Lux_Drmn Bldg_Gym/Pool/Lounge_/Real Wall_25th st a",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/oversizedflex-424luxdrmn/6497273214.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5990.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS  STUDIO - NO FEE + 1 MONTH FREE!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-no-fee-1/6497271585.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2423.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lg 3 Bed, Chefs Kitchen, Private Backyard, Utilities Included! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lg-3-bed-chefs-kitchen/6497270135.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Room in 2 Bedroom Apartment in Central Park West and 108th No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-in-2-bedroom-apartment/6497267348.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2-Family Private Home ~~ Beautiful Duplex ~~ Best Area ~  ~R2O ~",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/2-family-private-home/6497258228.html",
+    "containedIn": {
+      "name": " (Belmont)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "INCREDIBLE New Reno 1BR Apt*SS Apls*SHARED YARD*Prime CARROLL GARDENS!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-new-reno-1br-aptss/6497252397.html",
+    "containedIn": {
+      "name": " (Carroll Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Fabulous Sunny TWO Bedroom Apartment in BAY TERRACE*Washer/Dryer Combo",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/fabulous-sunny-two-bedroom/6497251948.html",
+    "containedIn": {
+      "name": " (Bay Terrace)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Incredible Sunny 1BR Condo Apt*SS Apls*DW*LNDRY*Prime Prospect Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-sunny-1br-condo/6497251335.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6497242040.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning 3BR in Great Location! No Fee | Large Apt!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3br-in-great/6497239359.html",
+    "containedIn": {
+      "name": " (Bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Perfect No Fee Studio | Super Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/perfect-no-fee-studio-super/6497236207.html",
+    "containedIn": {
+      "name": " (Bed Stuy / Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6497234246.html",
+    "containedIn": {
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6497232425.html",
+    "containedIn": {
+      "name": " (Bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Studio Apt *** No Fees",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/studio-apt-no-fees/6497218018.html",
+    "containedIn": {
+      "name": " (bensonhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "One Bedroom For Rent on 2nd Floor of Two-Family Home - No Brokers Fee!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/one-bedroom-for-rent-on-2nd/6497190399.html",
+    "containedIn": {
+      "name": " (Eastchester)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6497189085.html",
+    "containedIn": {
+      "name": " (Flatbush/ Brooklyn College/Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497181167.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6497181030.html",
+    "containedIn": {
+      "name": " (holywood ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1638.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6497178329.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV, 2BEDR  CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6497176760.html",
+    "containedIn": {
+      "name": " (Flushing)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2232.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6497170515.html",
+    "containedIn": {
+      "name": " (Flushing)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "100% NO FEE! XL 4 BEDROOM**STEPS FROM LOCAL METRO**UTILITIES INCLUDED*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-xl-4-bedroomsteps/6497167313.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6497164386.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV JUNIOR-1BEDR PRIME  REGO PARK/FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-junior/6497164305.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! LARGE STUDIO CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-large-studio-close-to/6497161727.html",
+    "containedIn": {
+      "name": " (FLUSHING)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny Spacious ALL RENOV 1 BdRm, Just 2 1/2 Blks to Wakefield Station",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/sunny-spacious-all-renov-1/6497161198.html",
+    "containedIn": {
+      "name": " (East Yonkers: Bronx River Rd)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1520.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OVERSIZED 850 SF Sunny Renovated One Bed Rm, Just 2 Blks to RR Station",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/oversized-850-sf-sunny/6497157959.html",
+    "containedIn": {
+      "name": " (Yonkers, West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1520.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CLASSIC PRE WAR SPACIOUS 1 Bed Rm w Working Brick F/Pl",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/classic-pre-war-spacious-1/6497155865.html",
+    "containedIn": {
+      "name": " (HARTSDALE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1580.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large Basement for rent",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-basement-for-rent/6497151467.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6497065218.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6133.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Bed Luxury Long Island City + Indoor Swimming Pool + 2 Months Free!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/1-bed-luxury-long-island-city/6497054873.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2120.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 bedroom apartment-Balcony-Red Hook-Guarantors welcome-nofee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-apartment-balcony/6497043817.html",
+    "containedIn": {
+      "name": " (redhook @ F ,G at Smith-9th St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "gorgeous 3 Bedroom-very spacious- Laundry In Building-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-very/6497043585.html",
+    "containedIn": {
+      "name": " (ridgewood @ M at forest ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6497043233.html",
+    "containedIn": {
+      "name": " (Crown Heights C,S at Franklin Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "4 Nice-sized Bedrooms-2 Full Bathrooms-long island city_NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/4-nice-sized-bedrooms-2-full/6497042880.html",
+    "containedIn": {
+      "name": " (long island city @F at 21st St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6497042475.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS 2 BEDROOM DUPLEX -BEDSTUY -NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-2-bedroom-duplex/6497041968.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant A,C at Utica Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "large 3 bedroom-nice living -bushwick-great deal-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3-bedroom-nice-living/6497040733.html",
+    "containedIn": {
+      "name": " (Bushwick M at Knickerbocker Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6497040329.html",
+    "containedIn": {
+      "name": " (park slope @ F,G,R at 4 Av-9 St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "4 bedroom 2 bath-renovated-2 skylights-bushwick- Great deal-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/4-bedroom-2-bath-renovated-2/6497039907.html",
+    "containedIn": {
+      "name": " (Bushwick  j at Halsey St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3bedroom 2bath-huge living-queen size bedrooms -Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3bedroom-2bath-huge-living/6497039497.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant @ c ralph ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2399.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6497039107.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6497038515.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6497037985.html",
+    "containedIn": {
+      "name": " (Nolita / Bowery)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6497037569.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6497037336.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6497037083.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny 2BR - 4th Floor - Walk Up - No Fee - Desirable UWS Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-4th-floor-walk-up/6497029130.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Largest Duplex With Backyard Near Broadway/Junction",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-largest-duplex-with/6497001947.html",
+    "containedIn": {
+      "name": " (Ocean Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Xtra-Large Duplex w/ Backyard near BWAY/Junction* Hull/E. Pkway",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-xtra-large-duplex/6497001425.html",
+    "containedIn": {
+      "name": " (Ocean Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 luxury Long Beach apartments for rent",
+    "url": "https://newyork.craigslist.org/lgi/nfb/d/2-luxury-long-beach/6496976642.html",
+    "containedIn": {
+      "name": " (Hewlett)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★NO FEE! OPULENT LUXURY ~WD ~OPEN KIT. ~HUGE WINDOWS ~GYM ~POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-opulent-luxury-wd-open/6496972491.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★NO FEE! MODERN FINISHES ~WD ~HIGH CEILING ~Dman ~GYM ~ROOF DECK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-modern-finishes-wd/6496972469.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★NO FEE! 7th AVE. ~WD ~NEW FINISHES ~OPEN KIT. ~Dman ~GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-7th-ave-wd-new/6496951127.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★DESIGNER APT.! 19TH St. ~EXQUISITE FINISHES ~FURN. ~ELEV.&LAUN.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/designer-apt-19th-st/6496951105.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MASSIVE BRAND NEW 1600 SQFT FLEX4BR/2BTH/CITY VIEWS IN LUX,DOORMAN BLD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-brand-new-1600-sqft/6496919037.html",
+    "containedIn": {
+      "name": " (Union Square)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE. Renovated 2 Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-2-bedroom/6496917357.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "A Spacious One-Bedroom Apartment",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-one-bedroom-apartment/6496914266.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6496902903.html",
+    "containedIn": {
+      "name": " (Greenwood / 4th Ave & 27th St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL! 3 BED APT W/ WASH/DRY IN UNIT!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876783.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! SPACIOUS STUDIO APT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6496876593.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6496864218.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MASSIVE 1 Bed**NO BROKER FEE**PLG**AMAZING DEAL!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-1-bedno-broker/6496851108.html",
+    "containedIn": {
+      "name": " (Prospect Park-Lefferts Garden)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6496850109.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496836487.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6133.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No FEE! 1 Month Free!  Spcious 3 Bdrm - Pets Ok! 148th & Broadway",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spcious-3/6496829890.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 1000sq.ft 3 Bed in Elev Bldg - Laundry - Pets Ok - 157 & Bway",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1000sqft-3-bed-in/6496823805.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2833.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Pet-friendly 1bd/1ba steps from subway and large kitchen!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pet-friendly-1bd-1ba-steps/6496822668.html",
+    "containedIn": {
+      "name": " (Fort Greene)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496810675.html",
+    "containedIn": {
+      "name": " (Ditmas park / Cortelyou Rd)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HOT DEAL! MASSIVE SUNNY STUDIO ** 100 % NO BROKERS FEE** LAUNDRY!!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hot-deal-massive-sunny-studio/6496810212.html",
+    "containedIn": {
+      "name": " (Midwood / 2,5 & B Trains)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "===1 MONTH FREE===NEWLY RENOVATED===WALK-IN CLOSET===SUNDRNECHED===TRI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-freenewly/6496797750.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "+++BATTERY PARK+++2 MONTHS FREE+++PANORAMIC ROOFDECK+++LATE SHOWINGS++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-park2-months/6496797127.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "+++1 MONTH FREE+++LUXURY+++RENOVATED+++NATURAL LIGHT+++LATE SHOWING",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month/6496796409.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3470.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "===2 MONTHS FREE===LATE SHOWING===SPACIOUS===LUXURY===RENOVATED===",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-months-freelate/6496795799.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "===BATTERY PARK===RIVER VIEWS===1 MONTH FREE===HUGE WINDOWS===CHEFS KI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/battery-parkriver-views1/6496794052.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Immaculate Spacious 2 Bdrm with den",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-spacious-2-bdrm/6496790991.html",
+    "containedIn": {
+      "name": " (Bonaire)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 BDRM with DINING ROOM AND Den in gorgeous 2nd empire",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/1-bdrm-with-dining-room-and/6496784934.html",
+    "containedIn": {
+      "name": " (STAPLETON)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Immaculate Oversized One Bedroom",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/immaculate-oversized-one/6496783505.html",
+    "containedIn": {
+      "name": " (Saint George)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny Apartment",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-apartment/6496780977.html",
+    "containedIn": {
+      "name": " (Dyker Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6496772662.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CLOSE TO PROSPECT PARK'S SHOPS AND CAFES*SPACIOUS*NEWLY RENOVATED",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-prospect-parks-shops/6496742550.html",
+    "containedIn": {
+      "name": " (PROSPECT PARK SOUTH)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496741302.html",
+    "containedIn": {
+      "name": " (13 Humboldt Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS*NEWLY RENOVATED*OUTDOOR SPACE* CLOSE TO KINGS PLAZA",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spaciousnewly/6496732746.html",
+    "containedIn": {
+      "name": " (Mill Basin)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE!!!!  large studio near Brooklyn College & 2/5 trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-large-studio/6496731301.html",
+    "containedIn": {
+      "name": " (Flatbush/ Brooklyn College/Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Newly Renovated NO FEE 3B 2B with Balcony close to Grand Central!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-no-fee-3b-2b/6496726773.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 2 Bedroom luxury gut renovated in prime Crown Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-2-bedroom-luxury/6496714027.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2195.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL RENO HUGE 2 BED IN PRIME DITMAS PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-reno-huge-2-bed-in/6496712822.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW CONSTRUCTION WITH ROOF DECK! GYM! LAUNDRY! BIKE ROOM!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-construction-with/6496710643.html",
+    "containedIn": {
+      "name": " (CROWN HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 1 Bedroom luxury gut renovated building in prime Fort Green",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-bedroom-luxury/6496709055.html",
+    "containedIn": {
+      "name": " (Fort Green)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3BR/2.5 Bath Private House No Broker Fee",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/3br-25-bath-private-house-no/6496697899.html",
+    "containedIn": {
+      "name": " (Hartsdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "DON'T MISS OUT THIS UNIT WONT LAST LONG!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/dont-miss-out-this-unit-wont/6496697746.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Breathtaking Hotel-Style 2 Bedroom in Bed-Stuy NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/breathtaking-hotel-style-2/6496697007.html",
+    "containedIn": {
+      "name": " (Bed-Stuy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2383.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee Amazing apartment with balcony and super tall ceilings Gramercy",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-apartment-with/6496683797.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5266.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Great Views, New Amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496682105.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "no fee!modern Studio  2/3/4/5/S/A/C trains bike storage",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feemodern-studioa-trains/6496681733.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - TRUE 4BR/2BA W90's W/D in Unit - CLOSETS GALORE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-4br-2ba-w90s-d-in/6496665768.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6864.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496655316.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TONS OF CLOSETS --- STAINLESS STEEL APPLIANCES --- KING SIZED BEDROOMS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tons-of-closets-stainless/6496654825.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3590.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496654035.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3690.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 BATHS!!! OPEN KITCHEN -- WALK IN CLOSETS --- TONS OF WINDOWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-open-kitchen-walk-in/6496646939.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "APRIL 15TH MOVE IN ////////// UNIT 17K ====== CITY VIEWS=== BOUKLIS GR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-unit-17k/6496632887.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNDER MKT / FS LUX 1BR / KIT WITH GRANITE, DW, MW/ MARBL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/under-mkt-fs-lux-1br-kit-with/6496632666.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2929.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated Studio Available March 1st! Exposed Brick & W/D!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-studio-available/6496632156.html",
+    "containedIn": {
+      "name": " (Bedstuy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee- Jr 1 Bed| Gym, Roof Deck, Laundry| Prime Location- E 60s",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-jr-1-bed-gym-roof-deck/6496623448.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2425.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Mill Hill Area Single Family",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/mill-hill-area-single-family/6496619369.html",
+    "containedIn": {
+      "name": " (Bridgeport)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MARCH MOVE IN ////////// UNIT 15D ====== WATER VIEWS  === BOUKLIS GROU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-15d-water/6496616614.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated 2 Bedroom Apartment with lots of sunlight / Pictures",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-2-bedroom-apartment/6496616009.html",
+    "containedIn": {
+      "name": " (East Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stamford Downtown, 4br/2Ba, yard",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/stamford-downtown-4br-2ba-yard/6496600120.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6496600030.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6496597011.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MARCH MOVE IN ////////// UNIT 18L ====== CITY VIEWS=== BOUKLIS GROUP P",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-unit-18l-city/6496590759.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496580650.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PERFECT FOR SHARING __ ROOMMATES ON BUDGET__38 ST & 2 AVE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-for-sharing-roommates/6496579581.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2525.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee - New Development - HUGE PRIVATE TERRACE - Doorman Building",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-huge/6496567997.html",
+    "containedIn": {
+      "name": " (Prospect Lefferts Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2725.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RARE LOFT SPACE - It still exists in Williamsburg! NO FEE - Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/rare-loft-space-it-still/6496561070.html",
+    "containedIn": {
+      "name": " (Williamsburg (Northside))",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - New Development in RED HOOK 2 bedrooms-$2950-$3100",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-new-development-in-red/6496558822.html",
+    "containedIn": {
+      "name": " (Red Hook)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6496554783.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Luxury One Bedroom Unit in Fort Greene! 1.5 MONTHS FREE & NO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-luxury-one-bedroom/6496554511.html",
+    "containedIn": {
+      "name": " (Fort Greene/Downtown/Boehrum Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2590.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6496553964.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- RENOVATED BEAUTIFUL TRUE 2 BED- EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-beautiful/6496553781.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*Lrg 3 Bed 2 Bath in Luxurious Walk Up! * Laundry in Unit * No Fee!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lrg-3-bed-2-bath-in-luxurious/6496552806.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE***LUXURY- 2 BED-24 HR DOORMAN-FURNISHED ROOF DECK WITH A POOL-H",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeluxury-2-bed-24-hr/6496552751.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS STUDIO IN HEART OF FIDI *NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-studio-in-heart-of/6496549594.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-LEX AVE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY R",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-lex-ave-luxury-massive/6496549204.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6496548034.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- RENOVATED BRIGHT BEAUTIFUL TRUE 2 BED- EXPOSED BRICK- WASHER&D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-renovated-bright/6496548011.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE**MASSIVE LUXURY 2BED-FITNESS CLUB-RESIDENTS LOUNGE-MEDIA ROOM-H",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feemassive-luxury-2bed/6496546971.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-LUXURY MASSIVE 2BED-24HR DOORMAN-FURNISHED ROOF-NEWLY RENOVATED",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-massive-2bed/6496545714.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-LIVE IN LUXURY- BRIGHT 2BED-FITNESS CLUB- FURNISHED ROOFDECK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-live-in-luxury-bright/6496544139.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE++HUGE 2BR++KNOCKOUT SIZE++ PRICE HURRY++ 207TH & POST",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feehuge-2brknockout-size/6496542647.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6496541652.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6496538962.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal! Converted 2BR on E 89th St ~ Amazing location ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-deal-converted-2br-on/6496537389.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS STUDIO IN LUXURY BUILDING* NO FEE* FREE RENT* 516-591-7478",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-studio-in-luxury/6496525029.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2769.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MAGNIFICENT GUT RENO THREE BED**NO FEE**HUGE UNIT!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/magnificent-gut-reno-three/6496524752.html",
+    "containedIn": {
+      "name": " (Crown Heights Utica)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Natural Light & New Appliances*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496524192.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous 3 bedroom/ Laundry / Stainless steel appliances/ 2 3 4 5",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-3-bedroom-laundry/6496506305.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 1 bedroom in great location! NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1899.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 1 bedroom in great location! NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-in-great/6496505821.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, REAL 1 BD,FULLY RENOVATED, DISHWASHER, LAUNDRY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-real-1-bdfully/6496497132.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496495097.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1899.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6496494381.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, NEW LUXURY BUILDING, POOL, ROOF DECK, GYM, SAUNA, 24h DOORMAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-new-luxury-building/6496492991.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE- Waterfront Elevated- Impeccable 2 Bedrooms \"Views\" $2170",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-fee-waterfront-elevated/6496484674.html",
+    "containedIn": {
+      "name": " (New Rochelle)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2170.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AMAZING Pelham- 1 Bedroom - Updated -Elevated nr train, NO FEE-DOG OK",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-pelham-1-bedroom/6496478136.html",
+    "containedIn": {
+      "name": " (Pelham- Best Apt Selection)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6496438562.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST DOWNTOWN BK **** CONDO FINISHES **** 11FT CEILINGS *** FREE POOL+",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/best-downtown-bk-condo/6496437549.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee! Gorgeous Sunny 1 Bedroom Jackson Heights! Close to 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-sunny-1/6496434870.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496431422.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6496430354.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Spacious 1 Bedroom Kew Gardens! Metro Ave + Lefferts!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-spacious-1-bedroom-kew/6496428635.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6496423596.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6496422297.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6496419575.html",
+    "containedIn": {
+      "name": " (Rego Park / Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6496416834.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1932.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated Studio with Separate Kitchen * Sunnyside * 2 Blocks to 7 Tra",
+    "url": "https://newyork.craigslist.org/que/nfb/d/renovated-studio-with/6496413817.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6496412240.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6496412097.html",
+    "containedIn": {
+      "name": " (Woodside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SMALL FULLY RENOVATED 1 BEDROOM NEAR  BROOKLYN COLLEGE 2,5 TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/small-fully-renovated-1/6496411072.html",
+    "containedIn": {
+      "name": " (Flatbush)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6496410985.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT DEAL ON SUNNY SPACIOUS 1 BEDROOM NEAR ALL Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-on-sunny-spacious/6496410003.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6496409897.html",
+    "containedIn": {
+      "name": " (Elmhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPRAWLING SUN DRENCHED 3 BEDROOMS OVERLOOKING PROSPECT PARK Q&B TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sprawling-sun-drenched-3/6496408848.html",
+    "containedIn": {
+      "name": " (Prospect Lefferts Vicinity)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bedroom/6496408465.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Spacious 2 Bed 1 Bath + Yard *! By J/M/G/L Tra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6496407342.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2819.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE ON BRIGHT BEAUTIFUL 1 BEDROOM 1 BLOCK FROM PARK 2,3,Q,B",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-on-bright/6496404851.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6496404198.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6496403753.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PRISTINE LIGHT &AIRY 1 BEDROOM CLOSE TO EVERYTHING 2,3,4,5,Q,B,S TRAIN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/pristine-light-airy-1-bedroom/6496402783.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Completely Renovated--Spectacular Finishes--Impecable Value--Gym/Loung",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/completely-renovated/6496379985.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6496378974.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous 2.5 bedroom 1 bathroom/ Spacious / Balcony/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-25-bedroom-1/6496374386.html",
+    "containedIn": {
+      "name": " (Red Hook)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6496373650.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1899.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***RARE 4 BEDROOM IN ASTORIA***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6496373469.html",
+    "containedIn": {
+      "name": " (3415 9th street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6496373009.html",
+    "containedIn": {
+      "name": " (13 Humboldt Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AWESOME STUDIO UWS 72nd St/CPW with NICE MURPHY BED avail!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-uws-72nd-st/6496370062.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Wow! Huge 4BR, Flex 5BR Duplex in Bed Stuy with Backyard!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wow-huge-4br-flex-5br-duplex/6496351187.html",
+    "containedIn": {
+      "name": " (Bedford Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous Newly Renovated  3BR - 1 block from Halsey L train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/gorgeous-newly-renovated-3br/6496349757.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Month Free rent+No Fee*360 Degrees endless views*Floor to ceilings win",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/month-free-rentno-fee360/6496349225.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6133.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Studio in Brooklyn - near Prospect Park and BK Museum!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-studio-in-brooklyn/6496348297.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW! Gorgeous Murray Hill Luxury Studio in Amazing Building! No Fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-gorgeous-murray-hill/6496345144.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2296.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496334329.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Laundry, New Kitchens, Near Subway*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496330728.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing 3BR w/ Yard! Heat &HW included! Great Location! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/amazing-3br-yard-heat-hw/6496327862.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey L)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2570.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Layouts, New Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496327115.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 4BR 2BA Apt in Bed Stuy, Brooklyn | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/large-4br-2ba-apt-in-bed-stuy/6496308067.html",
+    "containedIn": {
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6496317491.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*BUSHWICK NO FEE*3 Bedroom 2 Bath Duplex▰Backyard▰LJMZ TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bushwick-no-fee3-bedroom-2/6496316749.html",
+    "containedIn": {
+      "name": " (Bushwick, Brooklyn Call 347-484-9965)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 4BR 2BA apartment in Bed Stuy | No Fee | Laundry in Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-4br-2ba-apartment-in/6496315171.html",
+    "containedIn": {
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEB/MAR MOVE IN___25th FLOOR___CEILING TO FLOOR WINDOW___SUNRISE VIEW",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/feb-mar-move-in25th/6496313933.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ULTRA LUXE! MIDTOWN WEST*STUDIO*W/D*WATER VIEWS*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown/6496313601.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6496310326.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely No Fee Studio | Super Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-super/6496306309.html",
+    "containedIn": {
+      "name": " (Bed Stuy / Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CITY VIEWS-------WALL TO WALL WINDOWS-----CUSTOM CABINTRY---------NO F",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/city-views-wall-to-wall/6496305824.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6496305742.html",
+    "containedIn": {
+      "name": " (Bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "e 31 / lexington ave ~ NEWLY renovated, GORGEOUS, 2 bedroom-2 baths ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/31-lexington-ave-newly/6496302690.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "****FLOOR TO CEILING WINDOWS*****21ST FLOOR****NYC SKYLINE VIEW****WIN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/floor-to-ceiling-windows21st/6496301814.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2670.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUOS STUDIO LAYOUT________SUN DRENCH_____OVERSIZE WINDOWS______HA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spaciouos-studio-layoutsun/6496299139.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2590.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Duplex Townhouse Style - Pets welcome - bring Fido & Fluffy -",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/duplex-townhouse-style-pets/6496298786.html",
+    "containedIn": {
+      "name": " (Harrison)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3375.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6496298018.html",
+    "containedIn": {
+      "name": " (Greenwich Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW BUILDING________POOL ON ROOF_________10Ft CEILING_____",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-buildingpool-on/6496297663.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2470.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Totally Renovated Apartment For Rent",
+    "url": "https://newyork.craigslist.org/lgi/nfb/d/totally-renovated-apartment/6496294161.html",
+    "containedIn": {
+      "name": " (Selden)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautifully renovated 1 Bedroom apartment in the heart of SoHo",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautifully-renovated-1/6496290035.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6496287500.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6496286107.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6496285389.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Townhome Community 2 Bdrms 2 1/2 Baths DENISE 203.622.4000",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/luxury-townhome-community-2/6496277935.html",
+    "containedIn": {
+      "name": " (Greenwich/Cos Cob/Old Greenwich)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ONE BEDROOM NEAR HARLEM HOSPITAL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/one-bedroom-near-harlem/6496100226.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1425.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6496258458.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning 900 Sq Ft 1 Bed W/Dining Alcove * No Fee & 1 Month Free",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-900-sq-ft-1-bed/6496248255.html",
+    "containedIn": {
+      "name": " (Flatiron)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6496246112.html",
+    "containedIn": {
+      "name": " (Lefferts Garden/Prospect Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "****2 BR FLEX***FULL WALL**LUX BUILDING**100% NO FEE**POOL*GYM**ROOFTO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-br-flexfull-walllux/6496240206.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3195.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Penthouse, gourmet Kitchen, washer & dryer and spectacular outd",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-penthouse-gourmet/6496237691.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 12675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous LARGE No Fee Studio In Prime UWS Drmn/Elev/Lndry Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-large-no-fee-studio/6496228220.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE* Columbus Circle 24HR LUXURY swimming POOL/roof deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-columbus-circle-24hr/6496227066.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2723.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Near Transportation, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496221565.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2205.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 850SQ FT NO FEE 1BD IN DRMN/GYM/LNDRY BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-850sq-ft-no-fee-1bd-in/6496213867.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous West Village 1BR/1BA!! Great Deal!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-west-village-1br-1ba/6496206944.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE OPEN HOUSE in Kew Gardens by Atlantic Management 718-726-0003",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-open-house-in-kew/6496200994.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Midtown West - Large Studio W 34th Street and 9th Ave - PRICE BREAK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/midtown-west-large-studio/6496190532.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GIANT WINDOWS__GOURMET KITCHEN___NEW APPLIANCES___MINT CONDO FINISH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/giant-windowsgourmet/6496188628.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3120.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Exceptional 1,900 Sq Ft 3 Bed 2 Bath Palace ~ Wrap Around Terrace ~ So",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/exceptional-1900-sq-ft-3-bed/6496188039.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous No Fee +1 Mnth Free Studio In Drmn/Elev/Lndry/Gym Building",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-no-fee-1-mnth-free/6496186262.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2353.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NEW LIST*HUGE 870SQ FT NO FEE+1MONTH FREE 1BD IN DRMN/GYM/LNDRY BLDG",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/new-listhuge-870sq-ft-no/6496181375.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3276.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6496180835.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Below Market West Village 1BR/1BA!! No Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/below-market-west-village-1br/6496165056.html",
+    "containedIn": {
+      "name": " (West Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "What a DEAL!!Awesome 3 BED!!!Newly Renovated!!WOW!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/what-dealawesome-3-bednewly/6496157213.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6496152425.html",
+    "containedIn": {
+      "name": " (East Flatbush)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1475.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE*IN THE HEART OF TOWN..CLOSE TO RR/SHOPS*CHARMING*BUILDING*CATS",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/no-feein-the-heart-of/6496133794.html",
+    "containedIn": {
+      "name": " (TARRYTOWN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "✿COMMUTERS DREAM~REAL2BR~YOU'LL LOVE THIS APT & THE LOCATION !",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/commuters-dreamreal2bryoull/6496102159.html",
+    "containedIn": {
+      "name": " (𘝍Walk to Metro-North Fleetwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - 1 Beautifully furnished 1 bedroom apartment (id 43)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-beautifully/6496097778.html",
+    "containedIn": {
+      "name": " (Kips Bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6496092233.html",
+    "containedIn": {
+      "name": " (Ditmas park / Cortelyou Rd)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6496082858.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6496082551.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6496082095.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6496068611.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1825,SS Kit,HRDWD,Gym,W/D,Gar,Terr",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6496068357.html",
+    "containedIn": {
+      "name": " (Stamford)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "►Soho/LOFTSTYLE$1620,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1620hi-ceilngwk/6496067211.html",
+    "containedIn": {
+      "name": " (STAMFORD, CT)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1620.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SOARING CEILINGS__22nd FLOOR___MASSIVE WINDOWS___EXTRA CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/soaring-ceilings22nd/6496049379.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6496037020.html",
+    "containedIn": {
+      "name": " (Bay Ridge)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens *Spacious Apt Near Subway*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6496034792.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FURNISHED ROOMS (Shared Apartment) Long/Short Term",
+    "url": "https://newyork.craigslist.org/que/nfb/d/furnished-rooms-shared/6496033760.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6496033059.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2780.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CENTRAL PARK NORTH - 2 Bed 1 Bath - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/central-park-north-2-bed-1/6496023639.html",
+    "containedIn": {
+      "name": " (East Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New FiDi, W/D, No Brokers Fee Plus 2 Months Free Rent, No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-fidi-d-no-brokers/6496023151.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3777.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 92nd ? UES - Luxury Studio $2,432 - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-92nd-ues-luxury-studio/6496022006.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2432.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6496021776.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey J)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6496021625.html",
+    "containedIn": {
+      "name": " (Prospect heights @ 2,3,B,Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6496021332.html",
+    "containedIn": {
+      "name": " (Ridgewood @ Seneca M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2609.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "West 34th St. - CONV 3 Bed 2 Bath $4,450 net - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-34th-st-conv-3-bed-2/6496020074.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6496019700.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*STEPS TO PROSPECT PARK-BEAUTIFUL AREA-NEWLY RENOVATED-VERY SPACIOUS*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/steps-to-prospect-park/6496019241.html",
+    "containedIn": {
+      "name": " (crown heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 81st St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-81st-st-1-bed-white/6496018345.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2837.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Modern Room in shared apartment close to the train minutes to Manhatta",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/modern-room-in-shared/6496017837.html",
+    "containedIn": {
+      "name": " (Bedford stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 88th St - 1 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-88th-st-1-bed-white/6496017175.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2929.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*VERY AFFORDABLE NICE SIZED ROOM IN MODERN BUILDING CLOSE TO TRAIN**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/very-affordable-nice-sized/6496016638.html",
+    "containedIn": {
+      "name": " (East Flatbush)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large---------Studio --Vacant Ready---Near All  Call 646-250-8787",
+    "url": "https://newyork.craigslist.org/que/nfb/d/large-studio-vacant-ready/6496016099.html",
+    "containedIn": {
+      "name": " (Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1475.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated, Close to A C L, Roof Access",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-close-to-c-roof/6496012152.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large Bedrooms/Living Room, Hardwood Floors, Close to B Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-living-room/6496012091.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large Bedrooms, Large Living Room, Yard, By L train, Close to J M Z",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-bedrooms-large-living/6496011924.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bright, Luxury Studio / Modern Finishes, Laundry In-Unit, Pool, Gym, H",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-luxury-studio-modern/6495977703.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!! JUNIOR 1 BR/ALCOVE STUDIO IN FORT GREENE / DOBRO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-junior-1-br-alcove/6495977515.html",
+    "containedIn": {
+      "name": " (Boerum Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning and Vibrant Alcove Studio Apartment Located in Downtown Brook",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-and-vibrant-alcove/6495977368.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2325.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495977244.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE* ELEGANT STUDIO+HOME OFFICE, FLEX 2BR, 24HR DOORMAN, GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-elegant-studiohome/6495976913.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2867.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Long Island City ** 2beds with Wall* Partially Furnished* Luxury*NO FE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/long-island-city-2beds-with/6495976719.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large NO FEE Studio in the heart of the Financial District",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-no-fee-studio-in-the/6495976230.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2355.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury TRUE 1 / Flex 2 Bedroom *Modern Finishes*Laundry In-Unit*Pool*G",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-true-1-flex-2-bedroom/6495975819.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE LUXURY STUDIO, WITH OPEN KITCHEN, 24HR DOORMAN, FREE GYM AND AMAZ",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-luxury-studio-with-open/6495975507.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury Beautiful *NO FEE* One Bedroom in Fort Greene / Washer In Unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/luxury-beautiful-no-fee-one/6495975380.html",
+    "containedIn": {
+      "name": " (Boerum Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely Studio Apartment with Top Notch Finishes Located in Battery Par",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lovely-studio-apartment-with/6495970984.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 2.5 BR Apartment - Great price - Stuyvesant Heights",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-25-br-apartment/6495967695.html",
+    "containedIn": {
+      "name": " (Stuyvesant Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "REDUCED FEE!!!!! Spacious open layout GEM in PRIME Riverdale Loc",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/reduced-fee-spacious-open/6495951203.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!!!! HUGE 3Bed/2Bath in BEAUTIFUL Pre-War Riverdale Building",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-huge-3bed-2bath-in/6495950297.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2975.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!! LARGE STUDIO IN FORT GREENE / DOBRO",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-studio-in-fort/6495946291.html",
+    "containedIn": {
+      "name": " (Boerum Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Newly Renovated - Upper East Side - immediate move-in",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated-upper-east/6495943868.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2689.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495926225.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**SUNNY 2BR W/EXPOSED BRICK W 106 ST NEAR CENTRAL PARK & B/C TRAINS**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-2br-exposed-brick-106/6495923009.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2881.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "** ALL NEW 2BR ON BROADWAY & TIEMANN NEAR COLUMBIA & MSM - NO FEE **",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/all-new-2br-on-broadway/6495921088.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2451.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495905881.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3480.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495876435.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Near Transport* *Spacious Apts*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495875665.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495874363.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6495865916.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6495865347.html",
+    "containedIn": {
+      "name": " (Nolita / Bowery)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6495865012.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6495864773.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6495864558.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Upper East Side Mint Condition 1 Bedroom No Fee Convenient Location",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/upper-east-side-mint/6495864182.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 1 Bed in UWS; Eat in Kitchen; Marble Bathroom; Walk in Closet",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-bed-in-uws-eat-in/6495829178.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495823211.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OPEN HOUSE+++NO FEE+++E. 60's+++BEST DEAL UES+++CALL 646.247.6444!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-houseno-feee-60sbest/6495816286.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495807285.html",
+    "containedIn": {
+      "name": " (midwood/ Sheepshead bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "newly renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6495807260.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2549.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bright, Clean, queen size bedrooms, Laundry, Dishwasher, J M Z L train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-clean-queen-size/6495806967.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495806577.html",
+    "containedIn": {
+      "name": " (Kensington)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous 1 Bedroom in Newly Renovated Apartment Available April 1st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-1-bedroom-in-newly/6495800907.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495800346.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3480.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "newly gut renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-gut-renovated/6495800250.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2449.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEWLY RENO MIDTOWN WEST 1BR*2FM|14MN*NO SEC.DEP.*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-reno-midtown-west/6495799908.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "💛💛AWESOME💛💛 3 BR W/ EXPOSED BRICK WALL IN PRIME",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-br-exposed-brick/6495791232.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "🔶BEAUTIFUL DEAL🔶 ! 2 Bedroom in Prime Bushwick Area! NO FEE !!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-deal-2-bedroom-in/6495788703.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ULTRA LUXE! MIDTOWN WEST*2BR*W/D*HGH FL*C/W VIEW*2FM|14MN*PAY NET RENT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ultra-luxe-midtown-west2brw/6495787529.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "A Crown Heights Pre-War Beauty | Fine Detailing | No Fee | Must See!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/crown-heights-pre-war-beauty/6495783330.html",
+    "containedIn": {
+      "name": " (Pacific @ A,C train Franklin/Nostrand)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2985.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 MONTH FREE******** W/D IN UNIT********  AMAZING WATER VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-d-in-unit/6495783130.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495780310.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1932.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXE! MIDTOWN WEST*1BR*2FM|14MN*PAY NET RENT*BEST DEAL IN MIDTOWN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown/6495776062.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXE! MIDTOWN WEST*JR.1 ALC.STUD*W/D*2FM|14MN*PAY NET RENT*CALL BAMBI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-westjr1-alcstudw/6495767209.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 70s_NO FEE_Luxury 1 Bedroom w/ Doorman_GYM_Roof Deck_Playroom_Val",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-70sno-feeluxury-1/6495763252.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!...TRUE 3 BED...EAST 70TH...LAUNDRY...RENO...DW...LIVE IN SUPE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feetrue-3-bedeast/6495762813.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXE! MIDTOWN WEST*STUDIO*WATER VIEW*2FM|14MN*PAY NET RENT*CALL BAMBI!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxe-midtown-weststudiowater/6495757738.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Bay Ridge 2 Bed w/ Laundry. Walk to Gym, Train, & Shops!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bay-ridge-2-bed/6495734947.html",
+    "containedIn": {
+      "name": " (Bay Ridge)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huuuuge 2BR Stunner!!__{No Fee}__Unbelievable CLOSET SPACE!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huuuuge-2br-stunnerno/6495727313.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3476.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny UWS Studio - State of the Art RENO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-uws-studio-state-of-the/6495726302.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Beautiful renovated 2BR walk up - Available for Imm move in !!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-renovated/6495725600.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3822.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful One Bed (Upper East)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-one-bed-upper-east/6495718562.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning one bedroom  | Stainless Steel Appliances | Park & City Views",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-one-bedroom/6495707655.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Renovated 3 Bed (Upper East)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/renovated-3-bed-upper-east/6495705893.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Tribeca NYC Luxury Apartment, 3B/2B/BAL + WD , 2 Free Months, No Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-nyc-luxury-apartment/6495700105.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW ONE BED#####BEST VIEWS IN BROOKLYN____LIVE LIKE URBAN ROYALT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-one-bedbest-views/6495692482.html",
+    "containedIn": {
+      "name": " (Downtown)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6495691981.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2 Bedroom 2 Bath, Beautifully Renovated Doorman Building, 1 M",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bedroom-2-bath/6495691943.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - UWS 1BR Pre War Charm - P/T Doorman - Available Now",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-uws-1br-pre-war-charm/6495691793.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2966.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MASSIVE++ 3Bed in Prime Washington Heights!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3bed-in-prime/6495688325.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brownstone 2Bedroom with Private outdoor space - block is to die for!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brownstone-2bedroom-with/6495681374.html",
+    "containedIn": {
+      "name": " (Stuyvesant Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2195.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-THE CLOISTERS' BEST DEAL IN AREA-MASSIVE 2 BED- A EXPRESS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-cloisters-best/6495680440.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***RARE 4 BEDROOM IN ASTORIA***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/rare-4-bedroom-in-astoria/6495677740.html",
+    "containedIn": {
+      "name": " (3415 9th street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous Custom Studio at The Alabama! 11th & 5th Ave. No Broker Fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-custom-studio-at-the/6495676629.html",
+    "containedIn": {
+      "name": " (Union Square)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST OF WILLIAMSBURG!____AMAZING WATER VIEWS!____CANT BEAT THIS NEW BU",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/best-of-williamsburgamazing/6495676243.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**RENOVATED WILLIAMSBURG 3 BED** Unbeatable Price",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/renovated-williamsburg-3-bed/6495669836.html",
+    "containedIn": {
+      "name": " (13 Humboldt Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE  1 MONTH FREE SUNLIT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-sunlit/6495666381.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 2 Months FREE RENT - Upper West Side Pre War Charm",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-rent/6495662913.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3192.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE* LARGE 2 Bed in Prospect Lefferts Gardens! 2 & 5 trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-2-bed-in/6495662867.html",
+    "containedIn": {
+      "name": " (Prospect Lefferts Gardens / Nostrand Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495658646.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS STUDIO IN PRIME CROWN HEIGHTS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-studio-in-prime/6495658177.html",
+    "containedIn": {
+      "name": " (Franklin Ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**** NO FEE **** *** PRIME LOCATION *** ** 24 HOUR WHITE GLOVED ** **** GORGEOUS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-prime-location-24-hour/6494364835.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6495645865.html",
+    "containedIn": {
+      "name": " (Red Hook)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Low security deposit, no fee+free rent*Large Terrace*High ceilings*Flo",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/low-security-deposit-no/6495639723.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3480.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6495634200.html",
+    "containedIn": {
+      "name": " (Bedstuy @ A & C subway)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive Gut Renovated**Gorgeous Apartment**DITMAS PARK**NO FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/massive-gut-renovatedgorgeous/6495631810.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT DEAL**Prime Ditmas Park**No FEE**LAUNDRY&ELEVATOR!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-dealprime-ditmas-parkno/6495630991.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6495629678.html",
+    "containedIn": {
+      "name": " (Crown Heights @ A & C Nostrand ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6495629364.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, **Brand New Kitchens & Gym!**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495627825.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, laundry, great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495626217.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *spacious apts with amenities*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495623643.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2625.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**LUX BUILDING*TRUE 1 BR *100% NO FEE **24 DM **GYM/POOL/ROOFTOP*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-buildingtrue-1-br-100-no/6495622948.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "****** NO FEE ****** *** GORGEOUS BUILDING *** ** SWIMMING POOL ** *** INSANE AP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-building/6495621536.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6495620491.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**XXL STUDIO**100%NO FEE**24 DM**GYM*LOUNGE*POOL*ROOFTOP**INSANE DE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xxl-studio100no-fee24/6495619495.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***100 % NO FEE***2 MONTH FREE*XXL STUDIO***ROOFTOP**LOUNGE**HIGHLINE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee2-month-freexxl/6495616786.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MONTH FREE net effec.rent $2745 LG1 BR MBL BTH  UES Low 70s G",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free-net/6495611764.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "24/7 DOORMAN__FREE BIKE STORAGE____WATER VIEWS____SEPARATED KITCHEN __",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/24-7-doormanfree-bike/6495611623.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FULL SERVICE BLDG REAL 2BED/2BATH SPACIOUS LIVING ROOM GYM STEPS FROM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/full-service-bldg-real-2bed/6495611625.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PENTHOUSE PENTHOUSE PENTHOUSE____UNBEATABLE LOCATION____#VIEWS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-penthouse/6495611133.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TONS OF NATURAL LIGHT~~~~~~~FULL SIZE W/D IN UNIT~~~~~~~STARBUCKS COFF",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/tons-of-natural-lightfull/6495597526.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2375.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - Charming 2bed located in Prime crown heights off Eastern Pkwy",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-charming-2bed-located/6495592434.html",
+    "containedIn": {
+      "name": " (crown heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Newly Renovated Queen 3 bedroom w 2 FULL baths !! A MUST SEE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-newly-renovated-queen-3/6495585618.html",
+    "containedIn": {
+      "name": " (Ridgewood @ Seneca M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2609.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!  Unique, Gut-Reno Loft-style 3BR with 15' Ceilings, Exposed Brick &",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-unique-gut-reno-loft/6495560570.html",
+    "containedIn": {
+      "name": " (Greenpoint)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**TRUE 1 BEDROOM**100% NO FEE**LUX**24 HR DM**MONTH FREE**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom100-no-feelux24/6495553474.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AMAZING CITY VIEWS -- OPEN KITCHEN -- TONS OF CLOSETS -- QUEEN SIZED B",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-city-views-open/6495553006.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2670.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495552132.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Spacious Layouts, Near Subway!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495551710.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6495545252.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 BATHS!!! --- UNDER MARKET VALUE!!! --- HARDWOOD FLOORS --- HIGH CEIL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2-baths-under-market-value/6495543367.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE CORNER APARTMENT -- WINDOW IN EVERY ROOM -- WATER VIEWS -- OPEN K",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-corner-apartment-window/6495542273.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4680.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WATER VIEWS -- KING SIZED ROOMS -- HUGE LIVING ROOM -- TONS OF CLOSETS",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/water-views-king-sized-rooms/6495540582.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3590.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE LIVING AREA --- PLENTY OF CLOSET SPACE --- TONS OF LIGHT --- HIGH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-living-area-plenty-of/6495540124.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2340.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny and large 1 Bedroom on the Upper East Side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sunny-and-large-1-bedroom-on/6495524581.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2275.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "MARCH MOVE IN ////////// 3 BEDROOM ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-move-in-3-bedroom-city/6495523685.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "APRIL 15TH  MOVE IN ---- 20TH FLOOR ----- FULL SERVICE ----- CONDOMINI",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/april-15th-move-in-20th-floor/6495522164.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2775.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE BEAUTIFUL KITCHEN DISHWASHER LAUNDRY HUGE BEDROOM 3",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-broker-fee-beautiful/6495506268.html",
+    "containedIn": {
+      "name": " (ASTORIA)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bay Windows, Dining Alcove, Oversized Windows, Wall of Windows, Washer",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bay-windows-dining-alcove/6495506156.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 7745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXURY 1 BEDROOM (HUGE BEDROOM) (FREE UTILITIES) ) - SEE FLOOR PLAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-1-bedroom-huge-bedroom/6495505785.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 1BR NO BROKER FEE DISHWASHER LAUNDRY SPACIOUS BEDROOM",
+    "url": "https://newyork.craigslist.org/que/nfb/d/huge-1br-no-broker-fee/6495505761.html",
+    "containedIn": {
+      "name": " (ASTORIA)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXURY HUGE 2-BR (HUGE BEDROOMS) (FREE UTILITIES) (SEE FLOORPLAN)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-huge-2-br-huge/6495505323.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXURY 3 BEDROOM (NEW RENOVATION) (SEE FLOORPLAN) (FREE UTILITIES)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/luxury-3-bedroom-new/6495504840.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1000 SQ FT RENOVATED 2-BR * TONS OF CLOSET SPACE - SEE EXACT FLOORPLAN",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1000-sq-ft-renovated-2-br/6495504323.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENT STABILIZED $2,600 1br 1ba elevator dishwasher W/D in unit",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rent-stabilizedbr-1ba/6495503677.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE GIGANTIC 2BED/2BATH COLUMBUS CIRCLE FULL SERVICE DOORMAN FITNES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gigantic-2bed-2bath/6495502923.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand new finishes! 1 Bed in prime location at NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-finishes-1-bed-in/6495501886.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2855.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Prime Downtown Location! Spacious 2bed 2 ba..NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-downtown-location/6495501114.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Walls Of Floor to Ceiling Glass Windows, Incredible city views, State",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6495499927.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True No Fee 3BR w/ Yard! Heat &HW included! Great Location!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-no-fee-3br-yard-heat-hw/6495487689.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey L)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2570.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST DEAL IN MIDTOWN WEST NO BROKER FEE ELEVATOR BUILDING",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-deal-in-midtown-west-no/6495477378.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *New Amenities, Great Views*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495472223.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2070.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STELLAR 3 BEDROOM 2 BATH. BALCONY! DISHWASHER. GREAT AREA. NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stellar-3-bedroom-2-bath/6495466070.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New No Fee Two Bedroom Apartment with Amazing Views in Downtown",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/brand-new-no-fee-two-bedroom/6495462761.html",
+    "containedIn": {
+      "name": " (DOWNTOWN BROOKLYN)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MO.FREEnet rent $3020 LG 1 BR MBL BTH Hi flr UES  70s GYM RFD",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-3020/6495462646.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6495462583.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW**NO FEE*Converted 2 BR TERRACE* ELEVATOR TOWNHOUSE 60th nr 3rd LND",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wowno-feeconverted-2-br/6495462538.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Renovated Apts *Near Shopping*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6495457131.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "--->Mint New Dev--->Laundry in Unit--->Lux Amenities--->",
+    "url": "https://newyork.craigslist.org/que/nfb/d/mint-new-dev-laundry-in-unit/6495447297.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "=== 3 BEDROOM 2 BATH==PERFECT FOR ROOMATES==NO FEE==1 MONTH FREE==",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bedroom-2-bathperfect-for/6495435722.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "___CORNER APT-- WATER & BRIDGE VIEWS -- W/D IN UNIT -- CHEF'S KIT",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/corner-apt-water-bridge-views/6495425971.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3508.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee- 1 BR, 1BA. $2600/mo. Upscale Renovations. Avail now. Pets OK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-br-1ba-2600-mo/6495424824.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Close to Transport & Entertainment*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6495421004.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 2 MONTH FREE - LARGE 4 BR / 2.5 BATH -- PRIVATE TERRACE- WASH",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-large-4/6495415885.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Extra Sunny UWS Charmer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/extra-sunny-uws-charmer/6495407694.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 1 MONTH FREE -- SPACIOUS 3 BR -- FULL LUXURY BLDG - GYM - ROO",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-spacious/6495405482.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4520.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - 4 BR / 2 BATH - BRAND NEW BUILDING - FULL LUXURY AMENITIES -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-4-br-2-bath-brand-new/6495401952.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6460.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE++ 2BR++MASSIVE LIVING ROOM++DOGS ALLOWED++ ELEVATOR++ LAUNDRY++",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2brmassive-living/6495398429.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 2 MONTH FREE -- BRAND NEW RENOVATED -- 3 BR -- DOORMAN -- GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-month-free-brand-new/6495389547.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4564.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Duplex w/ Private Yard. March 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/duplex-private-yard-march-1st/6495385855.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE THE BEST MIDTOWN HAS TO OFFER FULL SERVICE LUXURY DM BLDG POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-the-best-midtown-has/6495380105.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Fresh Renovations! 4 bed two bath! march 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fresh-renovations-4-bed-two/6495374131.html",
+    "containedIn": {
+      "name": " (23rd Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS 3 BEDROOM APARTMENT! DISHWASHER! QUIET AREA! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-apartment/6495372663.html",
+    "containedIn": {
+      "name": " (Bushwick @ Myrtle L)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2549.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SUNNY & GIGANTIC 4 BEDROOM BARGAIN! QUIET AREA! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-gigantic-4-bedroom/6495372297.html",
+    "containedIn": {
+      "name": " (Prospect Lefferts Gardens @ Church 2/5)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3099.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 3 Bedroom! Great Location! ONE MONTH FREE!! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-3-bedroom-great/6495371985.html",
+    "containedIn": {
+      "name": " (Crown Heights @ Nostrand 2/3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2749.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Modern 2 Bed! Dishwasher! Shared Yard! Great Area | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-modern-2-bed/6495371619.html",
+    "containedIn": {
+      "name": " (Williamsburg @ Lorimer J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 4 Bedroom Beauty! Newly Renovated! Skylit Window! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-4-bedroom-beauty/6495370728.html",
+    "containedIn": {
+      "name": " (Bushwick @ Hasley J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS & AFFORDABLE 3 BED! LAUNDRY & YARD! PRIME LOCATION! | NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-affordable-3-bed/6495370403.html",
+    "containedIn": {
+      "name": " (Williamsburg @ Flushing J/M/Z)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful & Affordable 3 Bedroom in Prime Area! | No Fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-affordable-3/6495369994.html",
+    "containedIn": {
+      "name": " (Flatbush @ Newkirk Plaza B/Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO Fee ~ Huge Studio ~ Elevator, Laundry ~ 1 Free Month",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-huge-studio-elevator/6495369591.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2375.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!! LARGE  STUDIO-- HIGH CELLINGS -- P-R-I-M-E LOCATION-- MUST T",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-high/6495368890.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 3 bedroom on Upper East Side. No fee!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-3-bedroom-on-upper/6495368065.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FOR RENT! 4BED 2BA // Avail March 1st!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/for-rent-4bed-2ba-avail-march/6495363289.html",
+    "containedIn": {
+      "name": " (West 123rd Street)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & FREE MONTH -- ELEVATOR / LAUNDRY / MUST TAKE ADVANTAGE QUICK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-free-month-elevator/6495363074.html",
+    "containedIn": {
+      "name": " (Flatiron)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "March 1 ready!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/march-1-ready/6495362339.html",
+    "containedIn": {
+      "name": " (East 6th)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 1 MONTH FREE - LARGE PENTHOUSE - LUXURY BUILDING - GYM - ROOF",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-large/6495360579.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE--S-O-H-O!! FULLY RENO!!  LARGE 2 BR - SUPER SUNNY-- ELEV",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-o-o-fully-reno/6495355852.html",
+    "containedIn": {
+      "name": " (SoHo)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!! TRUE 3 BR -- PRIME LOCATION -- 29 ST & 3 AVE !! ELEVATOR - LA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-true-3-br-prime/6495352310.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & MONTH FREE // ULTRA HIGH RISE IN TIMES SQUARE // LAUNDRY IN U",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-month-free-ultra-high/6495341368.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2616.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 2BR Flatiron!! Great for Shares!! No fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-2br-flatiron-great/6495336658.html",
+    "containedIn": {
+      "name": " (Flatiron)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 2 MONTHS FREE -- LARGE STUDIO -- RESIDENT LOUNGE -- HEALTH CL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large/6495333774.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2447.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 2 MONTHS FREE -- LARGE 2 BR APT -- BRAND NEW BLDG -- 24 HR DM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-large-2/6495332222.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2966.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE AMAZING LOFT 1 BR!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-amazing-loft-1-br/6495324629.html",
+    "containedIn": {
+      "name": " (Flatiron)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous and large 1br! NO FEE! Laundry, Roof Deck. !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-and-large-1br-no-fee/6495323230.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1899.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Floor Thru Two Bedroom BRAND NEW KITCHEN - Short Walk To trains & Park",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/floor-thru-two-bedroom-brand/6495319597.html",
+    "containedIn": {
+      "name": " (PROSPECT HEIGHTS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**No Fee** 1BR__Prime UES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1brprime-ues/6495303185.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6495302161.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! PETS OK! Renovated 2 BEDROOM! Elevator/Laundry! 7 Trains/Shopp",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-renovated-2/6495293290.html",
+    "containedIn": {
+      "name": " (Flushing)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2232.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNIQUE 3BR in Jackson Heights - MUST SEE!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/unique-3br-in-jackson-heights/6495288556.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "w 56 / 9  ~ NEWLY renov 1 bedroom ~ DEAL of the Year ~ No fee ~",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/56-9-newly-renov-1-bedroom/6495283756.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Triboro Bridge Views -- No Fee! -- Washer/Dryer in Unit -- Brand New L",
+    "url": "https://newyork.craigslist.org/que/nfb/d/triboro-bridge-views-no-fee/6495270517.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE WALK TO GRAND CENTRAL SUPER LUXURY DM BLDG POOL & GYM MARBLE BA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-walk-to-grand-central/6495267856.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Transport!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495247130.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2780.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! Gorgeous 1 Bedroom in JACKSON HEIGHTS by 7 Train! Pet Friendly",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gorgeous-1-bedroom-in/6495223971.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated 2 Bed 1 Bath * Jackson Heights *",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-2/6495222241.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE__STUDIO BASEMENT___PETS ALLOWED__9 ST & 1 AVE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feestudio-basementpets/6495221482.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Huge 1 Bed 1 Bath* By 7 Train!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated-huge/6495218975.html",
+    "containedIn": {
+      "name": " (Jackson Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495208950.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Beautiful Renovated 1 Bed 1 Bath * Kew Gardens! Metro Ave/Lef",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-beautiful-renovated-1/6495205701.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Renovated Studio * Kew Gardens! Pet Ok!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-renovated/6495204516.html",
+    "containedIn": {
+      "name": " (Kew Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6495202722.html",
+    "containedIn": {
+      "name": " (Bed Stuy / Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Incredible Deal in Prospect Heights, Fully renovated 2 bed 2 bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/incredible-deal-in-prospect/6495202549.html",
+    "containedIn": {
+      "name": " (Prospect heights @ 2,3,B,Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "------>The Penelope Luxury Rentals------->1 Month Free------->",
+    "url": "https://newyork.craigslist.org/que/nfb/d/the-penelope-luxury-rentals-1/6495202045.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2469.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GORGEOUS 4 bedroom 2 full bathroom DUPLEX w YARD",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-4-bedroom-2-full/6495201763.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey J)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee! Pets Ok! Beautiful Sunny 1 Bedroom Woodside ! By E,F,M,R,7,LIR",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-pets-ok-beautiful/6495200419.html",
+    "containedIn": {
+      "name": " (Woodside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495199849.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUX *****GYM*****DOORMAN*****BREATHTAKING VIEWS*****MUST SEE*****",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/lux-gymdoormanbreathtaking/6495197375.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free * Sunnyside * Renovated HUGE 1 Bed 1 Bath * By 7",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-1-month-free-sunnyside/6495196995.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1932.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Studio/Separate Kitchen * Sunnyside * By 7 Train !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-studio/6495194474.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge 3 bedroom 3 full bath/ Parking/ Laundry hookup/ Balcony",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-3-bedroom-3-full-bath/6495192953.html",
+    "containedIn": {
+      "name": " (Midwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3699.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Studio * Rego Park * By M & R Trains & Rego Mall !",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-studio-rego/6495189651.html",
+    "containedIn": {
+      "name": " (Rego Park / Forest Hills)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 1 Bed 1 Bath * By M/R Trains * Rego Park",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-1-bed-1/6495174405.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Huge 2 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-huge-2-bed-1/6495172521.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE!!! Beautiful bright 1 bedroom. Lower East prime*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-bright-1/6495170414.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Elmhurst * Spacious 3 Bed 1.5 Bath * By E,M,R Trains/Queen Ce",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-elmhurst-spacious-3/6495169671.html",
+    "containedIn": {
+      "name": " (Elmhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Brokers Fee * Spacious 1 Bedroom Williamsburg! By J/M/G/L Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-brokers-fee-spacious-1/6495167505.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Location! Cute Studio in Beautiful Clinton Hill  | No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-cute-studio-in/6495164507.html",
+    "containedIn": {
+      "name": " (Bedstuy @ Franklin C)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee & 1 Month Free!! Spacious 2 Bed 1 Bath + Yard!! By J/M/G/L Trai",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-spacious/6495161872.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2818.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal! Large Classic Beautiful Bushwick 2 Bedroom with No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-large-classic/6495159740.html",
+    "containedIn": {
+      "name": " (bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Fully renovated 2 bedroom Apts-Inwood NYC",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/fully-renovated-2-bedroom/6495157586.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bright Beautiful Bushwick 3 Bed with Back Yard Access || No Fee! ||",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-beautiful-bushwick-3/6495156968.html",
+    "containedIn": {
+      "name": " (Bushwick @ Halsey L train)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2570.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Location! Beautiful Bright 3 Bedroom in Crown Heights No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-location-beautiful/6495156017.html",
+    "containedIn": {
+      "name": " (Crown Heights @ Franklin Ave A,C)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Bright Williamsburg 2 Bed with Laundry and Backyard! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-bright-williamsburg/6495154001.html",
+    "containedIn": {
+      "name": " (Williamsburg @ Lorimer JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal! Bright Spacious Bedstuy 4 Bed In Unit Laundry!  No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-bright-spacious/6495152550.html",
+    "containedIn": {
+      "name": " (bedstuy @ utica A,C)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3275.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal! Massive Bright 3 Bedroom in Beautiful Ditmas Park No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-deal-massive-bright-3/6495151178.html",
+    "containedIn": {
+      "name": " (Ditmas Park @ Newkirk Plaza B, Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee, 3 Bed,  Free 40\" flat screen TV! Minutes From Manhattan!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-3-bed-free-40-flat/6495147578.html",
+    "containedIn": {
+      "name": " (Mott Haven)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2015.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No fee, 1 month free and all Utilities included",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-free-and-all/6495146511.html",
+    "containedIn": {
+      "name": " (East Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 4 Bedroom in Prime Bed-Stuy",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-4-bedroom-in-prime/6495146306.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Newly renovated 3 bedroom apartment! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovated-3-bedroom/6495142366.html",
+    "containedIn": {
+      "name": " (Ridgewood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning Red Hook 2.5 Bedroom in Luxury Condo Buildling",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-red-hook-25-bedroom/6495140369.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Bensonhurst 1 Bedroom near N Train & 18th Ave Shops",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-bensonhurst-1-bedroom/6495140072.html",
+    "containedIn": {
+      "name": " (Bensonhurst)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HOT DEAL___True 1 bedroom____PRIME Lenox Hill____Fireplace____SUNNY___",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/hot-dealtrue-1-bedroomprime/6495139508.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Roommate Wanted!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/roommate-wanted/6495128953.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 122.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AMAZING LOCATION*FOREST HILLS*ELEVATOR*LAUNDRY ROOM*A MUST SEE!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/amazing-locationforest/6495123590.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1725.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FABULOUS 4 bed/2 bath~Private Backyard + basement~W/D in unit!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/fabulous-4-bed-2-bathprivate/6495123047.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2987.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Luxury 1 Bedroom in Great building",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/luxury-1-bedroom-in-great/6495122678.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "DIRT CHEAP____Sunny Studio______ELEVATOR + LAUNDRY_____Prime UES______",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/dirt-cheapsunny/6495117511.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1875.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "New to Market, Large, Bright, Gym, Parking, Roof Deck, Beach B & Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-to-market-large-bright/6495116768.html",
+    "containedIn": {
+      "name": " (Manhattan Beach / Sheepshead bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge 1800sqft + 2 Balconies, 1 parking spot, 3 full bath, Elevator Q",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-1800sqft-2-balconies-1/6495116087.html",
+    "containedIn": {
+      "name": " (midwood/ Sheepshead bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2.5 bedroom Washer Dryer hook up, Dishwasher F & G train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-25-bedroom-washer/6495115631.html",
+    "containedIn": {
+      "name": " (Red hook)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True 3 bedroom, plus Living room, separate Kitchen, great location",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/true-3-bedroom-plus-living/6495113774.html",
+    "containedIn": {
+      "name": " (Kensington)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Glass Walled 3 Bed w/ Private Balcony  -- No-Fee -- Luxury Building --",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-3-bed-private/6495111445.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4460.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 Bed/2 Bath -- River Views -- Luxury Building -- No Fee -- Gym+Roof+L",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3-bed-2-bath-river-views/6495110674.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3681.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-Brand New Large 2 bed-Laundry/Backyard access-Near the G train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-large-2-bed/6495110164.html",
+    "containedIn": {
+      "name": " (Prime Bed-Stuy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "GREAT VALUE ON RENOVATED 2 BEDROOMS NEAR TRENDY FRANKLIN 2,3,4,5,S",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/great-value-on-renovated-2/6495109701.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS SUNFILLED FURN 2 BR TOP FLOOR OF 4 FAM BROWNSTONE 1 BLOCK A&C",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-sunfilled-furn-2-br/6495108639.html",
+    "containedIn": {
+      "name": " (Bedford Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "^^GUT RENO LARGE 1 BED APARTMENT BY PROSPECT PARK^^NO BROKER FEE^^SUN!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gut-reno-large-1-bed/6495106466.html",
+    "containedIn": {
+      "name": " (LEFFERTS GARDEN/FLATBUSH/NO FEE)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TRUE 2 Bedroom____BIG Living Room___Eat-in Kitchen_____Tons of Light!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroombig-living/6495099740.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Perfect 2 Bedroom Share - No FEE! Lower East Side  - Two Bridges",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/perfect-2-bedroom-share-no/6495096121.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUNNING ****DOORMAN*****ROOFDECK*****GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/stunning-doormanroofdeckgym/6495095788.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "☆ Gorgeous Luxury 2BR ☆ Full Service Bldg - NO FEE//MUST SEE!--11221",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-luxury-2br-full/6495094390.html",
+    "containedIn": {
+      "name": " (Prime Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2610.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE-Newly renovated SUNNY 1 bed-Prime location near the D/N/R train",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-newly-renovated-sunny/6495089845.html",
+    "containedIn": {
+      "name": " (Prime Greenwood)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! BRAND NEW GORGEOUS 2 BED W/ a washer dryer hookup-Near trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-brand-new-gorgeous-2/6495089252.html",
+    "containedIn": {
+      "name": " (Prime Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AWESOME 3 BEDROOM WITH PRIVATE BACKYARD AND GARAGE! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-3-bedroom-with/6495068061.html",
+    "containedIn": {
+      "name": " (BUSHWICK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**BEST DEAL**HUGE STUDIO W/ 24 HR DM//FREE AMENITIES//100% NO BROKER FEE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/best-dealhuge-studio-24-hr-dm/6495063392.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!*WOW*!*RENOVATED 1 BED*NO FEE!NEAR PARK!*SUNLIGHT!*TRAINS!*STEAL DEAL",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowrenovated-1-bedno-feenear/6495053924.html",
+    "containedIn": {
+      "name": " (Lefferts Garden/Prospect Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1575.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!^HOT^!GORGEOUS SPACIOUS 1 BED*STEPS TO PARK*NEAR TRAIN*STEAL DEAL!**",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/hotgorgeous-spacious-1/6495053066.html",
+    "containedIn": {
+      "name": " (Lefferts Garden/Prospect Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!^WOW^!*NO FEE!*BEAUTIFUL JR 1BED*PRIME LOCATION!*STEPS TO TRAIN!*PARK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wowno-feebeautiful-jr/6495052139.html",
+    "containedIn": {
+      "name": " (Lefferts Garden/Prospect Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495049806.html",
+    "containedIn": {
+      "name": " (PROSPECT LEFFERTS GARDENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CLOSE TO CORTELYOU ROAD'S SHOPS AND CAFES*NEWLY RENOVATED AND SPACIOUS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-cortelyou-roads/6495048076.html",
+    "containedIn": {
+      "name": " (DITMAS PARK-FLATBUSH)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6495047266.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6495045809.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6495045310.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! BRAND NEW STUDIO + ELEVATOR!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-studio/6495044720.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE Sunny, Spacious 1 Br/Flex 2 Apartment with Roof-deck/Gym!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-sunny-spacious-1-br/6495043859.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City Spacious Apts, Laundry, Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6495042229.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "priced to rent! Large Upper West Side 3 bedroom shares!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/priced-to-rent-large-upper/6495036355.html",
+    "containedIn": {
+      "name": " (Riverside Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495036147.html",
+    "containedIn": {
+      "name": " (PROSPECT LEFFERTS GARDENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*EASY COMMUTE TO MANHATTAN",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/newly-renovatedclose-to-shops/6495035344.html",
+    "containedIn": {
+      "name": " (PROSPECT PARK SOUTH)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, MASSIVE TRUE 3 BED! ELEVATOR/LAUNDRY! TOP FL!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-massive-true-3-bed/6495032445.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning Bright 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-bright-2br-in-great/6495031206.html",
+    "containedIn": {
+      "name": " (Bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 3BR in Prime Bushwick ~ NO FEE ~ Laundry |",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3br-in-prime/6495030691.html",
+    "containedIn": {
+      "name": " (Bushwick @ Myrtle Wycoff L/M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Cute Cozy Studio in Great Location! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/cute-cozy-studio-in-great/6495029771.html",
+    "containedIn": {
+      "name": " (Crown Heights@ Nostrand 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 4 bedroom 2 bathroom | No Fee | Laundry! Bed Suy Brooklyn!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/massive-4-bedroom-2-bathroom/6495028457.html",
+    "containedIn": {
+      "name": " (Bed Stuy@ Myrtle G/J/M)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3449.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CLOSE TO BROOKLYN COLLEGE*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/close-to-brooklyn/6495024040.html",
+    "containedIn": {
+      "name": " (PROSPECT LEFFERTS GARDENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, LARGE 3 BED, SEPARATE LIVING ROOM/KITCHEN!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-3-bed-separate/6495012861.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Top Floor - 3 QUEEN SIZE Beds w/ Skylight. Sep Kitchen w/ Dishwasher",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/top-floor-3-queen-size-beds/6495010537.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Month Free & NO FEE!  Fort Greene/Downtown Brooklyn! Brand New!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee-fort/6495005970.html",
+    "containedIn": {
+      "name": " (Fort Greene, Downtown BK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Month Free & NO FEE!  BALCONY!Fort Greene/Downtown Brooklyn! Bra",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-month-free-no-fee/6495005400.html",
+    "containedIn": {
+      "name": " (Fort Greene, Downtown BK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2871.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "CLEAN ONE BEDROOM APT LOCATED IN CORONA",
+    "url": "https://newyork.craigslist.org/que/nfb/d/clean-one-bedroom-apt-located/6495005016.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2165.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 2 BEDROOM, GREAT PRICE + LOCATION!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-great-price/6495004241.html",
+    "containedIn": {
+      "name": " (Hamilton Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "EASY COMMUTE TO MANHATTAN*NEWLY RENOVATED*CLOSE TO SHOPS AND TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/easy-commute-to/6495003571.html",
+    "containedIn": {
+      "name": " (PROSPECT LEFFERTS GARDENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TRIBECA SOUTH ====AMPLE CLOSETS SPACE===CHEFS KITCHEN====2 MONTHS FREE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/tribeca-south-ample-closets/6495001585.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, Beautifully Renovated 1 Bedroom!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautifully-renovated/6495000355.html",
+    "containedIn": {
+      "name": " (Hamilton Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "_____OPEN LAYOUT____PASS THRU KITCHEN______LOTS OF CLOSET SPACE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-layoutpass-thru/6495000049.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***SUN-DRENCHED***2 HUGE WINDOWS***ITALIAN MARBLE***CHEFS KITCHEN***RE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/sun-drenched2-huge/6494997921.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! 1 BR Ditmas Park ELEVATOR/LAUNDRY BUILDING Near The B&Q Trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-br-ditmas-park/6494997370.html",
+    "containedIn": {
+      "name": " (Ditmas Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "UNDER-MARKET*NEWLY RENOVATED* SPACIOUS APARTMENT CLOSE TO TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/under-marketnewly-renovated/6494997350.html",
+    "containedIn": {
+      "name": " (PROSPECT LEFFERTS GARDENS)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 3 BEDROOM, GREAT PRICE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-3-bedroom-great-price/6494988353.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494983318.html",
+    "containedIn": {
+      "name": " (Carroll Gardens, Gowanus)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3092.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494982711.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494982020.html",
+    "containedIn": {
+      "name": " (Carroll Gardens, Gowanus)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL 2 BED TRIBECA STEPS TO BROADWAY - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-2-bed-tribeca-steps-to/6494968040.html",
+    "containedIn": {
+      "name": " (TriBeCa)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Walls Of Floor to Ceiling Glass! Stunning ! #Downtown #Luxury #Views #",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/walls-of-floor-to-ceiling/6494964320.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Huge Luxury Loft with Sleeping Alcove, Separate Kitchen with Breakfast",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-luxury-loft-with/6494959976.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Brand New LIC Full Service Luxury Apartments!! NO FEE + 2 MO FREE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/brand-new-lic-full-service/6494939543.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3934.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 2Bed, Elevator, Laundry, Overlooking Grand Army Plaza, Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2bed-elevator-laundry/6494928442.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO Fee True 3 Bed, Steps to A/C Franklin Ave Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-true-3-bed-steps-to-c/6494927324.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Gorgeous Large Studio, Expose Brick, 1 Block to Train, NO FEE!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/gorgeous-large-studio-expose/6494926476.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee 1 Bed Gem, 4 Blocks to 2/3/4/5 Franklin Trains, Will Not Last!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-bed-gem-4-blocks/6494923511.html",
+    "containedIn": {
+      "name": " (Prospect Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494902932.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Laundry, Great Location, Spacious!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494901597.html",
+    "containedIn": {
+      "name": " (Astoria)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494900754.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AMAZING 1 Bedroom Apartment! *MUST SEE*",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/amazing-1-bedroom-apartment/6494895715.html",
+    "containedIn": {
+      "name": " (Mt. Vernon)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1575.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful Studio Apartment Available for Immediate Move-in!",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/beautiful-studio-apartment/6494891581.html",
+    "containedIn": {
+      "name": " (Bronx Park East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1525.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494886774.html",
+    "containedIn": {
+      "name": " (Ditmas park / Cortelyou Rd)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "►Soho/LOFTSTYLE$1665,Hi ceilng,Wk to Metro,Gran/SS/Kit,Inc.Heat,Gym",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/soho-loftstyle1665hi-ceilngwk/6494874792.html",
+    "containedIn": {
+      "name": " (STAMFORD, CT)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1665.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "►►►Harborpoint,Concierge,  1BR $1798,HRDWD,W/D,Pool,Gym,Gar,",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/harborpointconcierge-1br/6494873652.html",
+    "containedIn": {
+      "name": " (Stamford)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1798.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE ! Spacious 3 Bedroom All utilities included UES / Harlem",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-spacious-3-bedroom-all/6494873144.html",
+    "containedIn": {
+      "name": " (East Harlem)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEST PRICE *NEW* DWNTWN 1BR\"s @ $1830,SS Kit,HRDWD,Gym,W/D,Gar,Terr",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/best-price-new-dwntwn-1brs/6494872684.html",
+    "containedIn": {
+      "name": " (Stamford)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1830.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! HUGE 1 BEDR IN PRIME AREA REGO PARK/ FOREST HILLS BORDER",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-huge-1-bedr-in-prime/6494866375.html",
+    "containedIn": {
+      "name": " (Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494861013.html",
+    "containedIn": {
+      "name": " (FLUSHING)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Avail March 1~ Newly renovated True 2 bed/1bath~ Near Subway~Wont Last",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/avail-march-1-newly-renovated/6494854889.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1MONTH FREE,1BEDR CLOSE TO MURRAY HILL LIRR STATION, FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee1month-free1bedr-close/6494850081.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BAM!Awesome DEAL!Large 1 BED Way Under PRICED!NO BROKER FEE!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bamawesome-deallarge-1-bed/6494846751.html",
+    "containedIn": {
+      "name": " (East Flatbush)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1475.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WoW! Prime Location !!Rite off Central PARK!Renovated!!NO BROKER FEEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-prime-location-rite-off/6494846361.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV, 2BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-2bedr/6494842091.html",
+    "containedIn": {
+      "name": " (Flushing)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2232.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "AWESOME NO FEE !!!  3 BR W/ EXPOSED BRICK WALL AND HIGH CEILINGS !!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-3-br-exposed/6494841522.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "6 BEDROOM START YOU 2018 WITH RENT TO OWN EASY AS 123",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/6-bedroom-start-you-2018-with/6494839888.html",
+    "containedIn": {
+      "name": " (holywood ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1638.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! NEWLY RENOV, 1BEDR CLOSE TO MAIN ST. TRAIN STATION FLUSHING",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-newly-renov-1bedr/6494838449.html",
+    "containedIn": {
+      "name": " (Flushing)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE !! 2 BEDROOM WITH HARDWOOD FLOORS AND STAINLESS STEEL APPLIANCE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-2-bedroom-with/6494829728.html",
+    "containedIn": {
+      "name": " (Prospect Lffert Gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2124.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!   1672 E 22 Street. 2 bed/2 bath unit with balconies",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-feestreet-2-bed-2-bath/6494822740.html",
+    "containedIn": {
+      "name": " (Madison)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Room available in a comfortable 3br LES apt with great roommates",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-room-available-in/6494804220.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1665.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***IMMACULATE RIVERDALE 1 BEDS ***AVAILABLE NOW!***",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-1-beds/6494802093.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUNNING ONE BEDROOM APARTMENT!",
+    "url": "https://newyork.craigslist.org/stn/nfb/d/stunning-one-bedroom-apartment/6494799559.html",
+    "containedIn": {
+      "name": " (staten island)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494798495.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***IMMACULATE RIVERDALE 2 BEDS // ***LOW PRICES AND HUGE LAYOUTS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/immaculate-riverdale-2-beds/6494797714.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2225.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*WASHINGTON HEIGHTS 1 BEDS [FORT TRYON AREA] -- GREAT SPACE + LOCATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/washington-heights-1-beds/6494796937.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS 1 BEDS [FORT WASHINGTON AREA] -- GREAT RENOVATIONS {NO FEE}",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-1-beds-fort/6494792695.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Private balcony,Corner Apt,Amazing amenities,Wash&dry*Lots of clos",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/private-balconycorner/6494792448.html",
+    "containedIn": {
+      "name": " (Downtown Brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4142.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE // HARLEM  2 BEDS (GREAT VIEWS) -- [UTILITIES INCLUDED!]",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-harlem-2-beds-great/6494792500.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494792437.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5349.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "JANUARY MOVE IN ////////// UNIT 22F ====== CITY VIEWS=== BOUKLIS GROUP",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/january-move-in-unit-22f-city/6494792370.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***QUALITY -- HARLEM 1 BEDS (RENOVATED WITH GREAT VIEWS)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/quality-harlem-1-beds/6494792314.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "STUDIOS FOR RENT -- GREATER HARLEM AREAS *NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studios-for-rent-greater/6494792168.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***EXCLUSIVE RIVERDALE 1 BEDS *** HUGE LAYOUTS -- GREAT RENOVATIONS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-1-beds/6494792013.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***EXCLUSIVE RIVERDALE 2 BEDS *** HUGE SUNLIT LAYOUTS",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/exclusive-riverdale-2-beds/6494791848.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "West 60th St. - 2 BED - White Glove Luxury, Gym - FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/west-60th-st-2-bed-white/6494788697.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5097.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 100th St - 3 Bed 1.5 Bath - Laundry - FREE UTILITIES - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-100th-st-3-bed-15-bath/6494786507.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 91st St - 2 BED 2 BATH - Luxury, Gym - ONE FREE MONTH - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-st-2-bed-2-bath/6494786203.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "East 91st & York Ave - 1 BED - Luxury, Gym - ONE FREE MONTH - NO F",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/east-91st-york-ave-1-bed/6494785843.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2929.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - BEAUTIFUL 1 BEDROOM nr Columbia Presbyterian hospital, 169st",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-1-bedroom-nr/6494784257.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE//59th&1st**QUEEN BEDS<<AWESOME LIGHT!!ELEVATOR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-59th1stqueen/6494777085.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE**45th&Lex//MASSIVE STUDIO<3open House!!NEW.RENO.",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee45thlex-massive/6494773800.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE Beautifully restored VINTAGE 3 BED GEM w. SKYLIGHTS & Central AC!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-beautifully-restored/6494712081.html",
+    "containedIn": {
+      "name": " (GREENPOINT)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494706179.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494700308.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5349.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "🔥🔥🔥 STUNNING 2 BR APARTMENT IN GREAT LOCATION",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-2-br-apartment-in/6494697693.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "🔥🔥🔥 STUNNING 3 BR APARTMENT IN PRIME LOCATION",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-3-br-apartment-in/6494693656.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***NO FEE*** SPACIOUS 1 BED W/ EXPOSED BRICK & GREAT NATURAL SUNLIGHT",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-1-bed-exposed/6494677446.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2175.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE SPACIOUS 2 BEDROOM IN CROWN HEIGHTS W/ BEAUTIFUL FRENCH DOORS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-spacious-2-bedroom-in/6494667328.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494665306.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "SPACIOUS MODERN STUDIO APT IN ELEVATOR/ LAUNDRY & EXPOSED BRICK",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-modern-studio-apt-in/6494662655.html",
+    "containedIn": {
+      "name": " (Crown Heights)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1870.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large One Bedroom/Furnished/ King bed/2 Murphy beds (double & single)",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-one-bedroom-furnished/6494616829.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE + 1 Month fee* Real pictures !!! Real 2BR",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-month-fee-real/6494605791.html",
+    "containedIn": {
+      "name": " (Lower East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, LUXURY, DOORMAN, ROOF DECK, LOUNGE, REAL WALLS, NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-luxury-doorman-roof/6494595797.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, VIEWS, LARGE SPACE, DOORMAN, POOL, GYM, SAUNA",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-views-large-space/6494594502.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4400.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "EV! NO FEE+1Month Free! +500 Rent Credit!W/d, All reno, Washer/Dryer!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/ev-no-fee1month-free-500-rent/6494579504.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RARE,NO FEE!+ONE MONTH FREE+500 Credit+near Soho,W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/rareno-feeone-month-free500/6494578837.html",
+    "containedIn": {
+      "name": " (Nolita / Bowery)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+ONE MONTH FREE+walk to Union Sq,PH,PV'T DECK!W/d,RENO! Pets ok!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feeone-month-freewalk-to/6494578300.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MONTH FREE,+500 Rent Credit+ Deck+RENO,W/d/w,Elev,Pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-month-free500-rent/6494577810.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 FREE Month+500 RENT CRED,ELEV,NET=3662.08,W/d,FPL,2BR,pets ok",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-free-month500-rent/6494577386.html",
+    "containedIn": {
+      "name": " (Gramercy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bright and sunny 1 bedroom duplex apartment in Union Sq elevator build",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bright-and-sunny-1-bedroom/6494567274.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4150.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Nice Bushwick Studio • Perfect for Single or Couple {No Fee} Must See",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-bushwick-studio-perfect/6494565490.html",
+    "containedIn": {
+      "name": " (Broadway @ J,M,Z train Halsey)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No  Fee Enormous 1 Bed - Riverdale - Henry Hudson Pkwy",
+    "url": "https://newyork.craigslist.org/brx/nfb/d/no-fee-enormous-1-bed/6494565369.html",
+    "containedIn": {
+      "name": " (Riverdale)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Astonishing 2 Bed with a Terrace",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/astonishing-2-bed-with-terrace/6494559982.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Month Free + No Broker Fee 1 Bedroom Upper East Side",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1-month-free-no-broker-fee-1/6494555259.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "OPEN HOUSE(S)~~NO FEE!  E. 60'S~~E. 70's~~BEST DEALS UES~~646.247.6444",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/open-housesno-fee-60se/6494536832.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful 2 Bed",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beautiful-2-bed/6494530514.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL 1-BR + 2 MONTHS FREE RENT + KING-SIZED BR + ELEVATOR/LAUNDRY",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-1-br-2-months-free/6494528170.html",
+    "containedIn": {
+      "name": " (Cobble Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE & 2 MONTHS FREE** LUXURY DEAL ALERT! TREU 2 BED APT W VIEWS!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-months-free-luxury/6494525169.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3445.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW!!! ----NO BROKER FEE--2BR 1bt APT!!!!! NEW LUXURY BUILDING!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-no-broker-fee-2br-1bt-apt/6494493983.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3090.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE STUDIO CITY VIEW WATERFRONT BALCONY 1STOP TO GRD CENTRAL LUXURY",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-studio-city-view/6494492433.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE BRAND NEW BLDG  24HR CONCIERGE ROOF DECK GYM AMAZING VIEWS WATE",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-brand-new-bldg-24hr/6494490413.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LUXURY BLDG-24HR CONCIERGE-ROOF DECK-GYM AMAZING VIEWS WATERFRONT 5min",
+    "url": "https://newyork.craigslist.org/que/nfb/d/luxury-bldg-24hr-concierge/6494488063.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No fee - Large studio for 1 yr lease, best street in Manhattan!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-large-studio-for-1-yr/6494475615.html",
+    "containedIn": {
+      "name": " (Nolita / Bowery)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3135.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**NO FEE!!**LUX 24HR DM**GYM / POOL / SUNDECK**PRIME E 86th LOCATION**",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-feelux-24hr-dmgym-pool/6494460481.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3790.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True 4 bed with Balcony and lots of closets space, For no brokers fee",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-4-bed-with-balcony-and/6494460233.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*3BR/2BA DUPLEX WITH 2PVT ROOFTOP SPACE E89TH BETWEEN 2ND AND 3RD AVE*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/3br-2ba-duplex-with-2pvt/6494456185.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO BROKERS FEE!* XL 1BR E92NDST & GAS/H/HW/ LAUNDRY *CALL 6465451574*",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-brokers-fee-xl-1br-e92ndst/6494455428.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "***NO FEE*** GORGEOUS!!!! *BRAND NEW* Inwood 1 BEDROOM!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-gorgeous-brand-new/6494455347.html",
+    "containedIn": {
+      "name": " (Inwood / Wash Hts)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!!! GUT RENOVATED STUDIO ***Sick DEAl***",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-gut-renovated-studio/6494455062.html",
+    "containedIn": {
+      "name": " (new york)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious 2 Bed 2 Bath Tri-Beca Apartment With Beautiful City View - Li",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-2-bed-2-bath-tri/6494452065.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 5349.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Penthouse home in condo no brokers fee! Sun Blasted Statue of Liberty",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/penthouse-home-in-condo-no/6494447936.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 27000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FEBRUARY MOVE IN ////////// UNIT 18M ====== QUEEN SIZE BEDROOM === BOU",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/february-move-in-unit-18m/6494443347.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "beautiful 3 bedroom-Exposed brick-Shared backyard-NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-3-bedroom-exposed/6494425727.html",
+    "containedIn": {
+      "name": " (Crown Heights C,S at Franklin Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Nice studio apartment-Prospect park-Great area- NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-studio-apartment/6494424927.html",
+    "containedIn": {
+      "name": " (Crown Heights 3 at Nostrand Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1699.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1 Bedroom In Great Location-Laundry-Central Air and Heat-NOFEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/1-bedroom-in-great-location/6494424371.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant G at Myrtle-Willoughb)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "3 bedrooms 2 full bath - fits queen size beds-exposed brick-no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/3-bedrooms-2-full-bath-fits/6494423544.html",
+    "containedIn": {
+      "name": " (Bedford-Stuyvesant G at Bedford-Nostrand)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2295$ Large 1 bedroom!! Upper east side!!no Fee!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/2295-large-1-bedroom-upper/6494421662.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "A real home! King sized master bedroom. Renovated 4BR 2 Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/real-home-king-sized-master/6494421267.html",
+    "containedIn": {
+      "name": " (Bedstuy @ A & C subway)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3099.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "large 1 Bedroom- brownstone-Park Slope-Subways under 500 feet away",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-1-bedroom-brownstone/6494419762.html",
+    "containedIn": {
+      "name": " (park slope @ F,G,R at 4 Av-9 St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2599.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beneficial, awesome 4bd apartment  in UES!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/beneficial-awesome-4bd/6494419308.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Ditmas Park- big 3 bedroom-Heat and hot water Inc- no fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/ditmas-park-big-3-bedroom/6494416757.html",
+    "containedIn": {
+      "name": " (Ditmas Park @B,Q at Newkirk Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Nice spacious 3 bedroom 1.5 bathroom duplex with outdoor space!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/nice-spacious-3-bedroom-15/6494411427.html",
+    "containedIn": {
+      "name": " (Crown Heights @ A & C Nostrand ave)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 1 BED, ELEVATOR/LAUNDRY!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-1-bed-elevator-laundry/6494409028.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Awesome studio with open, cute balcony!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/awesome-studio-with-open-cute/6494408695.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2226.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious Brownstone Floorthru",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/spacious-brownstone-floorthru/6494406551.html",
+    "containedIn": {
+      "name": " (Park Slope)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! BRAND NEW SPACIOUS 2 BED!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-brand-new-spacious-2/6494403288.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO fee Biggie Mural building apartment for rent! 3BR 2Bath",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-biggie-mural-building/6494399640.html",
+    "containedIn": {
+      "name": " (Bedford Stuyvasant)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2999.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE, 2 BED, UES!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bed-ues/6494396798.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2050.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 bedroom in prime Bushwick-Large Living room-1 Month Broker fee",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-in-prime-bushwick/6494392833.html",
+    "containedIn": {
+      "name": " (Bushwick @ L at DeKalb Av)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "TRUE 2 BEDROOM AT 61ST AND 2ND GORGEOUS APARTMENT ** NO BROKER FEE **",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-2-bedroom-at-61st-and/6494380706.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE!!! LARGE 1 BED IN PRIME DITMAS PARK W/ ELEVATOR & LAUNDRY!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-large-1-bed-in-prime/6494378582.html",
+    "containedIn": {
+      "name": " (Ditmas park / Cortelyou Rd)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKERS FEE * HUGE Renovated Studio Apartment in SUNNYSIDE *7 Train",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-brokers-fee-huge-renovated/6494376727.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful renovated 3 bedroom. Great for shares!!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-renovated-3-bedroom/6494375896.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Beautiful and cozy studio apartment! Great Area! Heat & Hot Water inc",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-and-cozy-studio/6494375207.html",
+    "containedIn": {
+      "name": " (Crownheights @2,3 subway)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1699.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "2 bedroom! Great area! Wont last!Williamsburg! NO FEE",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2-bedroom-great-area-wont/6494372773.html",
+    "containedIn": {
+      "name": " (Williamsburg @ L at Grand St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - New Amenities, Near Subway!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494369154.html",
+    "containedIn": {
+      "name": " (Queens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "FULLY RENOVATED 3.5 BEDROOM HEAT AND HOT WATER INCL. PARKING EXTRA",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/fully-renovated-35-bedroom/6494366755.html",
+    "containedIn": {
+      "name": " (BAY 26 STREET)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "**** 100% NO FEE **** *** FREE ELECTRICITY *** *** GORG 3 BR APT ***",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/100-no-fee-free-electricity/6494366513.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, renovated apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494366095.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2095.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "⎝NO FEE! > ULTRA LUX RENO 1 BR >Sundeck, Pool, Gym, View<",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-ultra-lux-reno-1-br/6494364172.html",
+    "containedIn": {
+      "name": " (Upper East Side / Roosevelt Island)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2265.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Stunning 2.5 bedroom w/ Balcony! Great area~!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/stunning-25-bedroom-balcony/6494363016.html",
+    "containedIn": {
+      "name": " (Red Hook)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, *Gym, Laundry, Brand New Kitchens*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494361711.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2745.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "1BD in Downtown Stamford + Large Closets & Parking Available!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/1bd-in-downtown-stamford/6494344871.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1499.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE, RENOVATED 3 BDR.  STEPS TO D TRAIN, BALCONY, 1.5 BATH  PARKING",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-renovated-3-bdr-steps-to/6494336802.html",
+    "containedIn": {
+      "name": " (bensonhurst. brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2295.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Enormous 1BD in Quiet Neighborhood + Washer/Dryer Inside the Unit!!!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/enormous-1bd-in-quiet/6494325050.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*NO FEE* Renovated EXTRA LARGE 1 bdrm in Greenwood! D,N,R trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-renovated-extra-large/6494317234.html",
+    "containedIn": {
+      "name": " (Greenwood / 4th Ave & 27th St)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1795.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO BROKER FEE | Newly Renovated 1 Bed On Tree Lined Block",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-broker-fee-newly-renovated/6494314454.html",
+    "containedIn": {
+      "name": " (Bed Stuy)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "RIVER VIEWS___ 13ft HIGH CEILINGS___W/D IN UNIT___SWIMMING POOL",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/river-views-13ft-high/6494304885.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Glass Walled 1 Bed -- Tons of Sunlight -- Luxury High Rise -- No Fee -",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/glass-walled-1-bed-tons-of/6494303725.html",
+    "containedIn": {
+      "name": " (Chelsea)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "🔑AMAZING 2 Bed / Perfect share!_Live-in super_🐶PetOK🐱",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-2-bed-perfect/6494290463.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "===STUDIO APT RENOVATED=== UES===$1800==1 MONTH FREE!!===",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/studio-apt-renovated-ues18001/6494290341.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1800.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494289747.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3475.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! massive 1 bedroom in \"PRIME P.L.G\" off the B,Q trains",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-massive-1-bedroom-in/6494286088.html",
+    "containedIn": {
+      "name": " (brooklyn)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1895.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ASAP MOVE IN__WIC__28'X13' LIVING AREA___18X13 BEDROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-inwic28x13-living/6494283335.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3475.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 MO.FREEnet rent $2745 LG 1 BR MBL BTH HI FLR UES Low 80s GYM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee1-mofreenet-rent-2745/6494277994.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, Oversized Closets *Near Subways*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494266748.html",
+    "containedIn": {
+      "name": " (Sheepshead Bay)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens *Natural Light* & *Near Subway*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494265832.html",
+    "containedIn": {
+      "name": " (Sunnyside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City - Terrace, New Amenities!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494264729.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3010.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing 1BR apt on E 30th St w. shared outdoor space in elev bldg!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-1br-apt-on-30th-st/6494253538.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!!!!!!!!!!!!!!!LOOK !!!REAL NO FEE AMAZING MIDTOWN TWO BEDROOM MUST SE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/look-real-no-fee-amazing/6494253086.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing Deal! Studio on E 30th st for only $1,750! Must See",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-deal-studio-on-30th/6494252595.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great Deal~True 2BR apt on E 77th St and 1st Ave ! $2,650 NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-dealtrue-2br-apt-on/6494251877.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large sunny loft studio on E 92nd St ~ $1,900 ~ Ldry Bldg ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-sunny-loft-studio-on/6494249169.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "HUGE 3 BR Duplex w/ 2 full BA & 2 private roof decks ~ Unreal ~ NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/huge-3-br-duplex-2-full-ba-2/6494248598.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Room For Rent",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/room-for-rent/6494247819.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Very large 1BR apt on 89th & 1st in elevator & laundry bldg ~ $2,300!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/very-large-1br-apt-on-89th/6494243370.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing No Fee+1Mnth Free 3 Bed/2Bth In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-3/6494233911.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 6230.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!!!!!!!!!!!!TOTAL SCORE REAL TWO BED NO FEE MIDTOWN EAST!!!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/total-score-real-two-bed-no/6494230108.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Amazing No Fee+1Mnth Free 1 Bed In Drmn/Elev/Gym/Lndry Building!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/amazing-no-fee1mnth-free-1/6494226614.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "❖GORGEOUS TWO  BD❖ ◆NO FEE◆NEW RENO◆PetOK",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/gorgeous-two-bd-no-feenew/6494225609.html",
+    "containedIn": {
+      "name": " (East Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "ASAP MOVE IN__GOURMET KITCHEN__LUXURY BATHROOM__29X13 LIVING ROOM",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/asap-move-ingourmet/6494222069.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2908.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "*WINTER SPECIAL* No Fee+2Mnths Free 2Bed,Drmn/Lndry/Elev/Gym/Roof Deck",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/winter-special-no-fee2mnths/6494219626.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3495.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Spacious NO FEE 1BR Lincoln Suqare Doorman Dishwasher TRADER JOES",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/spacious-no-fee-1br-lincoln/6494217643.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "★★★HUGE DUPLEX 2BR(flex3)/1.5ba off DEKALB L!★★",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/huge-duplex-2brflex3-15ba-off/6494212771.html",
+    "containedIn": {
+      "name": " (Bushwick)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "$$$$  NO FEE  $$$$ (2) BEDROOM $$$$  ONLY 2,100  $$$$ UPPER EAST SIDE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-2-bedroom-only-2100/6494201721.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Mint studio in luxury downtown brooklyn building full service",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/mint-studio-in-luxury/6494199703.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Live in Prime Clinton Hill - Steps to  A/C Trains!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/live-in-prime-clinton-hill/6494196018.html",
+    "containedIn": {
+      "name": " (Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1900.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Close to Transport, Laundry*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494192102.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2125.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "20th FLOOR______OVERSIZED WINDOWS_____WATER VIEWS____NEW RENOVATION",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/20th-flooroversized/6494186521.html",
+    "containedIn": {
+      "name": " (Battery Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2550.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Lovely No Fee Studio | Great Location steps from the Franklin C!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/lovely-no-fee-studio-great/6494178081.html",
+    "containedIn": {
+      "name": " (Bed Stuy / Clinton Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1799.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "$$$$  1825  $$$$$ NO FEE $$$$ LARGE (1) BEDROOM $$$$ Upper East Side (",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/1825-no-fee-large-1-bedroom/6494178008.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1825.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Awesome No Fee Studio with Original Details in Great Location! No Fee!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/awesome-no-fee-studio-with/6494176573.html",
+    "containedIn": {
+      "name": " (Crown Heights@ Nostrand 3)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1699.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sweet 2BR in Great Bushwick Location | No Fee | Great Deal!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sweet-2br-in-great-bushwick/6494174049.html",
+    "containedIn": {
+      "name": " (Bushwick @ Gates JMZ)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1995.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Large 3BR close to the B/Q Trains! Great Deal! No Fee ~ Must See!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/large-3br-close-to-the-q/6494171210.html",
+    "containedIn": {
+      "name": " (Ditmas Park @ Newkirk B/Q)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2199.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Excellent No Fee Studio | Exposed Brick | Great Area | Easy Commute!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/excellent-no-fee-studio/6494164489.html",
+    "containedIn": {
+      "name": " (Crown Heights@ Franklin 2,3,4,5)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BRAND NEW HIGH END LUXURY BUILDING, COMPLIMENTARY AMENITIES, PERFECT L",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/brand-new-high-end-luxury/6494160084.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2390.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "$2950 / 1br - GORGEOUS Luxury waterfront 1br Greenpoint",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/2950-1br-gorgeous-luxury/6494157117.html",
+    "containedIn": {
+      "name": null,
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2950.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee * Renovated Spacious 3 Bed 1 Bath * Rego Park * By M/R Trains.",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-renovated-spacious-3/6494136366.html",
+    "containedIn": {
+      "name": " (Forest Hills / Rego Park)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3200.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Delightfully Gorgeous 1BD in Downtown Stamford + Washer/Dryer in Unit!",
+    "url": "https://newyork.craigslist.org/fct/nfb/d/delightfully-gorgeous-1bd-in/6494134581.html",
+    "containedIn": {
+      "name": " (Stamford)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1625.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Make Your Friends Jealous!!! NO FEE!! LARGE TRUE 1BR Tennis Courts Gym",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/make-your-friends-jealous-no/6494124639.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE & 1 MONTH FREE/ 2 BEDROOM WITH OCEAN VIEWS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-1-month-free-2-bedroom/6494119294.html",
+    "containedIn": {
+      "name": " (Brighton Beach)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2600.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Broker Fee & Free Rent in Gorgeous & Sunny UWS Studio",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-broker-fee-free-rent-in/6494111476.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2300.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "newly renovated",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/newly-renovated/6494095590.html",
+    "containedIn": {
+      "name": " (Harlem / Morningside)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2695.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Grand Opening-NO FEE & 1.5 MONTHS FREE-W/D, Roof Deck, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-no-fee-15/6494095051.html",
+    "containedIn": {
+      "name": " (Carroll Gardens, Gowanus)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3092.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Grand Opening-2 Months FREE-POOL, W/D in Unit, Gym!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/grand-opening-2-months-free/6494094518.html",
+    "containedIn": {
+      "name": " (Carroll Gardens, Gowanus)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Sunny, Floor Through Condo in Prime Williamsburg!  N 10th Street!",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/sunny-floor-through-condo-in/6494093888.html",
+    "containedIn": {
+      "name": " (Williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE! *BEAUTIFUL 2BR APT NEAR COLUMBIA UNIV. UWS $2350* 347-219-1297",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-beautiful-2br-apt-near/6494089369.html",
+    "containedIn": {
+      "name": " (Upper West Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Great 2br unit on 97th and lex steps to subway 6 or Q train",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/great-2br-unit-on-97th-and/6494088123.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2500.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "XL REAL SUNNY 1BR WITH TERRACE *30th Street and 3rd AVE *VIEW TODAY",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/xl-real-sunny-1br-with/6494087221.html",
+    "containedIn": {
+      "name": " (Murray Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "PRIME LOCATION. BRAND NEW APT, NO BROKER FEE + 1 MONTH FREE, AMAZING D",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/prime-location-brand-new-apt/6494082498.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2857.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE - TOP FLOOR LOFT SPACE - Manhattan View- DM, Garage, Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-top-floor-loft-space/6494071187.html",
+    "containedIn": {
+      "name": " (Clinton Hill/Wallabout/Navy Yard)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3093.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "No Fee! E.77th! 2Bed! Elevator/Laundry!  Eat-In Kitchen!! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/no-fee-e77th-2bed-elevator/6494068587.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2650.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "WOW! E.92nd! Big 1 Bed! Great Price! SEE NOW! 917-723-3281",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/wow-e92nd-big-1-bed-great/6494067822.html",
+    "containedIn": {
+      "name": " (Upper East Side)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "!!!!!!!!JUST LOOK AT THIS AMAZING NO FEE REAL TWO BEDROOM !!!!!!!!!!!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/just-look-at-this-amazing-no/6494067318.html",
+    "containedIn": {
+      "name": " (Midtown West)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2250.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens. *Renovated Kitchen* *Great Location*",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-rentals-kings-queens/6494059637.html",
+    "containedIn": {
+      "name": " (Bay Ridge)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1395.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bright, King Size 1 Bedroom in Cobble Hill w/ Floor to Ceiling Windows",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/bright-king-size-1-bedroom-in/6494054510.html",
+    "containedIn": {
+      "name": " (Cobble Hill)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2750.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NEW LARGE ONE BED..A,C,G TRAIN..ReNOVaTED..PRIME LOCATION..NEAR ALL..",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/new-large-one-bedacg/6494053552.html",
+    "containedIn": {
+      "name": " (Clinton hill / ft Greene)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1850.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, Kings & Queens, spacious apts in a great location!",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-kings-queens/6494048572.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1675.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "LARGE STUDIO 1 MIN WALK TO FULTON SUBWAY - NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/large-studio-1-min-walk-to/6494046659.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2377.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "True 1 Bedroom on High Floor - w/ Views! - NO FEE!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/true-1-bedroom-on-high-floor/6494043743.html",
+    "containedIn": {
+      "name": " (Financial District)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3100.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive 1 BR Luxury in Greenwich Village!!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-1-br-luxury-in/6494040700.html",
+    "containedIn": {
+      "name": " (Greenwich Village)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 4000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE RENTALS, The NEW LeFrak City *Spacious Apartments, Laundry!*",
+    "url": "https://newyork.craigslist.org/que/nfb/d/no-fee-rentals-the-new-lefrak/6494040704.html",
+    "containedIn": {
+      "name": " (Corona)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2765.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE+1 Month Free - RARE LOFT SPACE - Doorman, Garage, Roof Deck",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee1-month-free-rare-loft/6494032892.html",
+    "containedIn": {
+      "name": " (Clinton Hill/Wallabout/Navy Yard)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3025.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "NO FEE--- If you find a better deal, Ill quit real estate",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/no-fee-if-you-find-better/6494032380.html",
+    "containedIn": {
+      "name": " (williamsburg)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3700.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Bedroom for rent in 3 bedroom duplex!",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/bedroom-for-rent-in-3-bedroom/6494025957.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "BEAUTIFUL LARGE 1BD - CLOSE WALK TO PROSPECT PARK AND 2,5,B,Q TRAINS",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/beautiful-large-1bd-close/6494024948.html",
+    "containedIn": {
+      "name": " (prospect lefferts gardens)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 1595.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Cold Spring apartment, Close to Town!",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/cold-spring-apartment-close/6494023978.html",
+    "containedIn": {
+      "name": " (1698 Route 9D)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2000.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Massive Prime Midtown East One Bedroom Gem! Doorman/Gym/Laundry NO FEE",
+    "url": "https://newyork.craigslist.org/mnh/nfb/d/massive-prime-midtown-east/6494018177.html",
+    "containedIn": {
+      "name": " (Midtown East)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 3255.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "Hudson Views: 1hr to GCT, walk 2 train, close to West Point, trails",
+    "url": "https://newyork.craigslist.org/wch/nfb/d/hudson-views-1hr-to-gct-walk/6494018059.html",
+    "containedIn": {
+      "name": " (Garrison)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2350.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "❤ Wonderful Deal on 3BR off Myrtle-Wyckoff L,M ❤ NO FEE!--11237",
+    "url": "https://newyork.craigslist.org/brk/nfb/d/wonderful-deal-on-3br-off/6494016544.html",
+    "containedIn": {
+      "name": " (BUSHWICK)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2450.0,
+      "currency": "USD"
+    }
+  },
+  {
+    "name": "\"SAVE NOW\"+Huge Closets+King Size Room+FREE Amenities/NO Fee",
+    "url": "https://newyork.craigslist.org/que/nfb/d/save-nowhuge-closetsking-size/6493985946.html",
+    "containedIn": {
+      "name": " (Long Island City)",
+      "containedInPlace": {
+        "name": "New York City"
+      }
+    },
+    "additionalProperty": {
+      "name": "price",
+      "value": 2668.0,
       "currency": "USD"
     }
   }

--- a/dstest/dstest.go
+++ b/dstest/dstest.go
@@ -47,18 +47,18 @@ func NewTestCaseFromDir(dir string, t *testing.T) (tc TestCase, err error) {
 	}
 	tc.Data, tc.DataFilename, err = ReadInputData(dir)
 	if err != nil {
-		err = fmt.Errorf("error reading test case data: %s", err.Error())
+		err = fmt.Errorf("error reading test case data for directory %s: %s", dir, err.Error())
 		return
 	}
 
 	tc.Input, err = ReadDataset(dir, InputDatasetFilename)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) && t != nil {
 		t.Logf("%s: error loading input dataset: %s", tc.Name, err)
 	}
 	err = nil
 
 	tc.Expect, err = ReadDataset(dir, ExpectDatasetFilename)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) && t != nil {
 		t.Logf("%s: error loading expect dataset: %s", tc.Name, err)
 	}
 	err = nil


### PR DESCRIPTION
This PR deals with two major bugs found while working with JSON-formatted data:

dsio.JSONReader wasn't properly observing escaped quote characters, causing it to do very odd things when `\"` was encounteed in a JSON document, it now does. This was throwing off the craigslist entries count. fixed.

Also, there was an off-by-one error in dsfs.prepareDataset for entry counting that was causing all dataset entry counts to be one more than what they actually wer. now also fixed.

Also, I'd stupidly left a whole series of tests commented-out in the dsio package. Those are back now.