### PR TITLE
refactor(generate): update generate package so it creates random entries

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1,22 +1,88 @@
-// Package generate is suite of functions generating random
-// structures and data
+// Package generate is for generating random data from given structures
 package generate
 
-// import (
-// 	"math/rand"
-// 	"time"
-// )
+import (
+	"fmt"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsio"
+	"math/rand"
+	"strings"
+	"time"
+)
 
-// func init() {
-// 	rand.Seed(time.Now().UnixNano())
-// }
+// Generator is a dsio.EntryReader that creates a new entry on each call to ReadEntry
+type Generator struct {
+	// structure will hold the jsonschema that generator should use
+	structure *dataset.Structure
+	// random number generator, per-instance for testing
+	random *rand.Rand
+	// maximum length of random values to generate
+	maxLen int
+	// when generating array entries
+	count int
+	// only two possible structures for now are "array" or "object"
+	schemaIsArray bool
+}
 
-// var alphaNumericRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+// ReadEntry implements the dsio.EntryReader interface
+func (g *Generator) ReadEntry() (dsio.Entry, error) {
+	// TODO: Actually inspect the structure more deeply than simply "array" vs "object".
+	if g.schemaIsArray {
+		index := g.count
+		g.count++
+		return dsio.Entry{Index: index, Value: g.randString()}, nil
+	}
+	return dsio.Entry{Key: g.randString(), Value: g.randString()}, nil
+}
 
-// func randString(n int) string {
-// 	b := make([]rune, n)
-// 	for i := range b {
-// 		b[i] = alphaNumericRunes[rand.Intn(len(alphaNumericRunes))]
-// 	}
-// 	return string(b)
-// }
+// Structure implements the dsio.EntryReader interface
+func (g Generator) Structure() *dataset.Structure {
+	return g.structure
+}
+
+var alphaNumericRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+// randString generates a random string of alpha numeric characters up to maxLen runes long.
+func (g Generator) randString() string {
+	n := rand.Intn(g.maxLen)
+	bytes := make([]rune, n)
+	for i := range bytes {
+		bytes[i] = alphaNumericRunes[rand.Intn(len(alphaNumericRunes))]
+	}
+	return string(bytes)
+}
+
+// Config stores settings for the generate package.
+type Config struct {
+	random *rand.Rand
+	maxLen int
+}
+
+// DefaultConfig returns the default configuration for a Generator.
+func DefaultConfig() *Config {
+	return &Config{
+		random: rand.New(rand.NewSource(time.Now().UnixNano())),
+		maxLen: 64,
+	}
+}
+
+// NewGenerator creates a generator with the given configuration options
+func NewGenerator(st *dataset.Structure, options ...func(*Config)) (*Generator, error) {
+	cfg := DefaultConfig()
+	for _, opt := range options {
+		opt(cfg)
+	}
+
+	// Convert the schema to a string, check for "array" string in the result.
+	// TODO: Inspect the structure more deeply than simply "array" vs "object".
+	pather := fmt.Sprintf("%s", st.Schema.Schema.JSONChildren()["type"])
+	schemaIsArray := false
+	if strings.Contains(pather, "array") {
+		schemaIsArray = true
+	}
+	return &Generator{
+		structure:     st,
+		maxLen:        cfg.maxLen,
+		random:        cfg.random,
+		schemaIsArray: schemaIsArray}, nil
+}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1,0 +1,72 @@
+package generate
+
+import (
+	"github.com/qri-io/dataset"
+	"math/rand"
+	"testing"
+)
+
+// Compile time check that Generator satisfies the EntryReader interace.
+var _ dsio.EntryReader = (*Generator)(nil)
+
+func AssignSeed(cfg *Config) {
+	cfg.random = rand.New(rand.NewSource(4))
+}
+
+func AssignMaxLen(cfg *Config) {
+	cfg.maxLen = 8
+}
+
+func TestGeneratorForBaseSchemaArray(t *testing.T) {
+	sta := dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaArray}
+	g, _ := NewGenerator(&sta, AssignSeed, AssignMaxLen)
+	cases := []struct {
+		index int
+		key   string
+		value string
+	}{
+		{0, "", "p"},
+		{1, "", "nfgDsc2"},
+		{2, "", "D8F2qN"},
+	}
+
+	for i, c := range cases {
+		e, _ := g.ReadEntry()
+		if e.Index != c.index {
+			t.Errorf("case %d index mismatch. expected: %d. got: %d", i, c.index, e.Index)
+		}
+		if e.Key != c.key {
+			t.Errorf("case %d key mismatch. expected: %s. got: %s", i, c.key, e.Key)
+		}
+		if e.Value != c.value {
+			t.Errorf("case %d value mismatch. expected: %s. got: %s", i, c.value, e.Value)
+		}
+	}
+}
+
+func TestGeneratorForBaseSchemaObject(t *testing.T) {
+	sta := dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaObject}
+	g, _ := NewGenerator(&sta, AssignSeed, AssignMaxLen)
+	cases := []struct {
+		index int
+		key   string
+		value string
+	}{
+		{0, "HK5a8", "jj"},
+		{0, "kwzDkh9", "2fhfU"},
+		{0, "uS9jZ", "uVbhV3"},
+	}
+
+	for i, c := range cases {
+		e, _ := g.ReadEntry()
+		if e.Index != c.index {
+			t.Errorf("case %d index mismatch. expected: %d. got: %d", i, e.Index, c.index)
+		}
+		if e.Key != c.key {
+			t.Errorf("case %d key mismatch. expected: %s. got: %s", i, e.Key, c.key)
+		}
+		if e.Value != c.value {
+			t.Errorf("case %d value mismatch. expected: %s. got: %s", i, e.Value, c.value)
+		}
+	}
+}


### PR DESCRIPTION
The generate package now inspects the jsonschema it owns, but only to determine if it's an array or
object. It also implements dsio.EntryReader, returning an entry with random data on each call.
Resolves #101.