### PR TITLE
Detect track bytes read

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             github.com/qri-io/varName
             github.com/qri-io/jsonschema
             github.com/ugorji/go/codec
+            gopkg.in/yaml.v2
       - run: 
           name: Run Lint Tests
           command: golint ./...

--- a/detect/cbor.go
+++ b/detect/cbor.go
@@ -18,19 +18,21 @@ const (
 )
 
 // CBORSchema determines the field names and types of an io.Reader of CBOR-formatted data, returning a json schema
-func CBORSchema(resource *dataset.Structure, data io.Reader) (schema *jsonschema.RootSchema, err error) {
+func CBORSchema(resource *dataset.Structure, data io.Reader) (schema *jsonschema.RootSchema, n int, err error) {
 	rd := bufio.NewReader(data)
 	bd, err := rd.ReadByte()
+	n++
 	if err != nil && err != io.EOF {
 		log.Debugf(err.Error())
-		return nil, fmt.Errorf("error reading data: %s", err.Error())
+		err = fmt.Errorf("error reading data: %s", err.Error())
+		return
 	}
 
 	switch {
 	case bd >= cborBaseArray && bd < cborBaseMap, bd == cborBdIndefiniteArray:
-		return dataset.BaseSchemaArray, nil
+		return dataset.BaseSchemaArray, n, nil
 	case bd >= cborBaseMap && bd < cborBaseTag, bd == cborBdIndefiniteMap:
-		return dataset.BaseSchemaObject, nil
+		return dataset.BaseSchemaObject, n, nil
 	default:
 		err = fmt.Errorf("invalid top-level type for CBOR data. cbor datasets must begin with either an array or map")
 		log.Debugf(err.Error())

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -20,37 +20,31 @@ var (
 
 // FromFile takes a filepath & tries to work out the corresponding dataset
 // for the sake of speed, it only works with files that have a recognized extension
-func FromFile(path string) (ds *dataset.Structure, err error) {
+func FromFile(path string) (st *dataset.Structure, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	return FromReader(path, f)
-}
 
-// FromReader is a shorthand for a path/filename and reader
-func FromReader(path string, data io.Reader) (ds *dataset.Structure, err error) {
 	format, err := ExtensionDataFormat(path)
 	if err != nil {
 		return nil, err
 	}
-	return Structure(format, data)
+
+	defer f.Close()
+	st, _, err = FromReader(format, f)
+	return st, err
 }
 
-// Structure attemptes to extract a structure based on a given format and data reader
-func Structure(format dataset.DataFormat, data io.Reader) (r *dataset.Structure, err error) {
-	r = &dataset.Structure{
+// FromReader detects a dataset structure from a reader and data format, returning a detected dataset
+// structure, the number of bytes read from the reader, and any error
+func FromReader(format dataset.DataFormat, data io.Reader) (st *dataset.Structure, n int, err error) {
+	st = &dataset.Structure{
 		Format: format,
 	}
-	// ds.Data = ReplaceSoloCarriageReturns(ds.Data)
-	r.Schema, err = Schema(r, data)
+	st.Schema, n, err = Schema(st, data)
 	return
 }
-
-// DataFormat does it's best to determine the format of a specified dataset
-// func DataFormat(path string) (format dataset.DataFormat, err error) {
-// 	return ExtensionDataFormat(path)
-// }
 
 // ExtensionDataFormat returns the corresponding DataFormat for a given file extension if one exists
 // TODO - this should probably come from the dataset package

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -25,13 +25,13 @@ func FromFile(path string) (st *dataset.Structure, err error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	format, err := ExtensionDataFormat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	defer f.Close()
 	st, _, err = FromReader(format, f)
 	return st, err
 }

--- a/detect/json_test.go
+++ b/detect/json_test.go
@@ -13,7 +13,7 @@ func TestJSONSchema(t *testing.T) {
 
 	pr, _ := io.Pipe()
 	pr.Close()
-	_, err := JSONSchema(&dataset.Structure{}, pr)
+	_, _, err := JSONSchema(&dataset.Structure{}, pr)
 	if err == nil {
 		t.Error("expected error when reading bad reader")
 		return
@@ -35,7 +35,7 @@ func TestJSONSchema(t *testing.T) {
 	for i, c := range cases {
 		rdr := strings.NewReader(c.data)
 
-		got, err := JSONSchema(c.st, rdr)
+		got, _, err := JSONSchema(c.st, rdr)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
 			return

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -341,7 +341,7 @@ func setEntryCount(ds *dataset.Dataset, data cafs.File, mu sync.Mutex, done chan
 		entries++
 	}
 	if err.Error() != "EOF" {
-		done <- fmt.Errorf("error reading values: %s", err.Error())
+		done <- fmt.Errorf("error reading values at entry %d: %s", entries, err.Error())
 		return
 	}
 

--- a/dsio/tracked_reader.go
+++ b/dsio/tracked_reader.go
@@ -1,0 +1,26 @@
+package dsio
+
+import "io"
+
+// TrackedReader wraps a reader, keeping an internal count of the bytes read
+type TrackedReader struct {
+	read int
+	r    io.Reader
+}
+
+// NewTrackedReader creates a new tracked reader
+func NewTrackedReader(r io.Reader) *TrackedReader {
+	return &TrackedReader{r: r}
+}
+
+// Read implements the io.Reader interface
+func (tr *TrackedReader) Read(p []byte) (n int, err error) {
+	n, err = tr.r.Read(p)
+	tr.read += n
+	return
+}
+
+// BytesRead gives the total number of bytes read from the underlying reader
+func (tr *TrackedReader) BytesRead() int {
+	return tr.read
+}

--- a/dsio/tracked_reader_test.go
+++ b/dsio/tracked_reader_test.go
@@ -1,0 +1,25 @@
+package dsio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTrackedReader(t *testing.T) {
+	r := strings.NewReader("0123456789")
+	tr := NewTrackedReader(r)
+
+	buf := make([]byte, 4)
+	tr.Read(buf)
+	if tr.BytesRead() != 4 {
+		t.Errorf("expected bytes read to equal 4, got: %d", tr.BytesRead())
+	}
+	tr.Read(buf)
+	if tr.BytesRead() != 8 {
+		t.Errorf("expected bytes read to equal 4, got: %d", tr.BytesRead())
+	}
+	tr.Read(buf)
+	if tr.BytesRead() != 10 {
+		t.Errorf("expected bytes read to equal 4, got: %d", tr.BytesRead())
+	}
+}

--- a/dstest/dstest.go
+++ b/dstest/dstest.go
@@ -27,6 +27,7 @@ const (
 // All files are optional for TestCase, but may be required
 // by the test itself.
 type TestCase struct {
+	path string
 	// Name is the casename, should match directory name
 	Name string
 	// 	 data.csv,data.json, etc
@@ -44,6 +45,17 @@ type TestCase struct {
 // DataFile creates a new in-memory file from data & filename properties
 func (t TestCase) DataFile() cafs.File {
 	return cafs.NewMemfileBytes(t.DataFilename, t.Data)
+}
+
+// DataFilepath retuns the path to the first valid data
+func DataFilepath(dir string) (string, error) {
+	for _, df := range dataset.SupportedDataFormats() {
+		path := fmt.Sprintf("%s/data.%s", dir, df)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			return path, nil
+		}
+	}
+	return "", os.ErrNotExist
 }
 
 // LoadTestCases loads a directory of case directories
@@ -68,6 +80,7 @@ func LoadTestCases(dir string) (tcs map[string]TestCase, err error) {
 // be logged using t.Log methods
 func NewTestCaseFromDir(dir string) (tc TestCase, err error) {
 	tc = TestCase{
+		path: dir,
 		Name: filepath.Base(dir),
 	}
 	tc.Data, tc.DataFilename, err = ReadInputData(dir)

--- a/dstest/dstest.go
+++ b/dstest/dstest.go
@@ -27,7 +27,8 @@ const (
 // All files are optional for TestCase, but may be required
 // by the test itself.
 type TestCase struct {
-	path string
+	// Path to the director on the local filesystem this test case is loaded from
+	Path string
 	// Name is the casename, should match directory name
 	Name string
 	// 	 data.csv,data.json, etc
@@ -47,7 +48,8 @@ func (t TestCase) DataFile() cafs.File {
 	return cafs.NewMemfileBytes(t.DataFilename, t.Data)
 }
 
-// DataFilepath retuns the path to the first valid data
+// DataFilepath retuns the path to the first valid data file it can find,
+// which is a file named "data" that ends in an extension we support
 func DataFilepath(dir string) (string, error) {
 	for _, df := range dataset.SupportedDataFormats() {
 		path := fmt.Sprintf("%s/data.%s", dir, df)
@@ -80,7 +82,7 @@ func LoadTestCases(dir string) (tcs map[string]TestCase, err error) {
 // be logged using t.Log methods
 func NewTestCaseFromDir(dir string) (tc TestCase, err error) {
 	tc = TestCase{
-		path: dir,
+		Path: dir,
 		Name: filepath.Base(dir),
 	}
 	tc.Data, tc.DataFilename, err = ReadInputData(dir)

--- a/dstest/dstest_test.go
+++ b/dstest/dstest_test.go
@@ -14,6 +14,17 @@ func TestLoadTestCases(t *testing.T) {
 	t.Logf("%d cases", len(tcs))
 }
 
+func TestDataFilepath(t *testing.T) {
+	fp, err := DataFilepath("testdata/complete")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	if fp != "testdata/complete/data.csv" {
+		t.Errorf("%s != %s", "testdata/complete/data.csv", fp)
+	}
+}
+
 func TestNewTestCaseFromDir(t *testing.T) {
 
 	if _, err := NewTestCaseFromDir("testdata"); err == nil {

--- a/dsutil/dataset_yaml.go
+++ b/dsutil/dataset_yaml.go
@@ -1,0 +1,67 @@
+package dsutil
+
+import (
+	"fmt"
+
+	"github.com/qri-io/dataset"
+	"gopkg.in/yaml.v2"
+)
+
+// UnmarshalYAMLDatasetPod reads yaml bytes into a DatasetPod
+func UnmarshalYAMLDatasetPod(data []byte, ds *dataset.DatasetPod) error {
+	if err := yaml.Unmarshal(data, ds); err != nil {
+		return err
+	}
+	if ds.Structure != nil && ds.Structure.Schema != nil {
+		for key, val := range ds.Structure.Schema {
+			ds.Structure.Schema[key] = cleanupMapValue(val)
+		}
+	}
+	return nil
+}
+
+// Unmarshal YAML to map[string]interface{} instead of map[interface{}]interface{}.
+// func Unmarshal(in []byte, out interface{}) error {
+// 	var res interface{}
+
+// 	if err := yaml.Unmarshal(in, &res); err != nil {
+// 		return err
+// 	}
+// 	*out.(*interface{}) = cleanupMapValue(res)
+
+// 	return nil
+// }
+
+// Marshal YAML wrapper function.
+// func Marshal(in interface{}) ([]byte, error) {
+// 	return yaml.Marshal(in)
+// }
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanupInterfaceMap(v)
+	case string, bool, int, int16, int32, int64, float32, float64, []byte:
+		return v
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/dsutil/dataset_yaml_test.go
+++ b/dsutil/dataset_yaml_test.go
@@ -1,0 +1,46 @@
+package dsutil
+
+import (
+	"testing"
+
+	"github.com/qri-io/dataset"
+)
+
+const yamlData = `---
+meta:
+  title: EPA TRI Basic Summary
+  description: A few key fields pulled from EPA TRI Basic data for 2016
+structure:
+  format: json
+  schema:
+    type: array
+    items:
+      type: array
+      items:
+      - title: Year
+        maxLength: 4
+        type: string
+        description: "The Reporting Year - Year the chemical was released or managed as waste"
+      - title: "TRI Facility ID"
+        maxLength: 15
+        type: string
+        description: "The TRI Facility Identification Number assigned by EPA/TRI"
+      - title: Facility Name
+        maxLength: 62
+        type: string
+        description: "Facility Name"
+`
+
+func TestUnmarshalYAMLDatasetPod(t *testing.T) {
+	dsp := &dataset.DatasetPod{}
+	if err := UnmarshalYAMLDatasetPod([]byte(yamlData), dsp); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	ds := &dataset.Dataset{}
+	if err := ds.Decode(dsp); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}

--- a/structure.go
+++ b/structure.go
@@ -390,9 +390,11 @@ func (s *Structure) Decode(cs *StructurePod) (err error) {
 		sch := &jsonschema.RootSchema{}
 		data, e := json.Marshal(cs.Schema)
 		if e != nil {
+			log.Errorf("marshaling schema data: %s", e.Error())
 			return e
 		}
 		if err = json.Unmarshal(data, sch); err != nil {
+			log.Errorf("unmarshaling schema: %s", err.Error())
 			return
 		}
 		dst.Schema = sch

--- a/validate/dataset.go
+++ b/validate/dataset.go
@@ -65,7 +65,7 @@ func Structure(s *dataset.Structure) error {
 	}
 
 	if s.Format == dataset.UnknownDataFormat {
-		return fmt.Errorf("dataFormat is required")
+		return fmt.Errorf("format is required")
 	} else if s.Format == dataset.CSVDataFormat {
 		if s.Schema == nil {
 			return fmt.Errorf("csv data format requires a schema")

--- a/validate/dataset_test.go
+++ b/validate/dataset_test.go
@@ -21,7 +21,7 @@ func TestDataset(t *testing.T) {
 		// {&dataset.Dataset{Commit: &dataset.Commit{}}, "commit: title is required"},
 		{&dataset.Dataset{Commit: &dataset.Commit{}}, "structure is required"},
 		{&dataset.Dataset{Commit: cm}, "structure is required"},
-		{&dataset.Dataset{Commit: cm, Structure: &dataset.Structure{Schema: jsonschema.Must(`true`)}}, "structure: dataFormat is required"},
+		{&dataset.Dataset{Commit: cm, Structure: &dataset.Structure{Schema: jsonschema.Must(`true`)}}, "structure: format is required"},
 		// {&dataset.Dataset{Commit: cm, Abstract: &dataset.Dataset{Metadata: &dataset.Metadata{}}}, "abstract field is not an abstract dataset. Metadata: nil: <not nil> != <nil>"},
 		{&dataset.Dataset{Commit: cm, Structure: st}, ""},
 	}
@@ -61,7 +61,7 @@ func TestStructure(t *testing.T) {
 		err string
 	}{
 		{nil, ""},
-		{&dataset.Structure{}, "dataFormat is required"},
+		{&dataset.Structure{}, "format is required"},
 		{&dataset.Structure{Format: dataset.CSVDataFormat}, "csv data format requires a schema"},
 		// {&dataset.Structure{Format: dataset.CSVDataFormat, Schema: jsonschema.Must(`true`)}, "schema: fields are required"},
 		{&dataset.Structure{Format: dataset.JSONDataFormat, Schema: jsonschema.Must(`{ "type" : "array" }`)}, ""},


### PR DESCRIPTION
I'm hoping we can enforce a new rule around qri:
> _any function that accepts an io.Reader and may only read part of the reader must return the number of bytes read_

io.Reader's `Read` method returns the number of bytes read and an error. This is simply echoing that pattern. In many cases the caller of such a function will ignore this bytes-read count, but by keeping this in the return signature it both signals to the caller that "hey, this thing might do funny stuff to your reader", *and* forces the author of the function to track what they're doing to the reader. We get all of this without introducing any novel conventions, just requiring that io.Reader's return signature be honored.

With that in mind, I've started with an update to `detect.FromReader`, and added a new TrackedReader, which is just a convenice wrapper around a reader to track bytes read for readers that don't export this info (ahem, csv.Reader...)

### Decode DatasetPod from YAML
Also added a shim for decoding a DatasetPod from yaml that we need upstream:

the current yaml package we use decodes to map[interface{}]interface{}, which isn't supported by JSON coding funcs, which creates nasty problems when you try to decode from DatasetPod (that's come from YAML) into a *dataset.Dataset. This silly little shim deals with that issue.

Plans are in place for a future version of the yaml package we use to implement decoding into map[string]interface{}. If/when that day comes we can drop this in favour of a package-native solution