### PR TITLE
refactor(Abstract,AbstractTransform): removed Abstract fields from dataset struct

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -36,14 +36,8 @@ func CompareDatasets(a, b *Dataset) error {
 	if err := CompareStructures(a.Structure, b.Structure); err != nil {
 		return fmt.Errorf("Structure: %s", err.Error())
 	}
-	if err := CompareDatasets(a.Abstract, b.Abstract); err != nil {
-		return fmt.Errorf("Abstract: %s", err.Error())
-	}
 	if err := CompareTransforms(a.Transform, b.Transform); err != nil {
 		return fmt.Errorf("Transform: %s", err.Error())
-	}
-	if err := CompareTransforms(a.AbstractTransform, b.AbstractTransform); err != nil {
-		return fmt.Errorf("AbstractTransform: %s", err.Error())
 	}
 	if err := CompareCommits(a.Commit, b.Commit); err != nil {
 		return fmt.Errorf("Commit: %s", err.Error())

--- a/compare_test.go
+++ b/compare_test.go
@@ -21,7 +21,6 @@ func TestCompareDatasets(t *testing.T) {
 		{&Dataset{DataPath: "a"}, &Dataset{DataPath: "b"}, "DataPath: a != b"},
 		{&Dataset{}, &Dataset{Structure: &Structure{}}, "Structure: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Transform: &Transform{}}, "Transform: nil: <nil> != <not nil>"},
-		{&Dataset{}, &Dataset{AbstractTransform: &Transform{}}, "AbstractTransform: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Commit: &Commit{}}, "Commit: nil: <nil> != <not nil>"},
 	}
 
@@ -92,40 +91,6 @@ func TestCompareStructures(t *testing.T) {
 	}
 }
 
-// TODO - restore
-// func TestCompareSchemas(t *testing.T) {
-// 	cases := []struct {
-// 		a, b *Schema
-// 		err  string
-// 	}{
-// 		{nil, nil, ""},
-// 		{AirportCodes.Structure.Schema, AirportCodes.Structure.Schema, ""},
-// 		{&Schema{}, nil, "nil: <not nil> != <nil>"},
-// 		{nil, &Schema{}, "nil: <nil> != <not nil>"},
-// 		{&Schema{PrimaryKey: FieldKey{"a"}}, &Schema{PrimaryKey: FieldKey{"b"}}, "PrimaryKey: element 0: a != b"},
-// 		{&Schema{}, &Schema{Fields: []*Field{}}, "Fields: [] != []"},
-// 		{&Schema{}, &Schema{Fields: []*Field{&Field{Name: "a"}}}, "Fields: [] != [%!s(*dataset.Field=&{a 0 <nil>  <nil>  })]"},
-// 		{&Schema{Fields: []*Field{&Field{Name: "a"}}}, &Schema{Fields: []*Field{&Field{Name: "b"}}}, "Fields: element 0: name: a != b"},
-// 	}
-
-// 	for i, c := range cases {
-// 		err := CompareSchemas(c.a, c.b)
-// 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-// 			t.Errorf("case %d error: expected: '%s', got: '%s'", i, c.err, err)
-// 		}
-// 	}
-// }
-
-// func TestCompareFields(t *testing.T) {
-// 	f := &Field{
-// 		Name:         "a",
-// 		Type:         datatypes.String,
-// 		MissingValue: "foo",
-// 		Format:       "fmt",
-// 		Title:        "a",
-// 		Description:  "a",
-// 	}
-
 func TestCompareVisConfigs(t *testing.T) {
 	cases := []struct {
 		a, b *VisConfig
@@ -148,24 +113,6 @@ func TestCompareVisConfigs(t *testing.T) {
 		}
 	}
 }
-
-// 	cases := []struct {
-// 		a, b *Field
-// 		err  string
-// 	}{
-// 		{nil, nil, ""},
-// 		{f, f, ""},
-// 		{nil, f, "nil: <nil> != <not nil>"},
-// 		{f, nil, "nil: <not nil> != <nil>"},
-// 	}
-
-// 	for i, c := range cases {
-// 		err := CompareFields(c.a, c.b)
-// 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-// 			t.Errorf("case %d error: expected: '%s', got: '%s'", i, c.err, err)
-// 		}
-// 	}
-// }
 
 func TestCompareCommits(t *testing.T) {
 	c1 := &Commit{

--- a/dataset.go
+++ b/dataset.go
@@ -29,11 +29,6 @@ type Dataset struct {
 	// private storage for reference to this object
 	path datastore.Key
 
-	// Abstract is the abstract form of this dataset
-	Abstract *Dataset `json:"abstract,omitempty"`
-	// AbstractTransform is a reference to the general form of the transformation
-	// that resulted in this dataset
-	AbstractTransform *Transform `json:"abstractTransform,omitempty"`
 	// Commit contains author & change message information
 	Commit *Commit `json:"commit,omitempty"`
 	// DataPath is the path to the hash of raw data as it resolves on the network.
@@ -54,9 +49,7 @@ type Dataset struct {
 
 // IsEmpty checks to see if dataset has any fields other than the internal path
 func (ds *Dataset) IsEmpty() bool {
-	return ds.Abstract == nil &&
-		ds.AbstractTransform == nil &&
-		ds.Commit == nil &&
+	return ds.Commit == nil &&
 		ds.Structure == nil &&
 		ds.DataPath == "" &&
 		ds.Meta == nil &&
@@ -119,20 +112,10 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 		} else if ds.Meta != nil {
 			ds.Meta.Assign(d.Meta)
 		}
-		if ds.Abstract == nil && d.Abstract != nil {
-			ds.Abstract = d.Abstract
-		} else if ds.Abstract != nil {
-			ds.Abstract.Assign(d.Abstract)
-		}
 		if ds.Transform == nil && d.Transform != nil {
 			ds.Transform = d.Transform
 		} else if ds.Transform != nil {
 			ds.Transform.Assign(d.Transform)
-		}
-		if ds.AbstractTransform == nil && d.AbstractTransform != nil {
-			ds.AbstractTransform = d.AbstractTransform
-		} else if ds.AbstractTransform != nil {
-			ds.AbstractTransform.Assign(d.AbstractTransform)
 		}
 		if ds.Commit == nil && d.Commit != nil {
 			ds.Commit = d.Commit

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -35,9 +35,7 @@ func TestDatasetAssign(t *testing.T) {
 	}{
 		{&Dataset{path: datastore.NewKey("/a")}},
 		{&Dataset{Structure: &Structure{Format: CSVDataFormat}}},
-		// {&Dataset{Abstract: &Dataset{Title: "I'm an abstract dataset"}}},
 		{&Dataset{Transform: &Transform{Data: "I'm transform data!"}}},
-		{&Dataset{AbstractTransform: &Transform{Data: "I'm abstract transform data?"}}},
 		{&Dataset{Commit: &Commit{Title: "foo"}}},
 		{&Dataset{DataPath: "foo"}},
 		{&Dataset{PreviousPath: "stuff"}},
@@ -57,20 +55,16 @@ func TestDatasetAssign(t *testing.T) {
 
 	// test model assignment
 	mads := &Dataset{
-		Abstract:          &Dataset{},
-		Transform:         &Transform{},
-		AbstractTransform: &Transform{},
-		Structure:         &Structure{},
-		Commit:            &Commit{},
-		VisConfig:         &VisConfig{},
+		Transform: &Transform{},
+		Structure: &Structure{},
+		Commit:    &Commit{},
+		VisConfig: &VisConfig{},
 	}
 	madsa := &Dataset{
-		Abstract:          &Dataset{Structure: &Structure{}},
-		Transform:         &Transform{Data: "I'm transform data!"},
-		AbstractTransform: &Transform{Data: "I'm abstract transform data?"},
-		Structure:         &Structure{Format: CSVDataFormat},
-		Commit:            &Commit{Title: "dy.no.mite."},
-		VisConfig:         &VisConfig{Qri: KindVisConfig},
+		Transform: &Transform{Data: "I'm transform data!"},
+		Structure: &Structure{Format: CSVDataFormat},
+		Commit:    &Commit{Title: "dy.no.mite."},
+		VisConfig: &VisConfig{Qri: KindVisConfig},
 	}
 	mads.Assign(madsa)
 
@@ -175,8 +169,6 @@ func TestDatasetIsEmpty(t *testing.T) {
 	cases := []struct {
 		ds *Dataset
 	}{
-		{&Dataset{Abstract: &Dataset{}}},
-		{&Dataset{AbstractTransform: &Transform{}}},
 		{&Dataset{Commit: &Commit{}}},
 		{&Dataset{DataPath: "foo"}},
 		{&Dataset{Meta: &Meta{}}},

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -148,11 +148,11 @@ func TestCreateDataset(t *testing.T) {
 		{"cities",
 			"/map/QmViLcZ6Yu4Yi4bQe7zcfntHNdDes5xwQp3fbxq3iUouWS", 6, ""},
 		{"complete",
-			"/map/QmRSc1VTBQnoWdH8dV3M9cLt6e1639SVN1L8CMZ7ipCc8F", 15, ""},
+			"/map/QmPbJ8wrbVbBGQBkPqJTcAnrhQVAxZ9KTeZNv1wnjN7kDw", 12, ""},
 		{"cities_no_commit_title",
-			"/map/QmPHmSFoxBn73t61M3E9SYNZvqD1BdFriTn3fVWjfG4seN", 17, ""},
+			"/map/QmPHmSFoxBn73t61M3E9SYNZvqD1BdFriTn3fVWjfG4seN", 14, ""},
 		{"craigslist",
-			"/map/QmdV6TqbjvwDqZrqPDyXeMYujEZaiaG18YjXVRhD66VFfZ", 20, ""},
+			"/map/QmdV6TqbjvwDqZrqPDyXeMYujEZaiaG18YjXVRhD66VFfZ", 17, ""},
 	}
 
 	for _, c := range cases {
@@ -222,8 +222,8 @@ func TestCreateDataset(t *testing.T) {
 	if err.Error() != expectedErr {
 		t.Errorf("case nil datafile and no PreviousPath, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	}
-	if len(store.(cafs.MapStore)) != 20 {
-		t.Errorf("case nil datafile and PreviousPath, expected invalid number of entries: %d != %d", 20, len(store.(cafs.MapStore)))
+	if len(store.(cafs.MapStore)) != 17 {
+		t.Errorf("case nil datafile and PreviousPath, invalid number of entries: %d != %d", 17, len(store.(cafs.MapStore)))
 		_, err := store.(cafs.MapStore).Print()
 		if err != nil {
 			panic(err)
@@ -252,7 +252,7 @@ func TestWriteDataset(t *testing.T) {
 		err       string
 	}{
 		{"testdata/cities/input.dataset.json", "testdata/cities/data.csv", "/map/", 6, ""},
-		{"testdata/complete/input.dataset.json", "testdata/complete/data.csv", "/map/", 15, ""},
+		{"testdata/complete/input.dataset.json", "testdata/complete/data.csv", "/map/", 12, ""},
 	}
 
 	for i, c := range cases {
@@ -310,26 +310,11 @@ func TestWriteDataset(t *testing.T) {
 			continue
 		}
 
-		if ref.Abstract != nil {
-			if !ref.Abstract.IsEmpty() {
-				t.Errorf("expected stored dataset.Abstract to be a reference")
-			}
-			// Abstract paths shouldnt' be loaded
-			ds.Abstract = dataset.NewDatasetRef(ref.Abstract.Path())
-		}
-
 		if ref.Transform != nil {
 			if !ref.Transform.IsEmpty() {
 				t.Errorf("expected stored dataset.Transform to be a reference")
 			}
 			ds.Transform.Assign(dataset.NewTransformRef(ref.Transform.Path()))
-		}
-		if ref.AbstractTransform != nil {
-			if !ref.AbstractTransform.IsEmpty() {
-				t.Errorf("expected stored dataset.AbstractTransform to be a reference")
-			}
-			// Abstract transforms aren't loaded
-			ds.AbstractTransform = dataset.NewTransformRef(ref.AbstractTransform.Path())
 		}
 		if ref.Meta != nil {
 			if !ref.Meta.IsEmpty() {


### PR DESCRIPTION
storing abstractions was a carry over from the SQL days that's needed removal for some time now.
This removes the struct fields, but leaves in abract calculation methods, which I think will still
be useful later on. Also a few other little cleanups here & there.