### PR TITLE
test(dstest): added LoadTestCases func to load a dir of test cases

### DIFF
--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -156,7 +156,7 @@ func TestCreateDataset(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tc, err := dstest.NewTestCaseFromDir("testdata/"+c.casePath, t)
+		tc, err := dstest.NewTestCaseFromDir("testdata/" + c.casePath)
 		if err != nil {
 			t.Errorf("%s: error creating test case: %s", c.casePath, err)
 			continue

--- a/dsio/cbor_test.go
+++ b/dsio/cbor_test.go
@@ -209,7 +209,7 @@ func TestCBORReaderFile(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/cbor/%s", c.name), t)
+		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/cbor/%s", c.name))
 		if err != nil {
 			t.Errorf("case %d:%s error reading test case: %s", i, c.name, err.Error())
 			continue

--- a/dsio/entry_buffer_test.go
+++ b/dsio/entry_buffer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEntryBuffer(t *testing.T) {
-	tc, err := dstest.NewTestCaseFromDir("testdata/csv/movies", t)
+	tc, err := dstest.NewTestCaseFromDir("testdata/csv/movies")
 	if err != nil {
 		t.Errorf("error loading test case: %s", err.Error())
 		return

--- a/dsio/entry_test.go
+++ b/dsio/entry_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEachEntry(t *testing.T) {
-	tc, err := dstest.NewTestCaseFromDir("testdata/json/city", t)
+	tc, err := dstest.NewTestCaseFromDir("testdata/json/city")
 	if err != nil {
 		t.Errorf("error reading test case: %s", err.Error())
 		return

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -55,7 +55,7 @@ func TestJSONReader(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/json/%s", c.name), t)
+		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/json/%s", c.name))
 		if err != nil {
 			t.Errorf("case %d:%s error reading test case: %s", i, c.name, err.Error())
 			continue

--- a/dstest/dstest_test.go
+++ b/dstest/dstest_test.go
@@ -6,8 +6,22 @@ import (
 	"testing"
 )
 
+func TestLoadTestCases(t *testing.T) {
+	tcs, err := LoadTestCases("testdata")
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("%d cases", len(tcs))
+}
+
 func TestNewTestCaseFromDir(t *testing.T) {
-	tc, err := NewTestCaseFromDir("testdata/complete", t)
+
+	if _, err := NewTestCaseFromDir("testdata"); err == nil {
+		t.Errorf("expected error")
+		return
+	}
+
+	tc, err := NewTestCaseFromDir("testdata/complete")
 	if err != nil {
 		t.Errorf("error reading test dir: %s", err.Error())
 		return

--- a/validate/data_test.go
+++ b/validate/data_test.go
@@ -22,7 +22,7 @@ func TestEntryReader(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/%s", c.name), t)
+		tc, err := dstest.NewTestCaseFromDir(fmt.Sprintf("testdata/%s", c.name))
 		if err != nil {
 			t.Errorf("%s: error loading %s", c.name, err.Error())
 			continue


### PR DESCRIPTION
also, removed the need to provide a *testing.T to dstest funcs, paving the way for pulling these sorts of funcs up & out into a library that allows standard unix file format interop with qri.