### PR TITLE
fix(csv): inferred csv structures use lazyQuotes by default, set VariadicFields

### DIFF
--- a/data_format_config.go
+++ b/data_format_config.go
@@ -42,7 +42,7 @@ func NewCSVOptions(opts map[string]interface{}) (FormatConfig, error) {
 
 	if opts["lazyQuotes"] != nil {
 		if lq, ok := opts["lazyQuotes"].(bool); ok {
-			o.HeaderRow = lq
+			o.LazyQuotes = lq
 		} else {
 			return nil, fmt.Errorf("invalid lazyQuotes value: %s", opts["lazyQuotes"])
 		}
@@ -82,7 +82,7 @@ type CSVOptions struct {
 	// It is set to comma (',') by NewReader.
 	// Comma must be a valid rune and must not be \r, \n,
 	// or the Unicode replacement character (0xFFFD).
-	Separator rune `json:"separator"`
+	Separator rune `json:"separator,omitempty"`
 	// VariadicFields sets permits records to have a variable number of fields
 	// avoid using this
 	VariadicFields bool `json:"variadicFields"`
@@ -98,9 +98,20 @@ func (o *CSVOptions) Map() map[string]interface{} {
 	if o == nil {
 		return nil
 	}
-	return map[string]interface{}{
-		"headerRow": o.HeaderRow,
+	opt := map[string]interface{}{}
+	if o.HeaderRow {
+		opt["headerRow"] = o.HeaderRow
 	}
+	if o.LazyQuotes {
+		opt["lazyQuotes"] = o.LazyQuotes
+	}
+	if o.VariadicFields {
+		opt["variadicFields"] = o.VariadicFields
+	}
+	if o.Separator != rune(0) {
+		opt["separator"] = o.Separator
+	}
+	return opt
 }
 
 // NewJSONOptions creates a JSONOptions pointer from a map

--- a/data_format_config_test.go
+++ b/data_format_config_test.go
@@ -68,7 +68,7 @@ func TestNewCSVOptions(t *testing.T) {
 	for i, c := range cases {
 		got, err := NewCSVOptions(c.opts)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
-			t.Errorf("case %d error expected: '%s', got: '%s'", i, c.err, err.Error())
+			t.Errorf("case %d error expected: '%s', got: '%s'", i, c.err, err)
 			continue
 		}
 		if c.err == "" {

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -3,6 +3,7 @@ package detect
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -49,6 +50,8 @@ func TestFromFile(t *testing.T) {
 			}
 
 			if err := dataset.CompareStructures(expect, st); err != nil {
+				fmt.Printf("exp: %#v\n", expect.FormatConfig)
+				fmt.Printf("got: %#v\n\n", st.FormatConfig)
 				t.Errorf("case %d structure mismatch: %s", i, err.Error())
 				continue
 			}

--- a/detect/determineFields_test.go
+++ b/detect/determineFields_test.go
@@ -1,106 +1,31 @@
 package detect
 
-var (
-	egCorruptCsvData = []byte(`
+var egCorruptCsvData = []byte(`
 		"""fhkajslfnakjlcdnajcl ashklj asdhcjklads ch,,,\dagfd
 	`)
-	egNaicsCsvData = []byte(`
+
+var egNaicsCsvData = []byte(`
 STATE,FIRM,PAYR_N,PAYRFL_N,STATEDSCR,NAICSDSCR,entrsizedscr
 00,--,74883.53,5621697325,United States,Total,01:  Total
 00,--,35806.37,241347624,United States,Total,02:  0-4`)
-	egNoHeaderData1 = []byte(`
+
+var egNoHeaderData1 = []byte(`
 example,false,other,stuff
 ex,true,text,col
 		`)
-	egNoHeaderData2 = []byte(`
+
+var egNoHeaderData2 = []byte(`
 this,example,has,a,number,column,1
 this,example,has,a,number,column,2
 this,example,has,a,number,column,3`)
-	egNoHeaderData3 = []byte(`
+
+var egNoHeaderData3 = []byte(`
 one, 1, three
 one, 2, three`)
-	egNonDeterministicHeader = []byte(`
+
+var egNonDeterministicHeader = []byte(`
 not,possible,to,tell,if,this,csv,data,has,a,header
 not,possible,to,tell,if,this,csv,data,has,a,header
 not,possible,to,tell,if,this,csv,data,has,a,header
 not,possible,to,tell,if,this,csv,data,has,a,header
 `)
-)
-
-// func colsEqual(a, b []*ql.Column) error {
-// 	for i, aCol := range a {
-// 		if b[i] == nil {
-// 			return errors.New(fmt.Sprintf("column %d doesn't exist", i))
-// 		}
-// 		bCol := b[i]
-
-// 		if aCol.Type != bCol.Type || aCol.Name != bCol.Name || aCol.Description != bCol.Description {
-// 			return errors.New(fmt.Sprintf("columns %d aren't equal. want: %s got: %s", i, aCol, bCol))
-// 		}
-// 	}
-
-// 	return nil
-// }
-
-// func TestPossibleHeaderRow(t *testing.T) {
-// 	cases := []struct {
-// 		data   []byte
-// 		expect bool
-// 	}{
-// 		// {egCorruptCsvData, false},
-// 		// {egNaicsCsvData, true},
-// 		// {egNoHeaderData1, false},
-// 		// {egNoHeaderData2, false},
-// 		{egNoHeaderData3, false},
-// 		// {egNonDeterministicHeader, true},
-// 	}
-
-// 	for i, c := range cases {
-// 		got := possibleHeaderRow(c.data)
-// 		if got != c.expect {
-// 			t.Errorf("case %d response mismatch. expected: %t, got: %t", i, c.expect, got)
-// 		}
-// 	}
-// }
-
-// func TestDetermineCsvSchema(t *testing.T) {
-// 	var (
-// 		egCorruptCsvData = []byte(`
-// 		"""fhkajslfnakjlcdnajcl ashklj asdhcjklads ch,,,\dagfd
-// 	`)
-// 		egNaicsInput = []byte(`
-// STATE,FIRM,PAYR_N,PAYRFL_N,STATEDSCR,NAICSDSCR,entrsizedscr
-// 00,--,74883.53,5621697325,United States,Total,01:  Total
-// 00,--,35806.37,241347624,United States,Total,02:  0-4`)
-
-// 		egNaicsCols = []*ql.Column{
-// 			{Name: "STATE", Type: dataTypeInt},
-// 			{Name: "FIRM", Type: dataTypeString},
-// 			{Name: "PAYR_N", Type: dataTypeFloat},
-// 			{Name: "PAYRFL_N", Type: dataTypeInt},
-// 			{Name: "STATEDSCR", Type: dataTypeString},
-// 			{Name: "NAICSDSCR", Type: dataTypeString},
-// 			{Name: "entrsizedscr", Type: dataTypeString},
-// 		}
-// 	)
-
-// 	cases := []struct {
-// 		data   []byte
-// 		expect []*ql.Column
-// 		err    error
-// 	}{
-// 		{egCorruptCsvData, nil, ErrCorruptCsvData},
-// 		{egNaicsInput, egNaicsCols, nil},
-// 	}
-
-// 	for i, c := range cases {
-// 		got, err := DetermineCsvSchema(c.data)
-// 		if err != c.err {
-// 			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err)
-// 		}
-
-// 		if err := colsEqual(c.expect, got); err != nil {
-// 			t.Errorf("case %d: %s", i, err)
-// 		}
-// 	}
-// }

--- a/detect/testdata/daily_wind_2011.structure.json
+++ b/detect/testdata/daily_wind_2011.structure.json
@@ -1,7 +1,8 @@
 {
   "format": "csv",
   "formatConfig": {
-    "headerRow" : true
+    "headerRow" : true,
+    "lazyQuotes" : true
   },
   "schema": {
     "type": "array",

--- a/detect/testdata/hours-with-header.structure.json
+++ b/detect/testdata/hours-with-header.structure.json
@@ -1,7 +1,8 @@
 {
   "format": "csv",
   "formatConfig" : {
-    "headerRow" : true
+    "headerRow" : true,
+    "lazyQuotes" : true
   },
   "schema": {
     "type": "array",

--- a/detect/testdata/hours.structure.json
+++ b/detect/testdata/hours.structure.json
@@ -1,5 +1,8 @@
 {
   "format": "csv",
+  "formatConfig": {
+    "lazyQuotes" : true
+  },
   "schema": {
     "type": "array",
     "items": {

--- a/detect/testdata/spelling.structure.json
+++ b/detect/testdata/spelling.structure.json
@@ -1,7 +1,8 @@
 {
   "format": "csv",
   "formatConfig" : {
-    "headerRow" : true
+    "headerRow" : true,
+    "lazyQuotes": true
   },
   "schema": {
     "type": "array",

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -105,7 +105,7 @@ func DerefDatasetStructure(store cafs.Filestore, ds *dataset.Dataset) error {
 	return nil
 }
 
-// DerefDatasetViz derferences a dataset's Viz element if required
+// DerefDatasetViz dereferences a dataset's Viz element if required
 // should be a no-op if ds.Viz is nil or isn't a reference
 func DerefDatasetViz(store cafs.Filestore, ds *dataset.Dataset) error {
 	if ds.Viz != nil && ds.Viz.IsEmpty() && ds.Viz.Path().String() != "" {

--- a/dsio/csv_test.go
+++ b/dsio/csv_test.go
@@ -94,6 +94,39 @@ func TestCSVReader(t *testing.T) {
 	}
 }
 
+func TestCSVReaderLazyQuotes(t *testing.T) {
+	data := `number,str
+2,"HYDROCHLORIC ACID (1995 AND AFTER "ACID AEROSOLS" ONLY)"`
+
+	st := &dataset.Structure{
+		Format: dataset.CSVDataFormat,
+		FormatConfig: &dataset.CSVOptions{
+			HeaderRow:  true,
+			LazyQuotes: true,
+		},
+		Schema: jsonschema.Must(`{
+			"type":"array",
+			"items":{
+				"type":"array",
+				"items": [
+					{"type":"number"},
+					{"type":"string"}
+				]
+			}
+		}`),
+	}
+
+	rdr, err := NewEntryReader(st, bytes.NewBuffer([]byte(data)))
+	if err != nil {
+		t.Fatalf("error allocating EntryReader: %s", err.Error())
+	}
+
+	_, err = rdr.ReadEntry()
+	if err != nil {
+		t.Errorf("expected no error: %s", err.Error())
+	}
+}
+
 func TestTSVReader(t *testing.T) {
 	// data separated with tabs, has variadic fields per record, and odd quoting
 	// bascially, a trash TSV file that can still parse with lots of CSVOption relaxing


### PR DESCRIPTION
Found & fixed a few bugs in csv.FormatConfig.Map(). Dope. Also realized that detect needs
to do more work when generating csv.FormatConfig.
A bunch of our parsing errors come from not having csv.Reader engage the LazyQuotes option,
and a few others come from not properly setting variadicFields. For now I've switched on
lazyQuotes for everything which will produce a general slowdown when working with csv,
but will mean _many_ more gross csv files will be parsable by Qri. Long term I think we
should solve the LazyQuotes slowness with two things: a default-convert-to-cbor, and a full
csv file scan that properly infers the need for lazyQuotes.

closes #140