### PR TITLE
refactor(CodingPattern): introduce coding pattern

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/jbenet/go-base58"
+	"github.com/mr-tron/base58/base58"
 	"github.com/multiformats/go-multihash"
 )
 


### PR DESCRIPTION
We've been running into all sorts of problems upstream when trying to send raw *Dataset's over the wire due to inconsistencies serializing to various formats.

To me this highlights a tension in the two roles that structs like Dataset, Commit, Structure, etc. have to play: Serialization & business logic. This shows up the most when trying to decide on the proper type for struct fields when a more "exotic" type (something other than `string`, `int`, `[]byte`, ...) is preferred to limit use cases to specific concerns. Things like our typed DataFormat consts are a great example.

For the serialization concern a struct field like `Structure.DataFormat` would ideally just be a `string`. serialization libraries like json, cbor, and gob all know how to deal with strings, so it's less code to maintain. On the other hand `DataFormat` can really only be a few things right now (CSV, JSON, CBOR), and we need tight controls on what values `DataFormat` can have because we make lots of decisions on that value. For this reason it makes lots of sense for a `DataFormat` field to be a custom type that errors if it isn't a value we like. This is a "business logic" concern enforced by taking advantage of custom types.

So I think the answer is to separate the concerns into two structs, one struct for the serialization concern, and another struct for the business logic concern. I've heard about this pattern in the wild, but haven't really implemented it myself. So, for lack of reading I'm going to call it the "coding pattern", and it works as follows:
* two structs, one "standard", the other with the prefix "Coding"
* the first struct gets two methods: Endode and Decode, that translate to & from the
  coding variant
* All serialization should happen at the "Coding struct"

This last bullet isn't yet fully implemented in this codebase, as it's going to take some time to migrate over. I'd like to start by switching codebases that use qri to this new pattern, then migrating all dataset subpackages once we have time.