### PR TITLE
feat(CSVOptions): added LazyQuotes, Separator, VariadicFields options

### DIFF
--- a/data_format_config.go
+++ b/data_format_config.go
@@ -31,11 +31,36 @@ func NewCSVOptions(opts map[string]interface{}) (FormatConfig, error) {
 	if opts == nil {
 		return o, nil
 	}
+
 	if opts["headerRow"] != nil {
 		if headerRow, ok := opts["headerRow"].(bool); ok {
 			o.HeaderRow = headerRow
 		} else {
 			return nil, fmt.Errorf("invalid headerRow value: %s", opts["headerRow"])
+		}
+	}
+
+	if opts["lazyQuotes"] != nil {
+		if lq, ok := opts["lazyQuotes"].(bool); ok {
+			o.HeaderRow = lq
+		} else {
+			return nil, fmt.Errorf("invalid lazyQuotes value: %s", opts["lazyQuotes"])
+		}
+	}
+
+	if opts["separator"] != nil {
+		if sep, ok := opts["separator"].(string); ok {
+			o.Separator = rune(sep[0])
+		} else {
+			return nil, fmt.Errorf("invalid separator value: %v", opts["separator"])
+		}
+	}
+
+	if opts["variadicFields"] != nil {
+		if vf, ok := opts["variadicFields"].(bool); ok {
+			o.VariadicFields = vf
+		} else {
+			return nil, fmt.Errorf("invalid variadicFields value: %s", opts["variadicFields"])
 		}
 	}
 
@@ -47,6 +72,17 @@ func NewCSVOptions(opts map[string]interface{}) (FormatConfig, error) {
 type CSVOptions struct {
 	// HeaderRow specifies weather this csv file has a header row or not
 	HeaderRow bool `json:"headerRow"`
+	// If LazyQuotes is true, a quote may appear in an unquoted field and a
+	// non-doubled quote may appear in a quoted field.
+	LazyQuotes bool `json:"lazyQuotes"`
+	// Separator is the field delimiter.
+	// It is set to comma (',') by NewReader.
+	// Comma must be a valid rune and must not be \r, \n,
+	// or the Unicode replacement character (0xFFFD).
+	Separator rune `json:"separator"`
+	// VariadicFields sets permits records to have a variable number of fields
+	// avoid using this
+	VariadicFields bool `json:"variadicFields"`
 }
 
 // Format announces the CSV Data Format for the FormatConfig interface

--- a/data_format_config.go
+++ b/data_format_config.go
@@ -50,6 +50,9 @@ func NewCSVOptions(opts map[string]interface{}) (FormatConfig, error) {
 
 	if opts["separator"] != nil {
 		if sep, ok := opts["separator"].(string); ok {
+			if len(sep) != 1 {
+				return nil, fmt.Errorf("separator must be a single character")
+			}
 			o.Separator = rune(sep[0])
 		} else {
 			return nil, fmt.Errorf("invalid separator value: %v", opts["separator"])

--- a/data_format_config_test.go
+++ b/data_format_config_test.go
@@ -59,6 +59,7 @@ func TestNewCSVOptions(t *testing.T) {
 		{map[string]interface{}{"lazyQuotes": true}, &CSVOptions{LazyQuotes: true}, ""},
 		{map[string]interface{}{"lazyQuotes": "foo"}, nil, "invalid lazyQuotes value: foo"},
 		{map[string]interface{}{"separator": "\t"}, &CSVOptions{Separator: '\t'}, ""},
+		{map[string]interface{}{"separator": "\t\t"}, nil, "separator must be a single character"},
 		{map[string]interface{}{"separator": true}, nil, "invalid separator value: true"},
 		{map[string]interface{}{"variadicFields": true}, &CSVOptions{VariadicFields: true}, ""},
 		{map[string]interface{}{"variadicFields": "foo"}, nil, "invalid variadicFields value: foo"},

--- a/data_format_config_test.go
+++ b/data_format_config_test.go
@@ -56,6 +56,12 @@ func TestNewCSVOptions(t *testing.T) {
 		{map[string]interface{}{}, &CSVOptions{}, ""},
 		{map[string]interface{}{"headerRow": true}, &CSVOptions{HeaderRow: true}, ""},
 		{map[string]interface{}{"headerRow": "foo"}, nil, "invalid headerRow value: foo"},
+		{map[string]interface{}{"lazyQuotes": true}, &CSVOptions{LazyQuotes: true}, ""},
+		{map[string]interface{}{"lazyQuotes": "foo"}, nil, "invalid lazyQuotes value: foo"},
+		{map[string]interface{}{"separator": "\t"}, &CSVOptions{Separator: '\t'}, ""},
+		{map[string]interface{}{"separator": true}, nil, "invalid separator value: true"},
+		{map[string]interface{}{"variadicFields": true}, &CSVOptions{VariadicFields: true}, ""},
+		{map[string]interface{}{"variadicFields": "foo"}, nil, "invalid variadicFields value: foo"},
 	}
 
 	for i, c := range cases {

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -175,9 +175,9 @@ func TestCreateDataset(t *testing.T) {
 				t.Errorf("%s: result path mismatch: expected: '%s', got: '%s'", tc.Name, resultPath, path)
 			}
 
-			if len(store.(cafs.MapStore)) != c.repoFiles {
-				t.Errorf("%s: invalid number of mapstore entries: %d != %d", tc.Name, c.repoFiles, len(store.(cafs.MapStore)))
-				_, err := store.(cafs.MapStore).Print()
+			if len(store.(*cafs.MapStore).Files) != c.repoFiles {
+				t.Errorf("%s: invalid number of mapstore entries: %d != %d", tc.Name, c.repoFiles, len(store.(*cafs.MapStore).Files))
+				_, err := store.(*cafs.MapStore).Print()
 				if err != nil {
 					panic(err)
 				}
@@ -222,9 +222,9 @@ func TestCreateDataset(t *testing.T) {
 	if err.Error() != expectedErr {
 		t.Errorf("case nil datafile and no PreviousPath, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	}
-	if len(store.(cafs.MapStore)) != 18 {
-		t.Errorf("case nil datafile and PreviousPath, invalid number of entries: %d != %d", 18, len(store.(cafs.MapStore)))
-		_, err := store.(cafs.MapStore).Print()
+	if len(store.(*cafs.MapStore).Files) != 18 {
+		t.Errorf("case nil datafile and PreviousPath, invalid number of entries: %d != %d", 18, len(store.(*cafs.MapStore).Files))
+		_, err := store.(*cafs.MapStore).Print()
 		if err != nil {
 			panic(err)
 		}
@@ -288,9 +288,9 @@ func TestWriteDataset(t *testing.T) {
 		// }
 
 		// total count expected of files in repo after test execution
-		if len(store.(cafs.MapStore)) != c.repoFiles {
-			t.Errorf("case expected %d invalid number of entries: %d != %d", i, c.repoFiles, len(store.(cafs.MapStore)))
-			str, err := store.(cafs.MapStore).Print()
+		if len(store.(*cafs.MapStore).Files) != c.repoFiles {
+			t.Errorf("case expected %d invalid number of entries: %d != %d", i, c.repoFiles, len(store.(*cafs.MapStore).Files))
+			str, err := store.(*cafs.MapStore).Print()
 			if err != nil {
 				panic(err)
 			}

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -60,8 +60,8 @@ func TestSaveTransform(t *testing.T) {
 	}
 
 	expectedEntries := 2
-	if len(store.(cafs.MapStore)) != expectedEntries {
-		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(cafs.MapStore)))
+	if len(store.(*cafs.MapStore).Files) != expectedEntries {
+		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(*cafs.MapStore).Files))
 		return
 	}
 
@@ -120,8 +120,8 @@ func TestSaveAbstractTransform(t *testing.T) {
 	}
 
 	expectedEntries := 3
-	if len(store.(cafs.MapStore)) != expectedEntries {
-		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(cafs.MapStore)))
+	if len(store.(*cafs.MapStore).Files) != expectedEntries {
+		t.Errorf("invalid number of entries added to store: %d != %d", expectedEntries, len(store.(*cafs.MapStore).Files))
 		return
 	}
 

--- a/dsio/csv.go
+++ b/dsio/csv.go
@@ -25,9 +25,21 @@ func NewCSVReader(st *dataset.Structure, r io.Reader) *CSVReader {
 	// TODO - handle error
 	_, types, _ := terribleHackToGetHeaderRowAndTypes(st)
 
+	csvr := csv.NewReader(ReplaceSoloCarriageReturns(r))
+
+	if opts, ok := st.FormatConfig.(*dataset.CSVOptions); ok {
+		csvr.LazyQuotes = opts.LazyQuotes
+		if opts.VariadicFields == true {
+			csvr.FieldsPerRecord = -1
+		}
+		if opts.Separator != rune(0) {
+			csvr.Comma = opts.Separator
+		}
+	}
+
 	return &CSVReader{
 		st:    st,
-		r:     csv.NewReader(ReplaceSoloCarriageReturns(r)),
+		r:     csvr,
 		types: types,
 	}
 }
@@ -140,6 +152,12 @@ func NewCSVWriter(st *dataset.Structure, w io.Writer) *CSVWriter {
 	titles, types, _ := terribleHackToGetHeaderRowAndTypes(st)
 
 	writer := csv.NewWriter(w)
+	if opts, ok := st.FormatConfig.(*dataset.CSVOptions); ok {
+		if opts.Separator != rune(0) {
+			writer.Comma = opts.Separator
+		}
+	}
+
 	wr := &CSVWriter{
 		st:    st,
 		w:     writer,

--- a/structure.go
+++ b/structure.go
@@ -390,11 +390,11 @@ func (s *Structure) Decode(cs *StructurePod) (err error) {
 		sch := &jsonschema.RootSchema{}
 		data, e := json.Marshal(cs.Schema)
 		if e != nil {
-			log.Errorf("marshaling schema data: %s", e.Error())
+			log.Debugf("marshaling schema data: %s", e.Error())
 			return e
 		}
 		if err = json.Unmarshal(data, sch); err != nil {
-			log.Errorf("unmarshaling schema: %s", err.Error())
+			log.Debugf("unmarshaling schema: %s", err.Error())
 			return
 		}
 		dst.Schema = sch


### PR DESCRIPTION
When working with CSV data that was close-but-not-quite-perfect for parsing, I've been missing being able to set these csv.Reader options. I've adjusted dsio.CSVReader & dsio.CSVWriter to leverage these & configure the underlying CSV reader/writer.