### PR TITLE
fix(dsio.ErrEOF): should be replaced with io.EOF

### DIFF
--- a/dsio/dsio.go
+++ b/dsio/dsio.go
@@ -12,9 +12,6 @@ import (
 
 var log = logger.Logger("dsio")
 
-// ErrEOF represents the End of a File
-var ErrEOF = fmt.Errorf("EOF")
-
 // EntryWriter is a generalized interface for writing structured data
 type EntryWriter interface {
 	// Structure gives the structure being written

--- a/dsio/json.go
+++ b/dsio/json.go
@@ -76,11 +76,11 @@ func (r *JSONReader) ReadEntry() (Entry, error) {
 	// Close JSON container if it is complete, signaling EOF.
 	if r.scanMode == smObject {
 		if r.readTokenChar('}') {
-			return ent, ErrEOF
+			return ent, io.EOF
 		}
 	} else {
 		if r.readTokenChar(']') {
-			return ent, ErrEOF
+			return ent, io.EOF
 		}
 	}
 

--- a/dsio/streams.go
+++ b/dsio/streams.go
@@ -2,6 +2,7 @@ package dsio
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/qri-io/dataset"
 )
@@ -30,7 +31,7 @@ func (r *PagedReader) ReadEntry() (Entry, error) {
 		r.Offset--
 	}
 	if r.Limit == 0 {
-		return Entry{}, ErrEOF
+		return Entry{}, io.EOF
 	}
 	r.Limit--
 	return r.Reader.ReadEntry()
@@ -42,7 +43,7 @@ func Copy(reader EntryReader, writer EntryWriter) error {
 	for {
 		val, err := reader.ReadEntry()
 		if err != nil {
-			if err == ErrEOF {
+			if err == io.EOF {
 				break
 			}
 			return fmt.Errorf("row iteration error: %s", err.Error())


### PR DESCRIPTION
We were using a variable ErrEOF to check against errors, but this will never return true. We need to use io.EOF to compare instead.