### PR TITLE
refactor(cbor): Rewrite of CBOR reader. Faster and simpler.

### DIFF
--- a/dsio/README.md
+++ b/dsio/README.md
@@ -1,5 +1,19 @@
 ## Performance
 
+2018-12-04
+
+    go test github.com/qri-io/dataset/dsio -bench=.
+
+    BenchmarkCBORWriterArrays-2    	    3000	    431290 ns/op
+    BenchmarkCBORWriterObjects-2   	    2000	    698920 ns/op
+    BenchmarkCBORReader-2          	    1000	   1764549 ns/op
+    BenchmarkCSVWriterArrays-2     	    1000	   1548509 ns/op
+    BenchmarkCSVWriterObjects-2    	    1000	   1458219 ns/op
+    BenchmarkCSVReader-2           	    1000	   2008097 ns/op
+    BenchmarkJSONWriterArrays-2    	    1000	   1556416 ns/op
+    BenchmarkJSONWriterObjects-2   	    1000	   1562488 ns/op
+    BenchmarkJSONReader-2          	     500	   2984057 ns/op
+
 2018-04-17
 
     go test github.com/qri-io/dataset/dsio -bench=.

--- a/dsio/cbor_test.go
+++ b/dsio/cbor_test.go
@@ -51,13 +51,13 @@ func TestCBORReaderOneArrayEntry(t *testing.T) {
 		{`811A004C4B40`, int64(5000000), ""}, // [5000000]
 		{`8020`, int64(-1), ""},              // [-1]
 
-		{`81FB4028AE147AE147AE`, 12.34, ""},                                             // [12.34]
-		{`81FB402A1D1F601797CC`, 13.05688, ""},                                          // [13.05688]
-		{`8163666F6F`, "foo", ""},                                                       // ["foo"]
-		{`81F5`, true, ""},                                                              // [true]
-		{`81F4`, false, ""},                                                             // [false]
-		{`81F6`, nil, ""},                                                               // [null]
-		{`81A0`, map[string]interface{}{}, ""},                                          // [{}]
+		{`81FB4028AE147AE147AE`, 12.34, ""},    // [12.34]
+		{`81FB402A1D1F601797CC`, 13.05688, ""}, // [13.05688]
+		{`8163666F6F`, "foo", ""},              // ["foo"]
+		{`81F5`, true, ""},                     // [true]
+		{`81F4`, false, ""},                    // [false]
+		{`81F6`, nil, ""},                      // [null]
+		{`81A0`, map[string]interface{}{}, ""}, // [{}]
 		{`81A163666F6FA0`, map[string]interface{}{"foo": map[string]interface{}{}}, ""}, // [{"foo":{}}]
 
 		{`81782A286F72672C64617461746F6765746865722C292F616374697669746965732F68617276657374696E673E`, "(org,datatogether,)/activities/harvesting>", ""}, // ["(org,datatogether,)/activities/harvesting>"]
@@ -105,21 +105,21 @@ func TestCBORReaderOneObjectEntry(t *testing.T) {
 		val  Entry
 		err  string
 	}{
-		{`A0`, Entry{}, "EOF"},                                                                                      // {}
-		{`A1616100`, Entry{Key: "a", Value: int64(0)}, ""},                                                          // {"a":0}
-		{`A1616217`, Entry{Key: "b", Value: int64(23)}, ""},                                                         // {"b":23}
-		{`A161631818`, Entry{Key: "c", Value: int64(24)}, ""},                                                       // {"c":24}
-		{`A161641901F4`, Entry{Key: "d", Value: int64(500)}, ""},                                                    // {"d":500}
-		{`A161651A004C4B40`, Entry{Key: "e", Value: int64(5000000)}, ""},                                            // {"e":5000000}
-		{`A1616620`, Entry{Key: "f", Value: int64(-1)}, ""},                                                         // {"f":-1}
-		{`A16166FB4028AE147AE147AE`, Entry{Key: "f", Value: 12.34}, ""},                                             // {"f":[12.34]}
-		{`A1616763666F6F`, Entry{Key: "g", Value: "foo"}, ""},                                                       // {"g":"foo"}
-		{`A16168F5`, Entry{Key: "h", Value: true}, ""},                                                              // {"h":true}
-		{`A16169F4`, Entry{Key: "i", Value: false}, ""},                                                             // {"i":false}
-		{`A1616AF6`, Entry{Key: "j", Value: nil}, ""},                                                               // {"j":null}
-		{`A1616BA0`, Entry{Key: "k", Value: map[string]interface{}{}}, ""},                                          // {"k":{}}
-		{`A1616CA163666F6FA0`, Entry{Key: "l", Value: map[string]interface{}{"foo": map[string]interface{}{}}}, ""}, // {"l": {"foo":{}}}
+		{`A0`, Entry{}, "EOF"},                                             // {}
+		{`A1616100`, Entry{Key: "a", Value: int64(0)}, ""},                 // {"a":0}
+		{`A1616217`, Entry{Key: "b", Value: int64(23)}, ""},                // {"b":23}
+		{`A161631818`, Entry{Key: "c", Value: int64(24)}, ""},              // {"c":24}
+		{`A161641901F4`, Entry{Key: "d", Value: int64(500)}, ""},           // {"d":500}
+		{`A161651A004C4B40`, Entry{Key: "e", Value: int64(5000000)}, ""},   // {"e":5000000}
+		{`A1616620`, Entry{Key: "f", Value: int64(-1)}, ""},                // {"f":-1}
+		{`A16166FB4028AE147AE147AE`, Entry{Key: "f", Value: 12.34}, ""},    // {"f":[12.34]}
+		{`A1616763666F6F`, Entry{Key: "g", Value: "foo"}, ""},              // {"g":"foo"}
+		{`A16168F5`, Entry{Key: "h", Value: true}, ""},                     // {"h":true}
+		{`A16169F4`, Entry{Key: "i", Value: false}, ""},                    // {"i":false}
+		{`A1616AF6`, Entry{Key: "j", Value: nil}, ""},                      // {"j":null}
+		{`A1616BA0`, Entry{Key: "k", Value: map[string]interface{}{}}, ""}, // {"k":{}}
 
+		{`A1616CA163666F6FA0`, Entry{Key: "l", Value: map[string]interface{}{"foo": map[string]interface{}{}}}, ""}, // {"l": {"foo":{}}}
 		{`A1616C782A286F72672C64617461746F6765746865722C292F616374697669746965732F68617276657374696E673E`, Entry{Key: "l", Value: "(org,datatogether,)/activities/harvesting>"}, ""}, // {"l":"(org,datatogether,)/activities/harvesting>"}
 		{bigObj, bigVal, ""},
 

--- a/dsio/streams_test.go
+++ b/dsio/streams_test.go
@@ -1,7 +1,6 @@
 package dsio
 
 import (
-	"bufio"
 	"bytes"
 	"strings"
 	"testing"
@@ -71,8 +70,7 @@ func TestCopyJSONToBytes(t *testing.T) {
 func TestCopyJSONToCBOR(t *testing.T) {
 	text := "[{\"a\":1},{\"b\":2},{\"c\":3},{\"d\":4}]"
 	expected := []byte{132, 161, 97, 97, 1, 161, 97, 98, 2, 161, 97, 99, 3, 161, 97, 100, 4}
-	var b bytes.Buffer
-	sink := bufio.NewWriter(&b)
+	sink := bytes.Buffer{}
 	st := &dataset.Structure{
 		Format: dataset.JSONDataFormat,
 		Schema: dataset.BaseSchemaArray,
@@ -82,7 +80,7 @@ func TestCopyJSONToCBOR(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	w, err := NewCBORWriter(st, sink)
+	w, err := NewCBORWriter(st, &sink)
 	if err != nil {
 		t.Error(err)
 		return
@@ -93,8 +91,9 @@ func TestCopyJSONToCBOR(t *testing.T) {
 		return
 	}
 	w.Close()
-	if bytes.Compare(b.Bytes(), expected) != 0 {
-		t.Errorf("Copy from json to cbor did not succeed: %v <> %v", b.Bytes(), expected)
+	b := sink.Bytes()
+	if bytes.Compare(b, expected) != 0 {
+		t.Errorf("Copy from json to cbor did not succeed: %v <> %v", b, expected)
 	}
 }
 


### PR DESCRIPTION
Rewrite CBOR reader so that it avoids buffering tokens. Instead, output parsed elements as they are read off the input reader. Decode CBOR bytes on our own, instead of relying on another library (which is what required buffering).

Performance is about 3x better. Before:

```
> go test ./dsio/. -bench=.

BenchmarkCBORWriterArrays-2    	    3000	    441960 ns/op
BenchmarkCBORWriterObjects-2   	    3000	    617959 ns/op
BenchmarkCBORReader-2          	     200	   6453132 ns/op
BenchmarkCSVWriterArrays-2     	    1000	   1547526 ns/op
BenchmarkCSVWriterObjects-2    	    1000	   1970756 ns/op
BenchmarkCSVReader-2           	     500	   2300161 ns/op
BenchmarkJSONWriterArrays-2    	    1000	   1890182 ns/op
BenchmarkJSONWriterObjects-2   	     500	   2021165 ns/op
BenchmarkJSONReader-2          	     500	   3043123 ns/op
```

(compare to https://github.com/qri-io/dataset/commit/819375c81ba49a904b97dd1f670e90920b4edbca)

After:

```
BenchmarkCBORWriterArrays-2    	    3000	    431290 ns/op
BenchmarkCBORWriterObjects-2   	    2000	    698920 ns/op
BenchmarkCBORReader-2          	    1000	   1764549 ns/op
BenchmarkCSVWriterArrays-2     	    1000	   1548509 ns/op
BenchmarkCSVWriterObjects-2    	    1000	   1458219 ns/op
BenchmarkCSVReader-2           	    1000	   2008097 ns/op
BenchmarkJSONWriterArrays-2    	    1000	   1556416 ns/op
BenchmarkJSONWriterObjects-2   	    1000	   1562488 ns/op
BenchmarkJSONReader-2          	     500	   2984057 ns/op
```