### PR TITLE
perf(dsfs.CreateDataset): parallelize ds prep with io.MultiWriter

### DIFF
--- a/detect/json.go
+++ b/detect/json.go
@@ -1,8 +1,6 @@
 package detect
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 
@@ -11,17 +9,31 @@ import (
 )
 
 // JSONSchema determines the field names and types of an io.Reader of JSON-formatted data, returning a json schema
+// This is currently a suuuuuuuuper simple interpretation that spits out a generic schema that'll work. In the future
+// we can do all sorts of stuff here to make better inferences about the shape of a dataset, but for now, this'll work,
+// and we'll instead focus on making it easier for users to provide hand-built schemas
 func JSONSchema(resource *dataset.Structure, data io.Reader) (schema *jsonschema.RootSchema, err error) {
-	rd := bufio.NewReader(data)
-	lin, err := rd.ReadSlice('{')
-	if err != nil && err != io.EOF {
-		log.Debugf(err.Error())
-		return nil, fmt.Errorf("error reading data: %s", err.Error())
-	}
+	buf := make([]byte, 100)
+	for {
+		if _, err := data.Read(buf); err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("invalid json data")
+			}
+			log.Debugf(err.Error())
+			return nil, fmt.Errorf("error reading data: %s", err.Error())
+		}
 
-	if bytes.Contains(lin, []byte{'['}) {
-		return dataset.BaseSchemaArray, nil
+		for _, b := range buf {
+			switch b {
+			case '[':
+				return dataset.BaseSchemaArray, nil
+			case '{':
+				return dataset.BaseSchemaObject, nil
+			case ' ', '\t', '\n', '\r':
+				continue
+			default:
+				return nil, fmt.Errorf("invalid json data")
+			}
+		}
 	}
-
-	return dataset.BaseSchemaObject, nil
 }

--- a/detect/json_test.go
+++ b/detect/json_test.go
@@ -1,0 +1,50 @@
+package detect
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/jsonschema"
+)
+
+func TestJSONSchema(t *testing.T) {
+
+	pr, _ := io.Pipe()
+	pr.Close()
+	_, err := JSONSchema(&dataset.Structure{}, pr)
+	if err == nil {
+		t.Error("expected error when reading bad reader")
+		return
+	}
+
+	cases := []struct {
+		st     *dataset.Structure
+		data   string
+		expect *jsonschema.RootSchema
+		err    string
+	}{
+		{&dataset.Structure{}, "", nil, "invalid json data"},
+		{&dataset.Structure{}, "f", nil, "invalid json data"},
+		{&dataset.Structure{}, "{", dataset.BaseSchemaObject, ""},
+		{&dataset.Structure{}, "[", dataset.BaseSchemaArray, ""},
+		{&dataset.Structure{}, strings.Repeat(" ", 250) + "[", dataset.BaseSchemaArray, ""},
+	}
+
+	for i, c := range cases {
+		rdr := strings.NewReader(c.data)
+
+		got, err := JSONSchema(c.st, rdr)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			return
+		}
+
+		// TODO - this is just basic pointer comparison for now,
+		// if JSONSchema ever returns a fresh schema this'll have to be improved
+		if got != c.expect {
+			t.Errorf("case %d return mismatch", i)
+		}
+	}
+}

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -1,11 +1,13 @@
 package dsfs
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ipfs/go-datastore"
@@ -172,7 +174,6 @@ func DerefDatasetCommit(store cafs.Filestore, ds *dataset.Dataset) error {
 // Dataset to be saved
 // Pin the dataset if the underlying store supports the pinning interface
 func CreateDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pk crypto.PrivKey, pin bool) (path datastore.Key, err error) {
-
 	if pk == nil {
 		err = fmt.Errorf("private key is required to create a dataset")
 		return
@@ -216,6 +217,168 @@ func CreateDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pk c
 // timestamps MUST be stored in UTC time zone
 var Timestamp = func() time.Time {
 	return time.Now().UTC()
+}
+
+// prepareDataset modifies a dataset in preparation for adding to a dsfs
+// it returns a new data file for use in WriteDataset
+func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, privKey crypto.PrivKey) (cafs.File, string, error) {
+	var (
+		err error
+		// lock for parallel edits to ds pointer
+		mu sync.Mutex
+		// accumulate reader into a buffer for shasum calculation & passing out another cafs.File
+		buf bytes.Buffer
+	)
+
+	if df == nil && ds.PreviousPath == "" {
+		return nil, "", fmt.Errorf("datafile or dataset PreviousPath needed")
+	}
+
+	if df == nil && ds.PreviousPath != "" {
+		prev, err := LoadDataset(store, datastore.NewKey(ds.PreviousPath))
+		if err != nil {
+			log.Debug(err.Error())
+			return nil, "", fmt.Errorf("error loading previous dataset: %s", err)
+		}
+		df, err = LoadData(store, prev)
+		if err != nil {
+			log.Debug(err.Error())
+			return nil, "", fmt.Errorf("error loading previous dataset data: %s", err)
+		}
+	}
+
+	errR, errW := io.Pipe()
+	entryR, entryW := io.Pipe()
+	hashR, hashW := io.Pipe()
+	done := make(chan error)
+
+	go setErrCount(ds, cafs.NewMemfileReader(df.FileName(), errR), mu, done)
+	go setEntryCount(ds, cafs.NewMemfileReader(df.FileName(), entryR), mu, done)
+	go setChecksumAndStats(ds, cafs.NewMemfileReader(df.FileName(), hashR), &buf, mu, done)
+
+	go func() {
+		// pipes must be manually closed to trigger EOF
+		defer errW.Close()
+		defer entryW.Close()
+		defer hashW.Close()
+
+		// allocate a multiwriter that writes to each pipe when
+		// mw.Write() is called
+		mw := io.MultiWriter(errW, entryW, hashW)
+		// copy file bytes to multiwriter from input file
+		io.Copy(mw, df)
+	}()
+
+	for i := 3; i > 0; i-- {
+		if err := <-done; err != nil {
+			return nil, "", err
+		}
+	}
+
+	//get auto commit message if necessary
+	diffDescription, err := generateCommitMsg(store, ds)
+	if err != nil {
+		log.Debug(err.Error())
+		return nil, "", fmt.Errorf("%s", err.Error())
+	}
+	if diffDescription == "" {
+		return nil, "", fmt.Errorf("error saving: no changes detected")
+	}
+
+	if ds.Commit.Title == "" && ds.Commit.Message != "" {
+		ds.Commit.Title = ds.Commit.Message
+		ds.Commit.Message = ""
+	}
+
+	if ds.Commit.Title == "" {
+		ds.Commit.Title = diffDescription
+	}
+	cleanTitleAndMessage(&ds.Commit.Title, &ds.Commit.Message)
+
+	ds.Commit.Timestamp = Timestamp()
+	sb, _ := ds.SignableBytes()
+	signedBytes, err := privKey.Sign(sb)
+	if err != nil {
+		log.Debug(err.Error())
+		return nil, "", fmt.Errorf("error signing commit title: %s", err.Error())
+	}
+	ds.Commit.Signature = base64.StdEncoding.EncodeToString(signedBytes)
+
+	return cafs.NewMemfileBytes("data."+ds.Structure.Format.String(), buf.Bytes()), diffDescription, nil
+}
+
+// setErrCount consumes sets the ErrCount field of a dataset's Structure
+func setErrCount(ds *dataset.Dataset, data cafs.File, mu sync.Mutex, done chan error) {
+	er, err := dsio.NewEntryReader(ds.Structure, data)
+	if err != nil {
+		log.Debug(err.Error())
+		done <- fmt.Errorf("reading data values: %s", err.Error())
+		return
+	}
+
+	validationErrors, err := validate.EntryReader(er)
+	if err != nil {
+		log.Debug(err.Error())
+		done <- fmt.Errorf("validating data: %s", err.Error())
+		return
+	}
+
+	mu.Lock()
+	ds.Structure.ErrCount = len(validationErrors)
+	mu.Unlock()
+
+	done <- nil
+}
+
+// setEntryCount set the Entries field of a ds.Structure
+func setEntryCount(ds *dataset.Dataset, data cafs.File, mu sync.Mutex, done chan error) {
+	er, err := dsio.NewEntryReader(ds.Structure, data)
+	if err != nil {
+		log.Debug(err.Error())
+		done <- fmt.Errorf("error reading data values: %s", err.Error())
+		return
+	}
+
+	entries := 0
+	for {
+		if _, err = er.ReadEntry(); err != nil {
+			log.Debug(err.Error())
+			break
+		}
+		entries++
+	}
+	if err.Error() != "EOF" {
+		done <- fmt.Errorf("error reading values: %s", err.Error())
+		return
+	}
+
+	mu.Lock()
+	ds.Structure.Entries = entries
+	mu.Unlock()
+
+	done <- nil
+}
+
+// setChecksumAndStats
+func setChecksumAndStats(ds *dataset.Dataset, data cafs.File, buf *bytes.Buffer, mu sync.Mutex, done chan error) {
+	if _, err := io.Copy(buf, data); err != nil {
+		done <- err
+		return
+	}
+
+	shasum, err := multihash.Sum(buf.Bytes(), multihash.SHA2_256, -1)
+	if err != nil {
+		log.Debug(err.Error())
+		done <- fmt.Errorf("error calculating hash: %s", err.Error())
+		return
+	}
+
+	mu.Lock()
+	ds.Structure.Checksum = shasum.B58String()
+	ds.Structure.Length = len(buf.Bytes())
+	mu.Unlock()
+
+	done <- nil
 }
 
 func generateCommitMsg(store cafs.Filestore, ds *dataset.Dataset) (string, error) {
@@ -284,116 +447,6 @@ func cleanTitleAndMessage(sTitle, sMsg *string) {
 	}
 	*sTitle = st
 	*sMsg = sm
-}
-
-// prepareDataset modifies a dataset in preparation for adding to a dsfs
-// it returns a new data file for use in WriteDataset
-func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, privKey crypto.PrivKey) (cafs.File, string, error) {
-	// TODO - need a better strategy for huge files. I think that strategy is to split
-	// the reader into multiple consumers that are all performing their task on a stream
-	// of byte slices
-	var err error
-	if df == nil && ds.PreviousPath == "" {
-		return nil, "", fmt.Errorf("datafile or dataset PreviousPath needed")
-	}
-
-	if df == nil && ds.PreviousPath != "" {
-		prev, err := LoadDataset(store, datastore.NewKey(ds.PreviousPath))
-		if err != nil {
-			log.Debug(err.Error())
-			return nil, "", fmt.Errorf("error loading previous dataset: %s", err)
-		}
-		df, err = LoadData(store, prev)
-		if err != nil {
-			log.Debug(err.Error())
-			return nil, "", fmt.Errorf("error loading previous dataset data: %s", err)
-		}
-	}
-
-	data, err := ioutil.ReadAll(df)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error reading file: %s", err.Error())
-	}
-	ds.Structure.Length = len(data)
-
-	// set error count
-
-	er, err := dsio.NewEntryReader(ds.Structure, cafs.NewMemfileBytes("data", data))
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error reading data values: %s", err.Error())
-	}
-
-	validationErrors, err := validate.EntryReader(er)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error validating data: %s", err.Error())
-	}
-	ds.Structure.ErrCount = len(validationErrors)
-
-	// TODO - add a dsio.RowCount function that avoids actually arranging data into rows
-	er, err = dsio.NewEntryReader(ds.Structure, cafs.NewMemfileBytes("data", data))
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error reading data values: %s", err.Error())
-	}
-
-	entries := 0
-	for {
-		if _, err = er.ReadEntry(); err != nil {
-			log.Debug(err.Error())
-			break
-		}
-		entries++
-	}
-	if err.Error() != "EOF" {
-		return nil, "", fmt.Errorf("error reading values: %s", err.Error())
-	}
-
-	ds.Structure.Entries = entries
-
-	// TODO - set hash
-	shasum, err := multihash.Sum(data, multihash.SHA2_256, -1)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error calculating hash: %s", err.Error())
-	}
-	ds.Structure.Checksum = shasum.B58String()
-
-	// generate abstract form of dataset
-	// ds.Abstract = dataset.Abstract(ds)
-
-	//get auto commit message if necessary
-	diffDescription, err := generateCommitMsg(store, ds)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("%s", err.Error())
-	}
-	if diffDescription == "" {
-		return nil, "", fmt.Errorf("error saving: no changes detected")
-	}
-
-	if ds.Commit.Title == "" && ds.Commit.Message != "" {
-		ds.Commit.Title = ds.Commit.Message
-		ds.Commit.Message = ""
-	}
-
-	if ds.Commit.Title == "" {
-		ds.Commit.Title = diffDescription
-	}
-	cleanTitleAndMessage(&ds.Commit.Title, &ds.Commit.Message)
-
-	ds.Commit.Timestamp = Timestamp()
-	sb, _ := ds.SignableBytes()
-	signedBytes, err := privKey.Sign(sb)
-	if err != nil {
-		log.Debug(err.Error())
-		return nil, "", fmt.Errorf("error signing commit title: %s", err.Error())
-	}
-	ds.Commit.Signature = base64.StdEncoding.EncodeToString(signedBytes)
-
-	return cafs.NewMemfileBytes("data."+ds.Structure.Format.String(), data), diffDescription, nil
 }
 
 // WriteDataset writes a dataset to a cafs, replacing subcomponents of a dataset with path references


### PR DESCRIPTION
I've been meaning to do this for a while, this change should make working with large files faster by splitting up dataset prep work into piped read/writers. Unfortunately, `CreateDataset` still needs to accumulate a full copy of the data at least once to calculate the checksum hash, but if we can find a way to do rolling SHA2_256 checksums, this requirement could be removed. In the future I'd also like to refactor `prepareDataset` further, ideally merging the whole func into WriteDataset, but that'll have to wait for another day.

This PR also includes a fix & test for our naive `detect.JSONSchema` func, which was causing errors in userland.