### PR TITLE
fix(dsio.CSVReader,dsfs.CreateDataset): fix mutex pass-by-ref, csv read corner case

### DIFF
--- a/dsio/csv.go
+++ b/dsio/csv.go
@@ -54,10 +54,9 @@ func (r *CSVReader) ReadEntry() (Entry, error) {
 	if !r.readHeader {
 		if HasHeaderRow(r.st) {
 			if _, err := r.r.Read(); err != nil {
-				if err.Error() == "EOF" {
-					return Entry{}, nil
+				if err.Error() != "EOF" {
+					log.Debug(err.Error())
 				}
-				log.Debug(err.Error())
 				return Entry{}, err
 			}
 		}


### PR DESCRIPTION
providing an empty slice to a CSV reader with `headerRow: true` would cause infinite loops. Also, don't pass mutexes by reference.