### PR TITLE
feat(structure.Depth): add depth parameter to detect tabular data

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -292,7 +292,7 @@ func CompareTransforms(a, b *Transform) error {
 	return nil
 }
 
-// CompareTransformResource checks if all fields are equal in both resources
+// CompareTransformResources checks if all fields are equal in both resources
 func CompareTransformResources(a, b *TransformResource) error {
 	if a == nil && b == nil {
 		return nil

--- a/compare.go
+++ b/compare.go
@@ -137,6 +137,9 @@ func CompareStructures(a, b *Structure) error {
 	if a.Checksum != b.Checksum {
 		return fmt.Errorf("Checksum: %s != %s", a.Checksum, b.Checksum)
 	}
+	if a.Depth != b.Depth {
+		return fmt.Errorf("Depth: %d != %d", a.Depth, b.Depth)
+	}
 	if a.Entries != b.Entries {
 		return fmt.Errorf("Entries: %d != %d", a.Entries, b.Entries)
 	}

--- a/compare_test.go
+++ b/compare_test.go
@@ -81,6 +81,7 @@ func TestCompareStructures(t *testing.T) {
 		{&Structure{Length: 0}, &Structure{Length: 1}, "Length: 0 != 1"},
 		{&Structure{Entries: 0}, &Structure{Entries: 1}, "Entries: 0 != 1"},
 		{&Structure{Checksum: "a"}, &Structure{Checksum: "b"}, "Checksum: a != b"},
+		{&Structure{Depth: 0}, &Structure{Depth: 1}, "Depth: 0 != 1"},
 		{&Structure{Format: CSVDataFormat}, &Structure{Format: UnknownDataFormat}, "Format: csv != "},
 		{&Structure{Encoding: "a"}, &Structure{Encoding: "b"}, "Encoding: a != b"},
 		{&Structure{Compression: compression.None}, &Structure{Compression: compression.Tar}, "Compression:  != tar"},

--- a/detect/determineFields.go
+++ b/detect/determineFields.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
+	"github.com/qri-io/dataset/dsio/replacecr"
 	"github.com/qri-io/dataset/vals"
 	"github.com/qri-io/jsonschema"
 	"github.com/qri-io/varName"
@@ -48,7 +49,7 @@ type field struct {
 // CSVSchema determines the field names and types of an io.Reader of CSV-formatted data, returning a json schema
 func CSVSchema(resource *dataset.Structure, data io.Reader) (schema *jsonschema.RootSchema, n int, err error) {
 	tr := dsio.NewTrackedReader(data)
-	r := csv.NewReader(dsio.ReplaceSoloCarriageReturns(tr))
+	r := csv.NewReader(replacecr.Reader(tr))
 	r.FieldsPerRecord = -1
 	r.TrimLeadingSpace = true
 	r.LazyQuotes = true

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -241,7 +241,7 @@ func prepareDataset(store cafs.Filestore, ds *dataset.Dataset, df cafs.File, pri
 	tasks := 3
 
 	go setErrCount(ds, cafs.NewMemfileReader(df.FileName(), errR), &mu, done)
-	go setEntryCount(ds, cafs.NewMemfileReader(df.FileName(), entryR), &mu, done)
+	go setDepthAndEntryCount(ds, cafs.NewMemfileReader(df.FileName(), entryR), &mu, done)
 	go setChecksumAndStats(ds, cafs.NewMemfileReader(df.FileName(), hashR), &buf, &mu, done)
 
 	go func() {
@@ -310,8 +310,8 @@ func setErrCount(ds *dataset.Dataset, data cafs.File, mu *sync.Mutex, done chan 
 	done <- nil
 }
 
-// setEntryCount set the Entries field of a ds.Structure
-func setEntryCount(ds *dataset.Dataset, data cafs.File, mu *sync.Mutex, done chan error) {
+// setDepthAndEntryCount set the Entries field of a ds.Structure
+func setDepthAndEntryCount(ds *dataset.Dataset, data cafs.File, mu *sync.Mutex, done chan error) {
 	er, err := dsio.NewEntryReader(ds.Structure, data)
 	if err != nil {
 		log.Debug(err.Error())
@@ -320,10 +320,15 @@ func setEntryCount(ds *dataset.Dataset, data cafs.File, mu *sync.Mutex, done cha
 	}
 
 	entries := 0
+	depth := 0
+	var ent dsio.Entry
 	for {
-		if _, err = er.ReadEntry(); err != nil {
+		if ent, err = er.ReadEntry(); err != nil {
 			log.Debug(err.Error())
 			break
+		}
+		if d := getDepth(ent.Value, 0); d > depth {
+			depth = d
 		}
 		entries++
 	}
@@ -334,9 +339,31 @@ func setEntryCount(ds *dataset.Dataset, data cafs.File, mu *sync.Mutex, done cha
 
 	mu.Lock()
 	ds.Structure.Entries = entries
+	ds.Structure.Depth = depth + 1 // add one for the original closure
 	mu.Unlock()
 
 	done <- nil
+}
+
+func getDepth(x interface{}, depth int) int {
+	switch v := x.(type) {
+	case map[string]interface{}:
+		depth++
+		for _, el := range v {
+			if d := getDepth(el, depth); d > depth {
+				depth = d
+			}
+		}
+	case []interface{}:
+		depth++
+		for _, el := range v {
+			if d := getDepth(el, depth); d > depth {
+				depth = d
+			}
+		}
+	}
+
+	return depth
 }
 
 // setChecksumAndStats

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -146,13 +146,13 @@ func TestCreateDataset(t *testing.T) {
 		{"invalid",
 			"", 0, "commit is required"},
 		{"cities",
-			"/map/QmZagVwGP1rUo9zEmdYFaJMvWCyoQ6ASpovtirC6owrKd7", 6, ""},
+			"/map/QmPm1VvN3PjZLuA12NSEUTwCft8JruHPwcL2zmKf4SGnWd", 6, ""},
 		{"all_fields",
-			"/map/QmbVhjG9YfJ8kfMqW8CRdxke9RfKisbaHVzhRoCcJTSoxN", 14, ""},
+			"/map/QmYHRKiQ52CETCBrMZR2c9hh1Je7292YBeD9gjQyWwEhtE", 14, ""},
 		{"cities_no_commit_title",
-			"/map/QmeuGsnqavk67cziEtDEPmBttCpKJsNwufjLCHUjuLJyLQ", 16, ""},
+			"/map/QmRXosHbnSXxVV7cFvnhTfCnzMcqjTj67fYVBKruLeRj9E", 16, ""},
 		{"craigslist",
-			"/map/QmP55iAnLkPpqqnhfg1mcRBqz7tKckm6bdW4kGhT1kRpP1", 20, ""},
+			"/map/QmUAn7Fm8KF2uVDSoafXfEvJj6EErRF9WxiCQtNED2k8HE", 20, ""},
 	}
 
 	for _, c := range cases {

--- a/dsfs/testdata/all_fields/expect.dataset.json
+++ b/dsfs/testdata/all_fields/expect.dataset.json
@@ -13,6 +13,7 @@
   "qri": "ds:0",
   "structure": {
     "checksum": "QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
+    "depth" : 2,
     "entries": 5,
     "errCount": 1,
     "format": "csv",

--- a/dsfs/testdata/cities/expect.dataset.json
+++ b/dsfs/testdata/cities/expect.dataset.json
@@ -15,6 +15,7 @@
   "structure": {
     "checksum": "QmcCcPTqmckdXLBwPQXxfyW2BbFcUT6gqv9oGeWDkrNTyD",
     "entries": 5,
+    "depth" : 2,
     "errCount": 1,
     "format": "csv",
     "formatConfig": {

--- a/dsfs/testdata/craigslist/expect.dataset.json
+++ b/dsfs/testdata/craigslist/expect.dataset.json
@@ -11,6 +11,7 @@
     "checksum": "QmUPfueN4Amv6pyPddi6KRtYFw3dpJKyD4ka95jUgBq9dv",
     "entries": 1200,
     "errCount": 1,
+    "depth" : 5,
     "format": "json",
     "length": 520254,
     "qri": "st:0",

--- a/dsio/csv.go
+++ b/dsio/csv.go
@@ -1,7 +1,6 @@
 package dsio
 
 import (
-	"bufio"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -9,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/dsio/replacecr"
 	"github.com/qri-io/dataset/vals"
 )
 
@@ -25,7 +25,7 @@ func NewCSVReader(st *dataset.Structure, r io.Reader) *CSVReader {
 	// TODO - handle error
 	_, types, _ := terribleHackToGetHeaderRowAndTypes(st)
 
-	csvr := csv.NewReader(ReplaceSoloCarriageReturns(r))
+	csvr := csv.NewReader(replacecr.Reader(r))
 
 	if opts, ok := st.FormatConfig.(*dataset.CSVOptions); ok {
 		csvr.LazyQuotes = opts.LazyQuotes
@@ -273,52 +273,4 @@ func encode(vs []interface{}) ([]string, error) {
 func (w *CSVWriter) Close() error {
 	w.w.Flush()
 	return nil
-}
-
-// ReplaceSoloCarriageReturns wraps an io.Reader, on every call of Read. it looks for
-// for instances of lonely \r replacing them with \r\n before returning to the end consumer
-// lots of files in the wild will come without "proper" line breaks, which irritates go's
-// standard csv package. This'll fix by wrapping the reader passed to csv.NewReader:
-// 		rdr, err := csv.NewReader(ReplaceSoloCarriageReturns(r))
-//
-func ReplaceSoloCarriageReturns(data io.Reader) io.Reader {
-	return crlfReplaceReader{
-		rdr: bufio.NewReader(data),
-	}
-}
-
-// crlfReplaceReader wraps a reader
-type crlfReplaceReader struct {
-	rdr *bufio.Reader
-}
-
-// Read implements io.Reader for crlfReplaceReader
-func (c crlfReplaceReader) Read(p []byte) (n int, err error) {
-	if len(p) == 0 {
-		return
-	}
-
-	for {
-		if n == len(p) {
-			return
-		}
-
-		p[n], err = c.rdr.ReadByte()
-		if err != nil {
-			log.Debug(err.Error())
-			return
-		}
-
-		// any time we encounter \r & still have space, check to see if \n follows
-		// ff next char is not \n, add it in manually
-		if p[n] == '\r' && n < len(p) {
-			if pk, err := c.rdr.Peek(1); (err == nil && pk[0] != '\n') || (err != nil && err.Error() == "EOF") {
-				n++
-				p[n] = '\n'
-			}
-		}
-
-		n++
-	}
-	return
 }

--- a/dsio/csv_test.go
+++ b/dsio/csv_test.go
@@ -240,24 +240,6 @@ a	12	23	"[""foo"",""bar""]"`
 		t.Errorf("output mismatch. %s != %s", buf.String(), expect)
 	}
 }
-
-func TestReplaceSoloCarriageReturns(t *testing.T) {
-	input := []byte("foo\r\rbar\r\nbaz\r\r")
-	expect := []byte("foo\r\n\r\nbar\r\nbaz\r\n\r\n")
-
-	got := make([]byte, 19)
-	n, err := ReplaceSoloCarriageReturns(bytes.NewReader(input)).Read(got)
-	if err != nil && err.Error() != "EOF" {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
-	if n != 19 {
-		t.Errorf("length error. expected: %d, got: %d", 19, n)
-	}
-	if !bytes.Equal(expect, got) {
-		t.Errorf("byte mismatch. expected:\n%v\ngot:\n%v", expect, got)
-	}
-}
-
 func BenchmarkCSVWriterArrays(b *testing.B) {
 	const NumWrites = 1000
 	st := &dataset.Structure{Format: dataset.CSVDataFormat, Schema: dataset.BaseSchemaObject}

--- a/dsio/replacecr/replace_cr.go
+++ b/dsio/replacecr/replace_cr.go
@@ -1,0 +1,57 @@
+// Package replacecr defines a wrapper for replacing solo carriage return characters (\r)
+// with carriage-return + line feed (\r\n)
+package replacecr
+
+import (
+	"bufio"
+	"io"
+)
+
+// Reader wraps an io.Reader. on every call of Read. it looks for
+// for instances of lonely \r replacing them with \r\n before returning to the end consumer
+// lots of files in the wild will come without "proper" line breaks, which irritates go's
+// standard csv package. This'll fix by wrapping the reader passed to csv.NewReader:
+// 		rdr, err := csv.NewReader(replacecr.Reader(r))
+// because Reader adds '\n' characters, the number of bytes reported from the underlying
+// reader can/will differ from if the reader were read from directly. This can cause issues
+// with checksums and byte counts. Use with caution.
+func Reader(data io.Reader) io.Reader {
+	return crlfReplaceReader{
+		rdr: bufio.NewReader(data),
+	}
+}
+
+// crlfReplaceReader wraps a reader
+type crlfReplaceReader struct {
+	rdr *bufio.Reader
+}
+
+// Read implements io.Reader for crlfReplaceReader
+func (c crlfReplaceReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return
+	}
+
+	for {
+		if n == len(p) {
+			return
+		}
+
+		p[n], err = c.rdr.ReadByte()
+		if err != nil {
+			return
+		}
+
+		// any time we encounter \r & still have space, check to see if \n follows
+		// ff next char is not \n, add it in manually
+		if p[n] == '\r' && n < len(p) {
+			if pk, err := c.rdr.Peek(1); (err == nil && pk[0] != '\n') || (err != nil && err.Error() == "EOF") {
+				n++
+				p[n] = '\n'
+			}
+		}
+
+		n++
+	}
+	return
+}

--- a/dsio/replacecr/replace_cr.go
+++ b/dsio/replacecr/replace_cr.go
@@ -53,5 +53,4 @@ func (c crlfReplaceReader) Read(p []byte) (n int, err error) {
 
 		n++
 	}
-	return
 }

--- a/dsio/replacecr/replace_cr.go
+++ b/dsio/replacecr/replace_cr.go
@@ -13,8 +13,9 @@ import (
 // standard csv package. This'll fix by wrapping the reader passed to csv.NewReader:
 // 		rdr, err := csv.NewReader(replacecr.Reader(r))
 // because Reader adds '\n' characters, the number of bytes reported from the underlying
-// reader can/will differ from if the reader were read from directly. This can cause issues
-// with checksums and byte counts. Use with caution.
+// reader can/will differ from what the underlyng reader would return
+// if read from directly. This can cause issues with checksums and byte counts.
+// Use with caution.
 func Reader(data io.Reader) io.Reader {
 	return crlfReplaceReader{
 		rdr: bufio.NewReader(data),

--- a/dsio/replacecr/replace_cr_test.go
+++ b/dsio/replacecr/replace_cr_test.go
@@ -1,0 +1,23 @@
+package replacecr
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	input := []byte("foo\r\rbar\r\nbaz\r\r")
+	expect := []byte("foo\r\n\r\nbar\r\nbaz\r\n\r\n")
+
+	got := make([]byte, 19)
+	n, err := Reader(bytes.NewReader(input)).Read(got)
+	if err != nil && err.Error() != "EOF" {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if n != 19 {
+		t.Errorf("length error. expected: %d, got: %d", 19, n)
+	}
+	if !bytes.Equal(expect, got) {
+		t.Errorf("byte mismatch. expected:\n%v\ngot:\n%v", expect, got)
+	}
+}

--- a/dstest/dstest_test.go
+++ b/dstest/dstest_test.go
@@ -43,12 +43,12 @@ func TestReadInputTransformScript(t *testing.T) {
 }
 
 func TestNewTestCaseFromDir(t *testing.T) {
-	if _, err := NewTestCaseFromDir("testdata"); err == nil {
+	var err error
+	if _, err = NewTestCaseFromDir("testdata"); err == nil {
 		t.Errorf("expected error")
 		return
-	} else {
-		t.Log(err)
 	}
+	t.Log(err)
 
 	tc, err := NewTestCaseFromDir("testdata/complete")
 	if err != nil {

--- a/structure.go
+++ b/structure.go
@@ -298,12 +298,6 @@ func UnmarshalStructure(v interface{}) (*Structure, error) {
 	}
 }
 
-// AbstractTableName prepends a given index with "t"
-// t1, t2, t3, ...
-func AbstractTableName(i int) string {
-	return fmt.Sprintf("t%d", i+1)
-}
-
 // AbstractColumnName is the "base26" value of a column name
 // to make short, sql-valid, deterministic column names
 func AbstractColumnName(i int) string {

--- a/structure.go
+++ b/structure.go
@@ -39,6 +39,8 @@ type Structure struct {
 	// Compression specifies any compression on the source data,
 	// if empty assume no compression
 	Compression compression.Type `json:"compression,omitempty"`
+	// Maximum nesting level of composite types in the dataset. eg: depth 1 == [], depth 2 == [[]]
+	Depth int `json:"depth,omitempty"`
 	// Encoding specifics character encoding, assume utf-8 if not specified
 	Encoding string `json:"encoding,omitempty"`
 	// ErrCount is the number of errors returned by validating data
@@ -112,6 +114,7 @@ func (s *Structure) Hash() (string, error) {
 type _structure struct {
 	Checksum     string                 `json:"checksum,omitempty"`
 	Compression  compression.Type       `json:"compression,omitempty"`
+	Depth        int                    `json:"depth,omitempty"`
 	Encoding     string                 `json:"encoding,omitempty"`
 	Entries      int                    `json:"entries,omitempty"`
 	ErrCount     int                    `json:"errCount"`
@@ -146,6 +149,7 @@ func (s Structure) MarshalJSONObject() ([]byte, error) {
 	return json.Marshal(&_structure{
 		Checksum:     s.Checksum,
 		Compression:  s.Compression,
+		Depth:        s.Depth,
 		Encoding:     s.Encoding,
 		Entries:      s.Entries,
 		ErrCount:     s.ErrCount,
@@ -186,6 +190,7 @@ func (s *Structure) UnmarshalJSON(data []byte) (err error) {
 	*s = Structure{
 		Checksum:     _s.Checksum,
 		Compression:  _s.Compression,
+		Depth:        _s.Depth,
 		Encoding:     _s.Encoding,
 		Entries:      _s.Entries,
 		ErrCount:     _s.ErrCount,
@@ -202,6 +207,7 @@ func (s *Structure) UnmarshalJSON(data []byte) (err error) {
 func (s *Structure) IsEmpty() bool {
 	return s.Checksum == "" &&
 		s.Compression == compression.None &&
+		s.Depth == 0 &&
 		s.Encoding == "" &&
 		s.Entries == 0 &&
 		s.ErrCount == 0 &&
@@ -237,6 +243,9 @@ func (s *Structure) Assign(structures ...*Structure) {
 		}
 		if st.Compression != compression.None {
 			s.Compression = st.Compression
+		}
+		if st.Depth != 0 {
+			s.Depth = st.Depth
 		}
 		if st.Encoding != "" {
 			s.Encoding = st.Encoding
@@ -349,6 +358,7 @@ func (s Structure) Encode() *StructurePod {
 	cs := &StructurePod{
 		Checksum:    s.Checksum,
 		Compression: s.Compression.String(),
+		Depth:       s.Depth,
 		Encoding:    s.Encoding,
 		ErrCount:    s.ErrCount,
 		Entries:     s.Entries,
@@ -370,6 +380,7 @@ func (s Structure) Encode() *StructurePod {
 func (s *Structure) Decode(cs *StructurePod) (err error) {
 	dst := Structure{
 		Checksum: cs.Checksum,
+		Depth:    cs.Depth,
 		Encoding: cs.Encoding,
 		ErrCount: cs.ErrCount,
 		Entries:  cs.Entries,
@@ -414,6 +425,7 @@ func (s *Structure) Decode(cs *StructurePod) (err error) {
 type StructurePod struct {
 	Checksum     string                 `json:"checksum,omitempty"`
 	Compression  string                 `json:"compression,omitempty"`
+	Depth        int                    `json:"depth,omitempty"`
 	Encoding     string                 `json:"encoding,omitempty"`
 	ErrCount     int                    `json:"errCount"`
 	Entries      int                    `json:"entries,omitempty"`
@@ -435,6 +447,9 @@ func (sp *StructurePod) Assign(sps ...*StructurePod) {
 
 		if s.Checksum != "" {
 			sp.Checksum = s.Checksum
+		}
+		if s.Depth != 0 {
+			sp.Depth = s.Depth
 		}
 		if s.Compression != "" {
 			sp.Compression = s.Compression

--- a/structure_test.go
+++ b/structure_test.go
@@ -71,6 +71,7 @@ func TestStructureIsEmpty(t *testing.T) {
 	}{
 		{&Structure{Checksum: "a"}},
 		{&Structure{Compression: compression.Tar}},
+		{&Structure{Depth: 1}},
 		{&Structure{Encoding: "a"}},
 		{&Structure{Entries: 1}},
 		{&Structure{ErrCount: 1}},

--- a/structure_test.go
+++ b/structure_test.go
@@ -110,36 +110,29 @@ func TestStructureSetPath(t *testing.T) {
 
 func TestStructureAssign(t *testing.T) {
 	expect := &Structure{
-		Format: CSVDataFormat,
-		Length: 2503,
-		// TODO - restore
-		// Schema: &Schema{
-		// 	Fields: []*Field{
-		// 		{Type: datatypes.String, Name: "foo"},
-		// 		{Type: datatypes.Integer, Name: "bar"},
-		// 		{Description: "bat"},
-		// 	},
-		// },
+		Length:      2503,
+		Checksum:    "hey",
+		Compression: compression.Gzip,
+		Depth:       11,
+		ErrCount:    12,
+		Encoding:    "UTF-8",
+		Entries:     3000000000,
+		Format:      CSVDataFormat,
 	}
 	got := &Structure{
-		Format: CSVDataFormat,
-		// Schema: &Schema{
-		// 	Fields: []*Field{
-		// 		{Type: datatypes.String},
-		// 		{Type: datatypes.Integer},
-		// 	},
-		// },
+		Length: 2000,
+		Format: JSONDataFormat,
 	}
 
 	got.Assign(&Structure{
-		Length: 2503,
-		// Schema: &Schema{
-		// 	Fields: []*Field{
-		// 		{Name: "foo"},
-		// 		{Name: "bar"},
-		// 		{Description: "bat"},
-		// 	},
-		// },
+		Length:      2503,
+		Checksum:    "hey",
+		Compression: compression.Gzip,
+		Depth:       11,
+		ErrCount:    12,
+		Encoding:    "UTF-8",
+		Entries:     3000000000,
+		Format:      CSVDataFormat,
 	})
 
 	if err := CompareStructures(expect, got); err != nil {
@@ -345,6 +338,7 @@ func TestStructureDecode(t *testing.T) {
 func TestStructurePodAssign(t *testing.T) {
 	expect := &StructurePod{
 		Format:      "format",
+		Depth:       24,
 		Length:      2503,
 		Compression: "nah",
 		Encoding:    "UTF-3000",
@@ -359,6 +353,7 @@ func TestStructurePodAssign(t *testing.T) {
 
 	got.Assign(&StructurePod{
 		Length:      2503,
+		Depth:       24,
 		Compression: "nah",
 		Encoding:    "UTF-3000",
 		ErrCount:    50,

--- a/subset/subset_test.go
+++ b/subset/subset_test.go
@@ -40,7 +40,7 @@ func TestLoadPreview(t *testing.T) {
 		t.Error(err)
 	}
 
-	expect := "4eca3a461dafd9477a14ef5c0a71107923c8c827"
+	expect := "3f4b42ad33241e81da3e874e772cbf99d0e7c949"
 	sum := dstest.DatasetPodChecksum(res)
 	if expect != sum {
 		t.Errorf("dataset pod checksum mismatch. expected: %s, got: %s", expect, sum)

--- a/testdata/structures/hours.json
+++ b/testdata/structures/hours.json
@@ -1,6 +1,7 @@
 {
   "format": "csv",
   "formatOptions": null,
+  "depth" : 2,
   "schema": {
     "type": "array",
     "items": {

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -131,6 +131,7 @@ var Hours = &Dataset{
 
 var HoursStructure = &Structure{
 	Format: CSVDataFormat,
+	Depth:  2,
 	Schema: jsonschema.Must(`{
 		"type": "array",
 		"items": {


### PR DESCRIPTION
This all secretly about tabular data, and properly detecting when we're dealing with it. Because JSON-schema is more about validation & description then definite requirements, we need another heuristic for checking if a dataset is "a table". 

The better way to phrase this in my opinion is to check the maximum number of dimensions a dataset contains:

| depth | example |
|-------|----------|
| 0 | `"hello"` |
| 1 | `["hello", "friend"]` |
| 2 | `[["hello", "friend"], ["how","are","you"]]` | 
| 3 | `[[  "hello",{ "friend" : true }], ["how,"are","you" ]]` |

Note in that last example there's only one place where the nesting level is 3 closures deep, but the depth is still 3.

We could have called this "maxDepth", but that implies there's a "minDepth", which doesn't make any sense (it would always be zero). We could have also called this dimensions, but in my opinion "dimensions" should be reserved for data that has a _uniform_ number of dimensions (for example, datasets that are always arrays of arrays of arrays, aka 3 dimensional data).  So, Depth.

Once we land this we can change the frontend to check for a `depth` property, and if it's 2, we _know_ we can safely display a table without any complications.