### PR TITLE
refactor(dsfs.CreateDataset): don't create dataset Abstract on save

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -335,7 +335,8 @@ func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pri
 	ds.Structure.Checksum = shasum.B58String()
 
 	// generate abstract form of dataset
-	ds.Abstract = dataset.Abstract(ds)
+	// ds.Abstract = dataset.Abstract(ds)
+
 	//get auto commit message if necessary
 	diffDescription, err := generateCommitMsg(store, ds)
 	if err != nil {

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -145,13 +145,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmU6iHxzLB8sL2Qjh8H1Q2vin5g9jX3hcQMSS7H3F6TjR8", 7, ""},
+			"/map/QmViLcZ6Yu4Yi4bQe7zcfntHNdDes5xwQp3fbxq3iUouWS", 6, ""},
 		{"complete",
-			"/map/QmQ2mRe5V83CjKBV5urUY2fSnENjnZyKPGBP5PiPgfr5aS", 15, ""},
+			"/map/QmRSc1VTBQnoWdH8dV3M9cLt6e1639SVN1L8CMZ7ipCc8F", 15, ""},
 		{"cities_no_commit_title",
-			"/map/QmUFienw6JdA71JwF1ptjcjSQXFV6qsJjdEt1b9uedG5BN", 17, ""},
+			"/map/QmPHmSFoxBn73t61M3E9SYNZvqD1BdFriTn3fVWjfG4seN", 17, ""},
 		{"craigslist",
-			"/map/QmU5Tx7ZA3WUB4Yd3nMnUgAjCb1NVp323uLYi9q5AQYFg8", 21, ""},
+			"/map/QmdV6TqbjvwDqZrqPDyXeMYujEZaiaG18YjXVRhD66VFfZ", 20, ""},
 	}
 
 	for _, c := range cases {
@@ -221,8 +221,8 @@ func TestCreateDataset(t *testing.T) {
 	if err.Error() != expectedErr {
 		t.Errorf("case nil datafile and no PreviousPath, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	}
-	if len(store.(memfs.MapStore)) != 21 {
-		t.Errorf("case nil datafile and PreviousPath, expected invalid number of entries: %d != %d", 21, len(store.(memfs.MapStore)))
+	if len(store.(memfs.MapStore)) != 20 {
+		t.Errorf("case nil datafile and PreviousPath, expected invalid number of entries: %d != %d", 20, len(store.(memfs.MapStore)))
 		_, err := store.(memfs.MapStore).Print()
 		if err != nil {
 			panic(err)

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -1,5 +1,4 @@
 {
-  "abstract": "/map/Qmb3n8FvgDbLoU9d7e3vo1UAyVkwV1RnqXUqPKC3Rj2Ej7",
   "commit": {
     "message": "",
     "qri": "cm:0",

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -1,5 +1,4 @@
 {
-  "abstract": "/map/QmW4cDbQYgie835Ro5uGfAeRU4PWPGcbuS5yn5uFRP4ddZ",
   "commit": {
     "qri": "cm:0",
     "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",


### PR DESCRIPTION
Dataset Abstractions are starting to lose their relevance in the general qri architecture. For now I'm removing them from being written. They're wasted space until we have a good reason for writing them.