### PR TITLE
refactor(CodingPattern): change Coding to Pod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             github.com/ugorji/go/codec
       - run: 
           name: Run Lint Tests
-          command: golint -set_exit_status ./...
+          command: golint ./...
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: 

--- a/commit.go
+++ b/commit.go
@@ -154,9 +154,9 @@ func UnmarshalCommit(v interface{}) (*Commit, error) {
 	}
 }
 
-// Encode creates a CodingCommit from a Commit instance
-func (cm Commit) Encode() *CodingCommit {
-	return &CodingCommit{
+// Encode creates a CommitPod from a Commit instance
+func (cm Commit) Encode() *CommitPod {
+	return &CommitPod{
 		Author:    cm.Author,
 		Message:   cm.Message,
 		Path:      cm.Path().String(),
@@ -167,8 +167,8 @@ func (cm Commit) Encode() *CodingCommit {
 	}
 }
 
-// Decode creates a Commit from a CodingCommit instance
-func (cm *Commit) Decode(cc *CodingCommit) error {
+// Decode creates a Commit from a CommitPod instance
+func (cm *Commit) Decode(cc *CommitPod) error {
 	c := Commit{
 		path:      datastore.NewKey(cc.Path),
 		Author:    cc.Author,
@@ -179,7 +179,7 @@ func (cm *Commit) Decode(cc *CodingCommit) error {
 	}
 
 	if cc.Qri == KindCommit.String() {
-		// TODO - this should respond to changes in CodingCommit
+		// TODO - this should respond to changes in CommitPod
 		c.Qri = KindCommit
 	} else if cc.Qri != "" {
 		return fmt.Errorf("invalid commit 'qri' value: %s", cc.Qri)
@@ -189,9 +189,9 @@ func (cm *Commit) Decode(cc *CodingCommit) error {
 	return nil
 }
 
-// CodingCommit is a variant of Commit safe for serialization (encoding & decoding)
+// CommitPod is a variant of Commit safe for serialization (encoding & decoding)
 // to static formats. It uses only simple go types
-type CodingCommit struct {
+type CommitPod struct {
 	Author    *User     `json:"author,omitempty"`
 	Message   string    `json:"message,omitempty"`
 	Path      string    `json:"path,omitempty"`

--- a/commit_test.go
+++ b/commit_test.go
@@ -260,11 +260,11 @@ func TestCommitCoding(t *testing.T) {
 
 func TestCommitDecode(t *testing.T) {
 	cases := []struct {
-		cm  *CodingCommit
+		cm  *CommitPod
 		err string
 	}{
-		{&CodingCommit{}, ""},
-		{&CodingCommit{Qri: "foo"}, "invalid commit 'qri' value: foo"},
+		{&CommitPod{}, ""},
+		{&CommitPod{Qri: "foo"}, "invalid commit 'qri' value: foo"},
 	}
 
 	for i, c := range cases {

--- a/dataset.go
+++ b/dataset.go
@@ -211,9 +211,9 @@ func UnmarshalDataset(v interface{}) (*Dataset, error) {
 	}
 }
 
-// Encode creates a CodingDataset from a Dataset instance
-func (ds Dataset) Encode() *CodingDataset {
-	cd := &CodingDataset{
+// Encode creates a DatasetPod from a Dataset instance
+func (ds Dataset) Encode() *DatasetPod {
+	cd := &DatasetPod{
 		DataPath:     ds.DataPath,
 		Meta:         ds.Meta,
 		Path:         ds.Path().String(),
@@ -235,8 +235,8 @@ func (ds Dataset) Encode() *CodingDataset {
 	return cd
 }
 
-// Decode creates a Dataset from a CodingDataset instance
-func (ds *Dataset) Decode(cd *CodingDataset) error {
+// Decode creates a Dataset from a DatasetPod instance
+func (ds *Dataset) Decode(cd *DatasetPod) error {
 	d := Dataset{
 		path:         datastore.NewKey(cd.Path),
 		DataPath:     cd.DataPath,
@@ -275,16 +275,16 @@ func (ds *Dataset) Decode(cd *CodingDataset) error {
 	return nil
 }
 
-// CodingDataset is a variant of Dataset safe for serialization (encoding & decoding)
+// DatasetPod is a variant of Dataset safe for serialization (encoding & decoding)
 // to static formats. It uses only simple go types
-type CodingDataset struct {
-	Commit       *CodingCommit    `json:"commit,omitempty"`
-	DataPath     string           `json:"dataPath,omitempty"`
-	Meta         *Meta            `json:"meta,omitempty"`
-	Path         string           `json:"path,omitempty"`
-	PreviousPath string           `json:"previousPath,omitempty"`
-	Qri          string           `json:"qri"`
-	Structure    *CodingStructure `json:"structure"`
-	Transform    *CodingTransform `json:"transform,omitempty"`
-	VisConfig    *VisConfig       `json:"visconfig,omitempty"`
+type DatasetPod struct {
+	Commit       *CommitPod    `json:"commit,omitempty"`
+	DataPath     string        `json:"dataPath,omitempty"`
+	Meta         *Meta         `json:"meta,omitempty"`
+	Path         string        `json:"path,omitempty"`
+	PreviousPath string        `json:"previousPath,omitempty"`
+	Qri          string        `json:"qri"`
+	Structure    *StructurePod `json:"structure"`
+	Transform    *TransformPod `json:"transform,omitempty"`
+	VisConfig    *VisConfig    `json:"visconfig,omitempty"`
 }

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -316,13 +316,13 @@ func TestDatasetCoding(t *testing.T) {
 
 func TestDatasetDecode(t *testing.T) {
 	cases := []struct {
-		cd  *CodingDataset
+		cd  *DatasetPod
 		err string
 	}{
-		{&CodingDataset{}, ""},
-		{&CodingDataset{Commit: &CodingCommit{Qri: "foo"}}, "invalid commit 'qri' value: foo"},
-		{&CodingDataset{Structure: &CodingStructure{Format: "foo"}}, "invalid data format: `foo`"},
-		{&CodingDataset{Transform: &CodingTransform{Resources: []byte("foo")}}, "decoding transform resources: invalid character 'o' in literal false (expecting 'a')"},
+		{&DatasetPod{}, ""},
+		{&DatasetPod{Commit: &CommitPod{Qri: "foo"}}, "invalid commit 'qri' value: foo"},
+		{&DatasetPod{Structure: &StructurePod{Format: "foo"}}, "invalid data format: `foo`"},
+		{&DatasetPod{Transform: &TransformPod{Resources: []byte("foo")}}, "decoding transform resources: invalid character 'o' in literal false (expecting 'a')"},
 	}
 
 	for i, c := range cases {

--- a/structure.go
+++ b/structure.go
@@ -322,8 +322,8 @@ func base26(d int) (s string) {
 	return s
 }
 
-// Encode creates a CodingStructure from a Structure instance
-func (s Structure) Encode() *CodingStructure {
+// Encode creates a StructurePod from a Structure instance
+func (s Structure) Encode() *StructurePod {
 	var (
 		sch  map[string]interface{}
 		schd []byte
@@ -341,7 +341,7 @@ func (s Structure) Encode() *CodingStructure {
 		}
 	}
 
-	cs := &CodingStructure{
+	cs := &StructurePod{
 		Checksum:    s.Checksum,
 		Compression: s.Compression.String(),
 		Encoding:    s.Encoding,
@@ -362,7 +362,7 @@ func (s Structure) Encode() *CodingStructure {
 }
 
 // Decode creates a Stucture from a CodingStructre instance
-func (s *Structure) Decode(cs *CodingStructure) (err error) {
+func (s *Structure) Decode(cs *StructurePod) (err error) {
 	dst := Structure{
 		Checksum: cs.Checksum,
 		Encoding: cs.Encoding,
@@ -402,9 +402,9 @@ func (s *Structure) Decode(cs *CodingStructure) (err error) {
 	return nil
 }
 
-// CodingStructure is a variant of Structure safe for serialization (encoding & decoding)
+// StructurePod is a variant of Structure safe for serialization (encoding & decoding)
 // to static formats. It uses only simple go types
-type CodingStructure struct {
+type StructurePod struct {
 	Checksum     string                 `json:"checksum,omitempty"`
 	Compression  string                 `json:"compression,omitempty"`
 	Encoding     string                 `json:"encoding,omitempty"`

--- a/structure_test.go
+++ b/structure_test.go
@@ -318,13 +318,13 @@ func TestStructureCoding(t *testing.T) {
 
 func TestStructureDecode(t *testing.T) {
 	cases := []struct {
-		cst *CodingStructure
+		cst *StructurePod
 		err string
 	}{
-		{&CodingStructure{}, ""},
-		{&CodingStructure{Format: "foo"}, "invalid data format: `foo`"},
-		{&CodingStructure{FormatConfig: map[string]interface{}{}}, "cannot parse configuration for format: "},
-		{&CodingStructure{Schema: map[string]interface{}{"foo": "bar"}}, "error unmarshaling foo from json: json: cannot unmarshal string into Go value of type jsonschema._schema"},
+		{&StructurePod{}, ""},
+		{&StructurePod{Format: "foo"}, "invalid data format: `foo`"},
+		{&StructurePod{FormatConfig: map[string]interface{}{}}, "cannot parse configuration for format: "},
+		{&StructurePod{Schema: map[string]interface{}{"foo": "bar"}}, "error unmarshaling foo from json: json: cannot unmarshal string into Go value of type jsonschema._schema"},
 	}
 
 	for i, c := range cases {

--- a/transform.go
+++ b/transform.go
@@ -206,8 +206,8 @@ func UnmarshalTransform(v interface{}) (*Transform, error) {
 	}
 }
 
-// Encode creates a CodingTransform from a Transform instance
-func (q Transform) Encode() *CodingTransform {
+// Encode creates a TransformPod from a Transform instance
+func (q Transform) Encode() *TransformPod {
 	var (
 		rsc []byte
 		err error
@@ -220,7 +220,7 @@ func (q Transform) Encode() *CodingTransform {
 		}
 	}
 
-	ct := &CodingTransform{
+	ct := &TransformPod{
 		AppVersion: q.AppVersion,
 		Config:     q.Config,
 		Data:       q.Data,
@@ -237,8 +237,8 @@ func (q Transform) Encode() *CodingTransform {
 	return ct
 }
 
-// Decode creates a Transform from a CodingTransform instance
-func (q *Transform) Decode(ct *CodingTransform) error {
+// Decode creates a Transform from a TransformPod instance
+func (q *Transform) Decode(ct *TransformPod) error {
 	t := Transform{
 		AppVersion: ct.AppVersion,
 		Config:     ct.Config,
@@ -269,16 +269,16 @@ func (q *Transform) Decode(ct *CodingTransform) error {
 	return nil
 }
 
-// CodingTransform is a variant of Transform safe for serialization (encoding & decoding)
+// TransformPod is a variant of Transform safe for serialization (encoding & decoding)
 // to static formats. It uses only simple go types
-type CodingTransform struct {
+type TransformPod struct {
 	AppVersion string                 `json:"appVersion,omitempty"`
 	Config     map[string]interface{} `json:"config,omitempty"`
 	Data       string                 `json:"data,omitempty"`
 	Path       string                 `json:"path,omitempty"`
 	Qri        string                 `json:"qri,omitempty"`
 	// resources are respresented as JSON-bytes
-	Resources []byte           `json:"resources,omitempty"`
-	Syntax    string           `json:"syntax,omitempty"`
-	Structure *CodingStructure `json:"structure,omitempty"`
+	Resources []byte        `json:"resources,omitempty"`
+	Syntax    string        `json:"syntax,omitempty"`
+	Structure *StructurePod `json:"structure,omitempty"`
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -239,12 +239,12 @@ func TestTransformCoding(t *testing.T) {
 
 func TestTransformDecode(t *testing.T) {
 	cases := []struct {
-		ct  *CodingTransform
+		ct  *TransformPod
 		err string
 	}{
-		{&CodingTransform{}, ""},
-		{&CodingTransform{Resources: []byte("foo")}, "decoding transform resources: invalid character 'o' in literal false (expecting 'a')"},
-		{&CodingTransform{Structure: &CodingStructure{Format: "foo"}}, "invalid data format: `foo`"},
+		{&TransformPod{}, ""},
+		{&TransformPod{Resources: []byte("foo")}, "decoding transform resources: invalid character 'o' in literal false (expecting 'a')"},
+		{&TransformPod{Structure: &StructurePod{Format: "foo"}}, "invalid data format: `foo`"},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
To represent plain-old-data, meant for serialization, use the Pod suffix instead of Coding.