### PR TITLE
feat(SignableBytes): sign dataset hash & timestamp instead of title

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -43,11 +43,6 @@ func (cm *Commit) Path() datastore.Key {
 	return cm.path
 }
 
-// SignableBytes produces the portion of a commit message used for signing
-func (cm *Commit) SignableBytes() []byte {
-	return []byte(fmt.Sprintf("%s\n%s", cm.Timestamp.Format(time.RFC3339), cm.Title))
-}
-
 // SetPath sets the internal path property of a commit
 // Use with caution. most callers should never need to call SetPath
 func (cm *Commit) SetPath(path string) {

--- a/commit_test.go
+++ b/commit_test.go
@@ -103,19 +103,6 @@ func TestCommitIsEmpty(t *testing.T) {
 	}
 }
 
-func TestCommitSignableBytes(t *testing.T) {
-	expect := []byte("2001-01-01T01:01:01Z\nI'm a commit message")
-	cm := &Commit{
-		Timestamp: time.Date(2001, 01, 01, 01, 01, 01, 0, time.UTC),
-		Title:     "I'm a commit message",
-	}
-	got := cm.SignableBytes()
-
-	if !bytes.Equal(expect, got) {
-		t.Errorf("mismatch. expected:\n'%s',got:\n'%s'", string(expect), string(got))
-	}
-}
-
 func TestCommitMarshalJSON(t *testing.T) {
 	ts := time.Date(2001, 01, 01, 01, 01, 01, 0, time.UTC)
 	cases := []struct {

--- a/dataset.go
+++ b/dataset.go
@@ -3,6 +3,7 @@ package dataset
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	logger "github.com/ipfs/go-log"
@@ -89,6 +90,22 @@ func (ds *Dataset) SetPath(path string) {
 	} else {
 		ds.path = datastore.NewKey(path)
 	}
+}
+
+// SignableBytes produces the portion of a commit message used for signing
+// the format for signable bytes is:
+// *  commit timestamp in RFC3339 format, UTC timezone
+// *  newline character
+// *  dataset structure checksum string
+// checksum string should be a base58-encoded multihash of the dataset data
+func (ds *Dataset) SignableBytes() ([]byte, error) {
+	if ds.Commit == nil {
+		return nil, fmt.Errorf("commit is required")
+	}
+	if ds.Structure == nil {
+		return nil, fmt.Errorf("structure is required")
+	}
+	return []byte(fmt.Sprintf("%s\n%s", ds.Commit.Timestamp.UTC().Format(time.RFC3339), ds.Structure.Checksum)), nil
 }
 
 // Assign collapses all properties of a group of datasets onto one.

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -212,9 +212,9 @@ func CreateDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pk c
 }
 
 // Timestamp is an function for getting commit timestamps
-// we replace this with a static function for testing purposes
+// timestamps MUST be stored in UTC time zone
 var Timestamp = func() time.Time {
-	return time.Now()
+	return time.Now().UTC()
 }
 
 func generateCommitMsg(store cafs.Filestore, ds *dataset.Dataset) (string, error) {
@@ -384,7 +384,8 @@ func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pri
 	cleanTitleAndMessage(&ds.Commit.Title, &ds.Commit.Message)
 
 	ds.Commit.Timestamp = Timestamp()
-	signedBytes, err := privKey.Sign(ds.Commit.SignableBytes())
+	sb, _ := ds.SignableBytes()
+	signedBytes, err := privKey.Sign(sb)
 	if err != nil {
 		log.Debug(err.Error())
 		return nil, "", fmt.Errorf("error signing commit title: %s", err.Error())

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -1,6 +1,7 @@
 package dsfs
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -390,7 +391,7 @@ func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pri
 		log.Debug(err.Error())
 		return nil, "", fmt.Errorf("error signing commit title: %s", err.Error())
 	}
-	ds.Commit.Signature = base58.Encode(signedBytes)
+	ds.Commit.Signature = base64.StdEncoding.EncodeToString(signedBytes)
 
 	return cafs.NewMemfileBytes("data."+ds.Structure.Format.String(), data), diffDescription, nil
 }

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -146,13 +146,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmViLcZ6Yu4Yi4bQe7zcfntHNdDes5xwQp3fbxq3iUouWS", 6, ""},
+			"/map/QmVFgsPBgUKEUahWW41WUevVE6NeGXcuDQgy5FrzetUuGn", 6, ""},
 		{"complete",
-			"/map/QmPbJ8wrbVbBGQBkPqJTcAnrhQVAxZ9KTeZNv1wnjN7kDw", 12, ""},
+			"/map/QmaquVWpsGBnZqmxm9jThG1Mm8jRKouBQQo6vD733yTTc2", 12, ""},
 		{"cities_no_commit_title",
-			"/map/QmPHmSFoxBn73t61M3E9SYNZvqD1BdFriTn3fVWjfG4seN", 14, ""},
+			"/map/Qmbb4jevWGG9sxWt44AkC6HokBFXk694ftckqHmaJ84pdi", 14, ""},
 		{"craigslist",
-			"/map/QmdV6TqbjvwDqZrqPDyXeMYujEZaiaG18YjXVRhD66VFfZ", 17, ""},
+			"/map/QmUvH1XJmQSQgd653e7TdwpRVZ4EW4BPWa8EtsxCCPdzsz", 18, ""},
 	}
 
 	for _, c := range cases {
@@ -222,8 +222,8 @@ func TestCreateDataset(t *testing.T) {
 	if err.Error() != expectedErr {
 		t.Errorf("case nil datafile and no PreviousPath, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	}
-	if len(store.(cafs.MapStore)) != 17 {
-		t.Errorf("case nil datafile and PreviousPath, invalid number of entries: %d != %d", 17, len(store.(cafs.MapStore)))
+	if len(store.(cafs.MapStore)) != 18 {
+		t.Errorf("case nil datafile and PreviousPath, invalid number of entries: %d != %d", 18, len(store.(cafs.MapStore)))
 		_, err := store.(cafs.MapStore).Print()
 		if err != nil {
 			panic(err)

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -146,13 +146,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmVFgsPBgUKEUahWW41WUevVE6NeGXcuDQgy5FrzetUuGn", 6, ""},
+			"/map/QmYXMg6gqMAT8seUFhgAagknFvfs71auFWbnSfVcg1NTd8", 6, ""},
 		{"complete",
-			"/map/QmaquVWpsGBnZqmxm9jThG1Mm8jRKouBQQo6vD733yTTc2", 12, ""},
+			"/map/QmPXQeoW82Jy9uZK5a6GSbG6JFBQcnfdp6hvf428kBg244", 12, ""},
 		{"cities_no_commit_title",
-			"/map/Qmbb4jevWGG9sxWt44AkC6HokBFXk694ftckqHmaJ84pdi", 14, ""},
+			"/map/QmNNtXBcv5Lp6rwHKFuLH4A7epnbgPVfBTUeMtZ7PFJiGL", 14, ""},
 		{"craigslist",
-			"/map/QmUvH1XJmQSQgd653e7TdwpRVZ4EW4BPWa8EtsxCCPdzsz", 18, ""},
+			"/map/QmayiyvRGkS8R6ifLRmHBKGd8ro9UWgXigrwsQU8vYFemg", 18, ""},
 	}
 
 	for _, c := range cases {

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -2,7 +2,7 @@
   "commit": {
     "message": "",
     "qri": "cm:0",
-    "signature": "4DXqY7LYbEqXQmhQMBzNAjAMgyFyCUcPBwnBY7FZZNMGmp65RqwefqFDawH75k1VbCST3oP9BwmhFagsg52YDA9iPGqgso3WeaubzbGc6VnjzEzNuSfRwiCLo6b7TYswLzUgBoZaBDV2stRErdCo7eqnTjS8CzEjby47XmJycwevbJVabxmVKrkafred8KSEyfD5QeGezETWDbedwbJsxWcCqv12sQuYkQUNRqkiEmQE2iq9AV1MrPhFdb7D6aGwDUvH2ZW65MLoUM91K6quyM6Py1ZBq43EmbnwyQrE3xGuds3hHrmUi3XNPCSEnwBcDFsvU5xpN1PYpYkA2Enbq55psrFtA8",
+    "signature": "RZU/18bxxacveMoNvGxINIS9MxvNwtc4OiSCRjCGnospztHNhJfJP0PflrzKG1tqLGi+c4w94BJRmLR/I5YaVqqwm86vGkYhwDRuBEViuT4GlKCzVEFUk63fJsT9YmcUWlabqEnUW2l0O6p+RatfmumlKOleONMYy1woa5PbIzRGoITo4u9piYiV6RVRJ9bURjEU7cr8iVXcwO+YEw6qMCUBKUAok+yttjt+iYm0JLD9hPoQO14Vu4jWMFxByoLvVIEquEqnlgyuQGvelFfuApUI5goTftOcASANuTsnrOe6gq0HJxNN27kAYQujS3swspi7qVrL9X8v341YKu77fQ==",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -2,7 +2,7 @@
   "commit": {
     "message": "",
     "qri": "cm:0",
-    "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
+    "signature": "4DXqY7LYbEqXQmhQMBzNAjAMgyFyCUcPBwnBY7FZZNMGmp65RqwefqFDawH75k1VbCST3oP9BwmhFagsg52YDA9iPGqgso3WeaubzbGc6VnjzEzNuSfRwiCLo6b7TYswLzUgBoZaBDV2stRErdCo7eqnTjS8CzEjby47XmJycwevbJVabxmVKrkafred8KSEyfD5QeGezETWDbedwbJsxWcCqv12sQuYkQUNRqkiEmQE2iq9AV1MrPhFdb7D6aGwDUvH2ZW65MLoUM91K6quyM6Py1ZBq43EmbnwyQrE3xGuds3hHrmUi3XNPCSEnwBcDFsvU5xpN1PYpYkA2Enbq55psrFtA8",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },

--- a/dsfs/testdata/complete/expect.dataset.json
+++ b/dsfs/testdata/complete/expect.dataset.json
@@ -3,7 +3,7 @@
   "abstractTransform": "/map/QmemJQrK7PTQvD3n8gmo9JhyaByyLmETiNR1Y8wS7hv4sP",
   "commit": {
     "qri": "cm:0",
-    "signature": "4DXqY7LYbEqXQmhQMBzNAjAMgyFyCUcPBwnBY7FZZNMGmp65RqwefqFDawH75k1VbCST3oP9BwmhFagsg52YDA9iPGqgso3WeaubzbGc6VnjzEzNuSfRwiCLo6b7TYswLzUgBoZaBDV2stRErdCo7eqnTjS8CzEjby47XmJycwevbJVabxmVKrkafred8KSEyfD5QeGezETWDbedwbJsxWcCqv12sQuYkQUNRqkiEmQE2iq9AV1MrPhFdb7D6aGwDUvH2ZW65MLoUM91K6quyM6Py1ZBq43EmbnwyQrE3xGuds3hHrmUi3XNPCSEnwBcDFsvU5xpN1PYpYkA2Enbq55psrFtA8",
+    "signature": "RZU/18bxxacveMoNvGxINIS9MxvNwtc4OiSCRjCGnospztHNhJfJP0PflrzKG1tqLGi+c4w94BJRmLR/I5YaVqqwm86vGkYhwDRuBEViuT4GlKCzVEFUk63fJsT9YmcUWlabqEnUW2l0O6p+RatfmumlKOleONMYy1woa5PbIzRGoITo4u9piYiV6RVRJ9bURjEU7cr8iVXcwO+YEw6qMCUBKUAok+yttjt+iYm0JLD9hPoQO14Vu4jWMFxByoLvVIEquEqnlgyuQGvelFfuApUI5goTftOcASANuTsnrOe6gq0HJxNN27kAYQujS3swspi7qVrL9X8v341YKu77fQ==",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "I'm a commit"
   },

--- a/dsfs/testdata/complete/expect.dataset.json
+++ b/dsfs/testdata/complete/expect.dataset.json
@@ -3,7 +3,7 @@
   "abstractTransform": "/map/QmemJQrK7PTQvD3n8gmo9JhyaByyLmETiNR1Y8wS7hv4sP",
   "commit": {
     "qri": "cm:0",
-    "signature": "8WVfbCKYc4rpugq5ZKYoWzX6wFQ6odffwe2UDAR1G1ktjQihiRx8EADNmxZDgh8LkuWSQLMKJ5xzndFVbW5AcnfeLkJ9GCut62QWmWapb5TWU2GeBxRZnmDhJKpDjTf5fvExUZk7F7viSbVGUfXWmKPZwieLVfowkJMGee8WLQo7hY3rK42dPjMfqP91AQgQsLCPFFFwGN94FExeQ5FcdP2ecLNpyxTbDNbQWeov6oUiHDTXFQ95T28WkJQDQvp5DwnS3WeBEF2TzxGq165KjLHLq3GJm5s767MzgWdZibKcRZpXX9k2S2DeMdRh1AhTXJEdXXj5TtS37ANeJ9f1QL4Eb6XAue",
+    "signature": "4DXqY7LYbEqXQmhQMBzNAjAMgyFyCUcPBwnBY7FZZNMGmp65RqwefqFDawH75k1VbCST3oP9BwmhFagsg52YDA9iPGqgso3WeaubzbGc6VnjzEzNuSfRwiCLo6b7TYswLzUgBoZaBDV2stRErdCo7eqnTjS8CzEjby47XmJycwevbJVabxmVKrkafred8KSEyfD5QeGezETWDbedwbJsxWcCqv12sQuYkQUNRqkiEmQE2iq9AV1MrPhFdb7D6aGwDUvH2ZW65MLoUM91K6quyM6Py1ZBq43EmbnwyQrE3xGuds3hHrmUi3XNPCSEnwBcDFsvU5xpN1PYpYkA2Enbq55psrFtA8",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "I'm a commit"
   },

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -1,7 +1,7 @@
 {
   "commit": {
     "qri": "cm:0",
-    "signature": "5LB6oyPr5VjMbTcwGRTqxmBkULqoJf3uYFM7ovoHkSLdfA94hPGa8uMveXE6YAxZYAB5kaKNWcEXg1oSwCKuXqVzvmjkPJPZs6J3LBYP1GdogZNMUxz9btrYAaS6qEcu4WwnTrhfr77wKc6mTDEzgnTR6tai78AjceXeEFpBppQ1xKXX3vn5ofmeRpoFVAKUN52FZra5x6swzncPaD8TzpFb4u59kHhVy9iKZ9xUKBmAAYPvSwJBJafYgSF5fR5sEYfjCbs6GXSDgpsRhdpGgqFpezUJL4u6ghCH5HbFtjEVGCiHFq5WRATDQMQSv1YNogKo9fhLPLkvKRqipRwsswSwTdEVXS",
+    "signature": "3y569rFMm5y2WT9caQyaUMvJfnMf2AFXXKGKukt31PtH9g99UZnmpA2mahGg6BLJMQUBRygtuS47BnM7xoC57bd8fjvCRLGZ8Juf6Lx8TfHQ5wc4Z6CAsuiXJ5DdrSiqqTpnHB6frWBA5gJ319z3ERqqKZXoiwkY4KJfNK3WyS9Vnj9g4upuH7qN8tcfYH2kn9DXv1QGTsEG88qPXAMY6WvHRUTFP2yr6HgyRam7YM8xbfpzzbLMMVk13ModTWH4W9gq3fWCCZofwvbN8e4nssfMBQsisegE4qMqn5RGL228BDuBwgD2hKqfACcX4mokeF83sqjBCVCqGnDP3RaYN6rrcyjA7A",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -1,7 +1,7 @@
 {
   "commit": {
     "qri": "cm:0",
-    "signature": "3y569rFMm5y2WT9caQyaUMvJfnMf2AFXXKGKukt31PtH9g99UZnmpA2mahGg6BLJMQUBRygtuS47BnM7xoC57bd8fjvCRLGZ8Juf6Lx8TfHQ5wc4Z6CAsuiXJ5DdrSiqqTpnHB6frWBA5gJ319z3ERqqKZXoiwkY4KJfNK3WyS9Vnj9g4upuH7qN8tcfYH2kn9DXv1QGTsEG88qPXAMY6WvHRUTFP2yr6HgyRam7YM8xbfpzzbLMMVk13ModTWH4W9gq3fWCCZofwvbN8e4nssfMBQsisegE4qMqn5RGL228BDuBwgD2hKqfACcX4mokeF83sqjBCVCqGnDP3RaYN6rrcyjA7A",
+    "signature": "QDA/hZm6buL6oBMdWAZnLi3mg5GMa10odfedy98hx8Alavbgn1c5WkZqd1dejqhkiKKjuok8fMdv5VLKGp12FVRXw3JpFa5fK8o5sQGNIVXe3TK/qmVHWKslNE7HhOkzb/ok8idTBHu3HPkXqDmHioZE0JeLkd6F41BIOkCcVBv+w3SviR3UqMSXtzeBqznUD4XfWUFe5PO08GkQ4qSOZKXj1aqxq/oSGQJHt4vN+891hn/fJDx0inLPRT4Dn4Hm8LL0tJ+o4OJ4q7gC+t9QrPaNK69aO6hgAXxJQbLGReh291Fdk+DWe7McGVJsp0YU0hdDC8kafotUHZosVVESWQ==",
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },


### PR DESCRIPTION
for a while we've been signing the commit datestamp & title string. Let's improve on that by always converting timestamps in UTC (potentially a *very* nasty problem if left the way it was), and signing the data hash instead of commit title.

Signing data hashes gives us the advantage of always signing a consistent number of bytes, and being a nice concept. In this version the author is signing off on the statement "at the point in time this data looked like this", which I'm a fan of. the only thing I'm left wondering about is maybe adding hash of metadata to the signature for added verification of meta info, but I'm not totally sure on that yet. It may be equally valid to argue that metadata, in being "data about data" isn't the principle subject of the dataset, and as such doesn't warrent signing.

Another suggestion mentioned by @dustmop is adding hash of the previous dataset version (if any), after some discussion we realized this would tie our signature mechanisms to the underlying content-addressed file system, which would require re-signing commits to switch between version control systems. Despite this, it may be worth investigating anyway.