### PR TITLE
test(dsio): benchmark EntryWriter usage for JSON, CBOR, and CSV

### DIFF
--- a/dsio/README.md
+++ b/dsio/README.md
@@ -1,0 +1,12 @@
+## Performance
+
+2018-27-03
+
+    go test github.com/qri-io/dataset/dsio -bench=.
+
+    BenchmarkCBORWriterArrays-2    	    3000	    459859 ns/op
+    BenchmarkCBORWriterObjects-2   	    3000	    576226 ns/op
+    BenchmarkCSVWriterArrays-2     	    1000	   1557871 ns/op
+    BenchmarkCSVWriterObjects-2    	    1000	   1489634 ns/op
+    BenchmarkJSONWriterArrays-2    	    1000	   1412656 ns/op
+    BenchmarkJSONWriterObjects-2   	    1000	   1665526 ns/op

--- a/dsio/cbor_test.go
+++ b/dsio/cbor_test.go
@@ -385,3 +385,43 @@ func TestCBORWriterCanonical(t *testing.T) {
 		buf.Reset()
 	}
 }
+
+func BenchmarkCBORWriterArrays(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.CBORDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w, err := NewCBORWriter(st, buf)
+		if err != nil {
+			b.Errorf("unexpected error creating writer: %s", err.Error())
+			return
+		}
+
+		for i := 0; i < NumWrites; i++ {
+			// Write an array entry.
+			arrayEntry := Entry{Index: i, Value: "test"}
+			w.WriteEntry(arrayEntry)
+		}
+	}
+}
+
+func BenchmarkCBORWriterObjects(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.CBORDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w, err := NewCBORWriter(st, buf)
+		if err != nil {
+			b.Errorf("unexpected error creating writer: %s", err.Error())
+			return
+		}
+
+		for i := 0; i < NumWrites; i++ {
+			// Write an object entry.
+			objectEntry := Entry{Key: "key", Value: "test"}
+			w.WriteEntry(objectEntry)
+		}
+	}
+}

--- a/dsio/csv_test.go
+++ b/dsio/csv_test.go
@@ -125,3 +125,33 @@ func TestReplaceSoloCarriageReturns(t *testing.T) {
 		t.Errorf("byte mismatch. expected:\n%v\ngot:\n%v", expect, got)
 	}
 }
+
+func BenchmarkCSVWriterArrays(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.CSVDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w := NewCSVWriter(st, buf)
+		for i := 0; i < NumWrites; i++ {
+			// Write an array entry.
+			arrayEntry := Entry{Index: i, Value: "test"}
+			w.WriteEntry(arrayEntry)
+		}
+	}
+}
+
+func BenchmarkCSVWriterObjects(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.CSVDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w := NewCSVWriter(st, buf)
+		for i := 0; i < NumWrites; i++ {
+			// Write an object entry.
+			objectEntry := Entry{Key: "key", Value: "test"}
+			w.WriteEntry(objectEntry)
+		}
+	}
+}

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -224,3 +224,43 @@ func TestJSONWriterDoubleKey(t *testing.T) {
 		return
 	}
 }
+
+func BenchmarkJSONWriterArrays(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w, err := NewJSONWriter(st, buf)
+		if err != nil {
+			b.Errorf("unexpected error creating writer: %s", err.Error())
+			return
+		}
+
+		for i := 0; i < NumWrites; i++ {
+			// Write an array entry.
+			arrayEntry := Entry{Index: i, Value: "test"}
+			w.WriteEntry(arrayEntry)
+		}
+	}
+}
+
+func BenchmarkJSONWriterObjects(b *testing.B) {
+	const NumWrites = 1000
+	st := &dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaObject}
+
+	for n := 0; n < b.N; n++ {
+		buf := &bytes.Buffer{}
+		w, err := NewJSONWriter(st, buf)
+		if err != nil {
+			b.Errorf("unexpected error creating writer: %s", err.Error())
+			return
+		}
+
+		for i := 0; i < NumWrites; i++ {
+			// Write an object entry.
+			objectEntry := Entry{Key: "key", Value: "test"}
+			w.WriteEntry(objectEntry)
+		}
+	}
+}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsio"
 	"math/rand"
 	"testing"
 )


### PR DESCRIPTION
Benchmarks for multiple EntryWriter implementations. Add current benchmark numbers to a README file. Also fix a test broken by 6a7bffac6e. Resolves #102.