### PR TITLE
feat(dataset.Body): rename Data fields to Body

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -26,8 +26,8 @@ func CompareDatasets(a, b *Dataset) error {
 	if a.PreviousPath != b.PreviousPath {
 		return fmt.Errorf("PreviousPath: %s != %s", a.PreviousPath, b.PreviousPath)
 	}
-	if a.DataPath != b.DataPath {
-		return fmt.Errorf("DataPath: %s != %s", a.DataPath, b.DataPath)
+	if a.BodyPath != b.BodyPath {
+		return fmt.Errorf("BodyPath: %s != %s", a.BodyPath, b.BodyPath)
 	}
 
 	if err := CompareMetas(a.Meta, b.Meta); err != nil {
@@ -176,8 +176,8 @@ func CompareVisConfigs(a, b *VisConfig) error {
 	if a.Format != b.Format {
 		return fmt.Errorf("Format: %s != %s", a.Format, b.Format)
 	}
-	// if a.DataPath != b.DataPath {
-	// 	return fmt.Errorf("DataPath: %s != %s", a.DataPath, b.DataPath)
+	// if a.BodyPath != b.BodyPath {
+	// 	return fmt.Errorf("BodyPath: %s != %s", a.BodyPath, b.BodyPath)
 	// }
 	if !reflect.DeepEqual(a.Visualizations, b.Visualizations) {
 		return fmt.Errorf("Visualizations not equal")

--- a/compare_test.go
+++ b/compare_test.go
@@ -18,7 +18,7 @@ func TestCompareDatasets(t *testing.T) {
 		{AirportCodes, AirportCodes, ""},
 		{&Dataset{Qri: "a"}, &Dataset{Qri: "b"}, "Qri: a != b"},
 		{&Dataset{PreviousPath: "a"}, &Dataset{PreviousPath: "b"}, "PreviousPath: a != b"},
-		{&Dataset{DataPath: "a"}, &Dataset{DataPath: "b"}, "DataPath: a != b"},
+		{&Dataset{BodyPath: "a"}, &Dataset{BodyPath: "b"}, "BodyPath: a != b"},
 		{&Dataset{}, &Dataset{Structure: &Structure{}}, "Structure: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Transform: &Transform{}}, "Transform: nil: <nil> != <not nil>"},
 		{&Dataset{}, &Dataset{Commit: &Commit{}}, "Commit: nil: <nil> != <not nil>"},

--- a/dataset.go
+++ b/dataset.go
@@ -32,8 +32,8 @@ type Dataset struct {
 
 	// Commit contains author & change message information
 	Commit *Commit `json:"commit,omitempty"`
-	// DataPath is the path to the hash of raw data as it resolves on the network.
-	DataPath string `json:"dataPath,omitempty"`
+	// BodyPath is the path to the hash of raw data as it resolves on the network.
+	BodyPath string `json:"bodyPath,omitempty"`
 	// Meta contains all human-readable meta about this dataset
 	Meta *Meta `json:"meta,omitempty"`
 	// PreviousPath connects datasets to form a historical DAG
@@ -52,7 +52,7 @@ type Dataset struct {
 func (ds *Dataset) IsEmpty() bool {
 	return ds.Commit == nil &&
 		ds.Structure == nil &&
-		ds.DataPath == "" &&
+		ds.BodyPath == "" &&
 		ds.Meta == nil &&
 		ds.PreviousPath == "" &&
 		ds.Transform == nil &&
@@ -145,8 +145,8 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 			ds.VisConfig.Assign(d.VisConfig)
 		}
 
-		if d.DataPath != "" {
-			ds.DataPath = d.DataPath
+		if d.BodyPath != "" {
+			ds.BodyPath = d.BodyPath
 		}
 		if d.PreviousPath != "" {
 			ds.PreviousPath = d.PreviousPath
@@ -214,7 +214,7 @@ func UnmarshalDataset(v interface{}) (*Dataset, error) {
 // Encode creates a DatasetPod from a Dataset instance
 func (ds Dataset) Encode() *DatasetPod {
 	cd := &DatasetPod{
-		DataPath:     ds.DataPath,
+		BodyPath:     ds.BodyPath,
 		Meta:         ds.Meta,
 		Path:         ds.Path().String(),
 		PreviousPath: ds.PreviousPath,
@@ -239,7 +239,7 @@ func (ds Dataset) Encode() *DatasetPod {
 func (ds *Dataset) Decode(cd *DatasetPod) error {
 	d := Dataset{
 		path:         datastore.NewKey(cd.Path),
-		DataPath:     cd.DataPath,
+		BodyPath:     cd.BodyPath,
 		PreviousPath: cd.PreviousPath,
 		Meta:         cd.Meta,
 		VisConfig:    cd.VisConfig,
@@ -285,14 +285,14 @@ func (ds *Dataset) Decode(cd *DatasetPod) error {
 // fields is populated at a time.
 type DatasetPod struct {
 	Commit *CommitPod `json:"commit,omitempty"`
-	// Data is the designated field for representing dataset data with native go types
+	// Body is the designated field for representing dataset data with native go types
 	// this will often not be populated
-	Data interface{} `json:"data,omitempty"`
-	// DataBytes is the designated field for representing dataset data as a slice of bytes
+	Body interface{} `json:"data,omitempty"`
+	// BodyBytes is fpr representing dataset data as a slice of bytes
 	// this will often not be populated
-	DataBytes []byte `json:"dataBytes,omitempty"`
-	// DataPath is the path to retrieve this dataset
-	DataPath string `json:"dataPath,omitempty"`
+	BodyBytes []byte `json:"dataBytes,omitempty"`
+	// BodyPath is the path to retrieve this dataset
+	BodyPath string `json:"bodyPath,omitempty"`
 	// Unique name reference for this dataset
 	Name string `json:"name,omitempty"`
 	Meta *Meta  `json:"meta,omitempty"`

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -38,7 +38,7 @@ func TestDatasetAssign(t *testing.T) {
 		{&Dataset{Structure: &Structure{Format: CSVDataFormat}}},
 		{&Dataset{Transform: &Transform{ScriptPath: "some_transform_script.sky"}}},
 		{&Dataset{Commit: &Commit{Title: "foo"}}},
-		{&Dataset{DataPath: "foo"}},
+		{&Dataset{BodyPath: "foo"}},
 		{&Dataset{PreviousPath: "stuff"}},
 		{&Dataset{Meta: &Meta{Title: "foo"}}},
 		{&Dataset{VisConfig: &VisConfig{Qri: KindVisConfig}}},
@@ -211,7 +211,7 @@ func TestDatasetIsEmpty(t *testing.T) {
 		ds *Dataset
 	}{
 		{&Dataset{Commit: &Commit{}}},
-		{&Dataset{DataPath: "foo"}},
+		{&Dataset{BodyPath: "foo"}},
 		{&Dataset{Meta: &Meta{}}},
 		{&Dataset{PreviousPath: "nope"}},
 		{&Dataset{Structure: &Structure{}}},
@@ -288,7 +288,7 @@ func TestDatasetCoding(t *testing.T) {
 	cases := []*Dataset{
 		{},
 		{Commit: &Commit{Title: "foo"}},
-		{DataPath: "foo"},
+		{BodyPath: "foo"},
 		{Meta: &Meta{Title: "foo"}},
 		{PreviousPath: "foo"},
 		{Qri: KindDataset},

--- a/dsfs/data.go
+++ b/dsfs/data.go
@@ -12,7 +12,7 @@ import (
 
 // LoadData loads the data this dataset points to from the store
 func LoadData(store cafs.Filestore, ds *dataset.Dataset) (cafs.File, error) {
-	return store.Get(datastore.NewKey(ds.DataPath))
+	return store.Get(datastore.NewKey(ds.BodyPath))
 }
 
 // LoadRows loads a slice of raw bytes inside a limit/offset row range

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -393,7 +393,7 @@ func generateCommitMsg(store cafs.Filestore, ds *dataset.Dataset) (string, error
 				Checksum: base58.Encode([]byte(placeholder)),
 				Format:   ds.Structure.Format,
 			},
-			DataPath: placeholder,
+			BodyPath: placeholder,
 		}
 	}
 
@@ -553,7 +553,7 @@ func WriteDataset(store cafs.Filestore, ds *dataset.Dataset, dataFile cafs.File,
 			case PackageFileVisConfig.String():
 				ds.VisConfig = dataset.NewVisConfigRef(ao.Path)
 			case dataFile.FileName():
-				ds.DataPath = ao.Path.String()
+				ds.BodyPath = ao.Path.String()
 			case "transform_script":
 				ds.Transform.ScriptPath = ao.Path.String()
 				tfdata, err := json.Marshal(ds.Transform)

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -146,13 +146,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmYXMg6gqMAT8seUFhgAagknFvfs71auFWbnSfVcg1NTd8", 6, ""},
+			"/map/QmXjDWV4D9FPrU7p3bdBz2tFjtu8KG78hZtKf4FZo9uhAb", 6, ""},
 		{"complete",
-			"/map/QmZPqhESomGtMcetWPdMNfeGgSkFeeKkj3tpzMqin1i8m1", 13, ""},
+			"/map/QmX5thqsJJ6yk7swticKYwrjC7BKdyFiLx7ZRAPFa3kUPo", 13, ""},
 		{"cities_no_commit_title",
-			"/map/QmNNtXBcv5Lp6rwHKFuLH4A7epnbgPVfBTUeMtZ7PFJiGL", 15, ""},
+			"/map/QmbiPVhUKJNqC9cA5QNq83SwaXgkt98fgo74TYkeiPem4L", 15, ""},
 		{"craigslist",
-			"/map/QmayiyvRGkS8R6ifLRmHBKGd8ro9UWgXigrwsQU8vYFemg", 19, ""},
+			"/map/QmP55iAnLkPpqqnhfg1mcRBqz7tKckm6bdW4kGhT1kRpP1", 19, ""},
 	}
 
 	for _, c := range cases {
@@ -342,7 +342,7 @@ func TestWriteDataset(t *testing.T) {
 			}
 			ds.VisConfig.Assign(dataset.NewVisConfigRef(ref.VisConfig.Path()))
 		}
-		ds.DataPath = ref.DataPath
+		ds.BodyPath = ref.BodyPath
 
 		ds.Assign(dataset.NewDatasetRef(got))
 		result, err := LoadDataset(store, got)

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -6,7 +6,7 @@
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },
-  "dataPath": "/map/QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
+  "bodyPath": "/map/QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
   "meta": {
     "qri": "md:0",
     "title": "example city data"

--- a/dsfs/testdata/complete/expect.dataset.json
+++ b/dsfs/testdata/complete/expect.dataset.json
@@ -7,7 +7,7 @@
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "I'm a commit"
   },
-  "dataPath": "/map/QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
+  "bodyPath": "/map/QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
   "meta": {
     "qri": "md:0",
     "title": "dataset with all submodels example"

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -5,7 +5,7 @@
     "timestamp": "2001-01-01T01:01:01.000000001Z",
     "title": "initial commit"
   },
-  "dataPath": "/map/QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",
+  "bodyPath": "/map/QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",
   "qri": "ds:0",
   "structure": {
     "checksum": "QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",

--- a/testdata/datasets/hours.json
+++ b/testdata/datasets/hours.json
@@ -7,5 +7,5 @@
     "downloadPath": "https://example.com/not/a/url",
     "readmePath": "/ipfs/notahash"
   },
-  "dataPath": "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"
+  "bodyPath": "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"
 }

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -126,7 +126,7 @@ var Hours = &Dataset{
 		DownloadPath: "https://example.com/not/a/url",
 		ReadmePath:   "/ipfs/notahash",
 	},
-	DataPath: "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
+	BodyPath: "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
 }
 
 var HoursStructure = &Structure{

--- a/transform_test.go
+++ b/transform_test.go
@@ -217,7 +217,7 @@ func TestTransformCoding(t *testing.T) {
 		{ScriptPath: "foo"},
 		{path: datastore.NewKey("/foo")},
 		{Qri: KindTransform},
-		{Resources: map[string]*Dataset{"foo": &Dataset{DataPath: "foo"}}},
+		{Resources: map[string]*Dataset{"foo": &Dataset{BodyPath: "foo"}}},
 		{Syntax: "foo"},
 		{Structure: &Structure{Format: CBORDataFormat}},
 	}


### PR DESCRIPTION
After a bunch of discussion, we've decided to rename "Data" to "Body", our logic is outlined here: https://github.com/qri-io/qri/issues/422. Basically it's just a rename, but it renames a required field. This'll break all sorts of stuff, but considering we're still _very_ early days, I'd rather get it merged now.
To me this dataset-as-html-page metaphor is worth a breaking change, so let's make one.

BREAKING CHANGE: dataset.DataPath is renamed to dataset.BodyPath.