### PR TITLE
feat(dsio): ConvertFormat utility function

### DIFF
--- a/dsio/dsio.go
+++ b/dsio/dsio.go
@@ -12,6 +12,9 @@ import (
 
 var log = logger.Logger("dsio")
 
+// ErrEOF represents the End of a File
+var ErrEOF = fmt.Errorf("EOF")
+
 // EntryWriter is a generalized interface for writing structured data
 type EntryWriter interface {
 	// Structure gives the structure being written

--- a/dsio/json.go
+++ b/dsio/json.go
@@ -76,11 +76,11 @@ func (r *JSONReader) ReadEntry() (Entry, error) {
 	// Close JSON container if it is complete, signaling EOF.
 	if r.scanMode == smObject {
 		if r.readTokenChar('}') {
-			return ent, fmt.Errorf("EOF")
+			return ent, ErrEOF
 		}
 	} else {
 		if r.readTokenChar(']') {
-			return ent, fmt.Errorf("EOF")
+			return ent, ErrEOF
 		}
 	}
 

--- a/dsio/streams.go
+++ b/dsio/streams.go
@@ -1,0 +1,55 @@
+package dsio
+
+import (
+	"fmt"
+
+	"github.com/qri-io/dataset"
+)
+
+// PagedReader wraps a reader, starting reads from offset, and only reads limit number of entries
+type PagedReader struct {
+	Reader EntryReader
+	Limit  int
+	Offset int
+}
+
+var _ EntryReader = (*PagedReader)(nil)
+
+// Structure returns the wrapped reader's structure
+func (r *PagedReader) Structure() *dataset.Structure {
+	return r.Reader.Structure()
+}
+
+// ReadEntry returns an entry, taking offset and limit into account
+func (r *PagedReader) ReadEntry() (Entry, error) {
+	for r.Offset > 0 {
+		_, err := r.Reader.ReadEntry()
+		if err != nil {
+			return Entry{}, err
+		}
+		r.Offset--
+	}
+	if r.Limit == 0 {
+		return Entry{}, ErrEOF
+	}
+	r.Limit--
+	return r.Reader.ReadEntry()
+}
+
+// Copy reads all entries from the reader and writes them to the writer
+// TODO: Tests
+func Copy(reader EntryReader, writer EntryWriter) error {
+	for {
+		val, err := reader.ReadEntry()
+		if err != nil {
+			if err == ErrEOF {
+				break
+			}
+			return fmt.Errorf("row iteration error: %s", err.Error())
+		}
+		if err := writer.WriteEntry(val); err != nil {
+			return fmt.Errorf("error writing value to buffer: %s", err.Error())
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
ConvertFormat takes an io.Reader of bytes in some parsable format, and converts
it into an EntryBuffer of any other desired format.