### PR TITLE
feat(dsio): Generate example entries, fuzz testing, documentation

### DIFF
--- a/dsio/README.md
+++ b/dsio/README.md
@@ -13,3 +13,23 @@
     BenchmarkJSONWriterArrays-2    	    1000	   1423156 ns/op
     BenchmarkJSONWriterObjects-2   	    1000	   1620801 ns/op
     BenchmarkJSONReader-2          	     300	   5286851 ns/op
+
+## Fuzz testing
+
+From: [https://medium.com/@dgryski/go-fuzz-github-com-arolek-ase-3c74d5a3150c](http://https://medium.com/@dgryski/go-fuzz-github-com-arolek-ase-3c74d5a3150c)
+
+How to fuzz test:
+
+    go install github.com/qri-io/dataset/use_generate
+    cd $GOPATH
+    mkdir out
+    bin/use_generate
+    cp $GOPATH/out/* workdir/corpus/.
+
+    go get github.com/dvyukov/go-fuzz/go-fuzz
+    go get github.com/dvyukov/go-fuzz/go-fuzz-build
+    go install github.com/dvyukov/go-fuzz/go-fuzz
+    go install github.com/dvyukov/go-fuzz/go-fuzz-build
+
+    go-fuzz-build github.com/qri-io/dataset/dsio
+    go-fuzz -bin=dsio-fuzz.zip -workdir=workdir

--- a/dsio/fuzz.go
+++ b/dsio/fuzz.go
@@ -1,0 +1,28 @@
+package dsio
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/qri-io/dataset"
+)
+
+// Fuzz is the entry-point for go-fuzz. Return 1 for a successful parse and 0 for failures.
+func Fuzz(data []byte) int {
+	r := bytes.NewReader(data)
+	st := &dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaObject}
+	reader, err := NewJSONReader(st, r)
+	if err != nil {
+		return 0
+	}
+	for {
+		_, err = reader.ReadEntry()
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			fmt.Printf("Error: %s\n", err.Error())
+			return 0
+		}
+	}
+	return 1
+}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -3,20 +3,11 @@ package generate
 import (
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
-	"math/rand"
 	"testing"
 )
 
 // Compile time check that Generator satisfies the EntryReader interace.
 var _ dsio.EntryReader = (*Generator)(nil)
-
-func AssignSeed(cfg *Config) {
-	cfg.random = rand.New(rand.NewSource(4))
-}
-
-func AssignMaxLen(cfg *Config) {
-	cfg.maxLen = 8
-}
 
 func TestGeneratorForBaseSchemaArray(t *testing.T) {
 	sta := dataset.Structure{Format: dataset.JSONDataFormat, Schema: dataset.BaseSchemaArray}
@@ -26,9 +17,9 @@ func TestGeneratorForBaseSchemaArray(t *testing.T) {
 		key   string
 		value string
 	}{
-		{0, "", "p"},
-		{1, "", "nfgDsc2"},
-		{2, "", "D8F2qN"},
+		{0, "", "gltBH"},
+		{1, "", "VJQV"},
+		{2, "", "dv8A"},
 	}
 
 	for i, c := range cases {
@@ -53,9 +44,9 @@ func TestGeneratorForBaseSchemaObject(t *testing.T) {
 		key   string
 		value string
 	}{
-		{0, "HK5a8", "jj"},
-		{0, "kwzDkh9", "2fhfU"},
-		{0, "uS9jZ", "uVbhV3"},
+		{0, "VJQV", "gltBH"},
+		{0, "0", "dv8A"},
+		{0, "", ""},
 	}
 
 	for i, c := range cases {

--- a/use_generate/main.go
+++ b/use_generate/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsio"
+	"github.com/qri-io/dataset/generate"
+	"github.com/qri-io/jsonschema"
+	"math/rand"
+	"os"
+)
+
+func main() {
+	generateExamples(dataset.BaseSchemaObject, 40, "data_obj_%d")
+	generateExamples(dataset.BaseSchemaArray, 40, "data_array_%d")
+}
+
+func generateExamples(schema *jsonschema.RootSchema, numExamples int, template string) {
+	sta := dataset.Structure{Format: dataset.JSONDataFormat, Schema: schema}
+	g, _ := generate.NewGenerator(&sta, generate.AssignUseRandomType)
+	for i := 0; i < numExamples; i++ {
+		filename := fmt.Sprintf("out/"+template+".json", i)
+		f, err := os.Create(filename)
+		if err != nil {
+			fmt.Printf("%s", err)
+			return
+		}
+		writer, err := dsio.NewJSONWriter(&sta, f)
+		if err != nil {
+			fmt.Printf("%s", err)
+			return
+		}
+
+		numEntries := rand.Intn(10)
+		for j := 0; j < numEntries; j++ {
+			ent, err := g.ReadEntry()
+			if err != nil {
+				fmt.Printf("%s", err)
+				return
+			}
+
+			writer.WriteEntry(ent)
+		}
+		writer.Close()
+	}
+}


### PR DESCRIPTION
Add a small binary to generate example json entries. Add an entry-point that go-fuzz can use to
perform fuzz testing. Add documentation on how to run fuzz testing.

This is a partial fix to #103, but doesn't fully solve it yet because the readers do not handle errors well enough for fuzz testing to work properly.