### PR TITLE
fix(dsio.JSONReader): handle edge case of object/array reading empty buffer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/qri-io/dataset
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.10.1
         environment:
           GOLANG_ENV: test
           PORT: 3000

--- a/dsio/entry.go
+++ b/dsio/entry.go
@@ -30,7 +30,7 @@ func EachEntry(rr EntryReader, fn DataIteratorFunc) error {
 			if err.Error() == io.EOF.Error() {
 				return nil
 			}
-			err := fmt.Errorf("error reading row: %s", err.Error())
+			err := fmt.Errorf("error reading row %d: %s", num, err.Error())
 			log.Debug(err.Error())
 			return err
 		}

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -225,6 +225,44 @@ func TestJSONReaderSmallerBufferForHugeToken(t *testing.T) {
 	}
 }
 
+func TestJSONSizeReader(t *testing.T) {
+	cases := []struct {
+		structure *dataset.Structure
+		size      int
+		data      string
+	}{
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
+		}, 16, `[["a","b","cdef"]]`},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
+		}, 18, `[{"a":"b","c":"d","e":"f"}]`},
+	}
+
+	for i, c := range cases {
+		r, err := NewJSONReaderSize(c.structure, strings.NewReader(c.data), c.size)
+		if err != nil {
+			t.Errorf("case %d unexpected error creating reader: %s", i, err.Error())
+			continue
+		}
+
+		err = EachEntry(r, func(i int, ent Entry, e error) error {
+			if e != nil {
+				return e
+			}
+			return nil
+		})
+
+		if err != nil {
+			t.Errorf("case %d: unexpected error: %s", i, err.Error())
+			continue
+		}
+
+	}
+}
+
 func TestJSONReaderErrors(t *testing.T) {
 	cases := []struct {
 		text      string

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -238,7 +238,23 @@ func TestJSONSizeReader(t *testing.T) {
 		{&dataset.Structure{
 			Format: dataset.JSONDataFormat,
 			Schema: dataset.BaseSchemaArray,
+		}, 16, `[[12345,67890,12345,67890]]`},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
 		}, 18, `[{"a":"b","c":"d","e":"f"}]`},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
+		}, 16, `[[  "a"  ,  "b"  ,  "c"  ,  "d"  ]]`},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
+		}, 16, `[[false, false, false , false]]`},
+		{&dataset.Structure{
+			Format: dataset.JSONDataFormat,
+			Schema: dataset.BaseSchemaArray,
+		}, 16, `[[true, true, true, true]]`},
 	}
 
 	for i, c := range cases {

--- a/validate/data.go
+++ b/validate/data.go
@@ -26,7 +26,11 @@ func EntryReader(r dsio.EntryReader) ([]jsonschema.ValError, error) {
 		if err != nil {
 			return fmt.Errorf("error reading row %d: %s", i, err.Error())
 		}
-		return buf.WriteEntry(ent)
+		err = buf.WriteEntry(ent)
+		if err != nil {
+			return fmt.Errorf("error writing row %d: %s", i, err.Error())
+		}
+		return nil
 	})
 
 	if err != nil {


### PR DESCRIPTION
Found a weird edge case while adding a large json file. validate uses dsio.JSONReader to validate json data, which was failing if while reading object/array and r.reader.Buffered() doesn't contain a valid token.

From what I can tell, it seems this only occurs in rare circumstances where the desired token lines up with the end of the current buffer, which zeros out the buffer, and on next read causes the tokenization process to fail.

@dustmop I managed a possibly-terrible fix by checking the length of `r.reader.Buffered()` at the top of each iteration of an object or array read. This might be better placed, and I'd be happy to adjust this PR based on what you think.