### PR TITLE
fix(dstest): Cache the reading of TestCases, speeding up unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             go get -v -d -u
             github.com/ipfs/go-datastore
             github.com/jbenet/go-base58
+            github.com/jinzhu/copier
             github.com/multiformats/go-multihash
             github.com/qri-io/compare
             github.com/datatogether/cdxj


### PR DESCRIPTION
Our unit tests currently spend a lot of time re-reading and re-parsing test
files. Though these are quick individually, they add up to a significant
total of tests' runtimes, especially the craigslist/*.dataset.json files, which
are over 1MB and take about 1 second to parse. By caching these reads and
parses, and returning copies on future calls, we speed up tests by about 35%.

Some performance numbers follow.

Before this change:
```
Run 0
ok      github.com/qri-io/qri/api      25.587s
ok      github.com/qri-io/qri/cmd      84.258s
ok      github.com/qri-io/qri/config   48.832s
ok      github.com/qri-io/qri/lib      90.485s
ok      github.com/qri-io/qri/p2p      54.261s
Run 1
ok      github.com/qri-io/qri/api      30.159s
ok      github.com/qri-io/qri/cmd      79.327s
ok      github.com/qri-io/qri/config   40.614s
ok      github.com/qri-io/qri/lib      74.311s
ok      github.com/qri-io/qri/p2p      43.396s
Run 2
ok      github.com/qri-io/qri/api      23.189s
ok      github.com/qri-io/qri/cmd      79.591s
ok      github.com/qri-io/qri/config   44.684s
ok      github.com/qri-io/qri/lib      75.476s
ok      github.com/qri-io/qri/p2p      41.786s
```

After this change:
```
Run 0
ok      github.com/qri-io/qri/api      18.428s
ok      github.com/qri-io/qri/cmd      59.639s
ok      github.com/qri-io/qri/config   46.602s
ok      github.com/qri-io/qri/lib      52.682s
ok      github.com/qri-io/qri/p2p      40.562s
Run 1
ok      github.com/qri-io/qri/api      21.280s
ok      github.com/qri-io/qri/cmd      55.533s
ok      github.com/qri-io/qri/config   51.034s
ok      github.com/qri-io/qri/lib      44.018s
ok      github.com/qri-io/qri/p2p      49.323s
Run 2
ok      github.com/qri-io/qri/api      15.110s
ok      github.com/qri-io/qri/cmd      57.857s
ok      github.com/qri-io/qri/config   43.257s
ok      github.com/qri-io/qri/lib      49.521s
ok      github.com/qri-io/qri/p2p      36.730s
```