### PR TITLE
refactor(CreateDataset): first step toward CreateDataset as a write only (to the store) function

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -243,7 +243,7 @@ func prepareDataset(store cafs.Filestore, ds, dsPrev *dataset.Dataset, bf, bfPre
 	tasks := 3
 
 	go setErrCount(ds, cafs.NewMemfileReader(bf.FileName(), errR), &mu, done)
-	go setEntryCount(ds, cafs.NewMemfileReader(bf.FileName(), entryR), &mu, done)
+	go setDepthAndEntryCount(ds, cafs.NewMemfileReader(bf.FileName(), entryR), &mu, done)
 	go setChecksumAndStats(ds, cafs.NewMemfileReader(bf.FileName(), hashR), &buf, &mu, done)
 
 	go func() {

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -186,7 +186,7 @@ func CreateDataset(store cafs.Filestore, ds, dsPrev *dataset.Dataset, bf, bfPrev
 		return
 	}
 
-	if !(dsPrev == nil || dsPrev.IsEmpty()) {
+	if dsPrev != nil && !dsPrev.IsEmpty() {
 		if err = DerefDataset(store, dsPrev); err != nil {
 			log.Debug(err.Error())
 			return
@@ -231,7 +231,7 @@ func prepareDataset(store cafs.Filestore, ds, dsPrev *dataset.Dataset, bf, bfPre
 		return nil, "", fmt.Errorf("datafile or previous datafile needed")
 	}
 
-	if bf == nil && bfPrev != nil {
+	if bf == nil {
 		bf = bfPrev
 	}
 

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -138,21 +138,29 @@ func TestCreateDataset(t *testing.T) {
 	cases := []struct {
 		casePath   string
 		resultPath string
+		prev       *dataset.Dataset
 		repoFiles  int // expected total count of files in repo after test execution
 		err        string
 	}{
 		{"invalid_reference",
-			"", 0, "error loading dataset commit: error loading commit file: datastore: key not found"},
+			"", nil, 0, "error loading dataset commit: error loading commit file: datastore: key not found"},
 		{"invalid",
-			"", 0, "commit is required"},
+			"", nil, 0, "commit is required"},
 		{"cities",
-			"/map/QmPm1VvN3PjZLuA12NSEUTwCft8JruHPwcL2zmKf4SGnWd", 6, ""},
+			"/map/QmPm1VvN3PjZLuA12NSEUTwCft8JruHPwcL2zmKf4SGnWd", nil, 6, ""},
 		{"all_fields",
-			"/map/QmYHRKiQ52CETCBrMZR2c9hh1Je7292YBeD9gjQyWwEhtE", 14, ""},
+			"/map/QmYHRKiQ52CETCBrMZR2c9hh1Je7292YBeD9gjQyWwEhtE", nil, 14, ""},
 		{"cities_no_commit_title",
-			"/map/QmRXosHbnSXxVV7cFvnhTfCnzMcqjTj67fYVBKruLeRj9E", 16, ""},
+			"/map/QmX3JQrS5oZ8SdkJQRMhmV4qRD2tBMwcwktoECbmK4BpfH", nil, 16, ""},
 		{"craigslist",
-			"/map/QmUAn7Fm8KF2uVDSoafXfEvJj6EErRF9WxiCQtNED2k8HE", 20, ""},
+			"/map/QmUAn7Fm8KF2uVDSoafXfEvJj6EErRF9WxiCQtNED2k8HE", nil, 20, ""},
+		// should error when previous dataset won't dereference.
+		{"craigslist",
+			"", &dataset.Dataset{Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path"))}, 20, "error loading dataset structure: error loading structure file: datastore: key not found"},
+		// should error when previous dataset isn't valid. Aka, when it isn't empty, but missing
+		// either structure or commit. Commit is checked for first.
+		{"craigslist",
+			"", &dataset.Dataset{Meta: &dataset.Meta{Title: "previous"}, Structure: nil}, 20, "commit is required"},
 	}
 
 	for _, c := range cases {
@@ -178,7 +186,7 @@ func TestCreateDataset(t *testing.T) {
 			tc.Input.Viz.Script = vs
 		}
 
-		path, err := CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, false)
+		path, err := CreateDataset(store, tc.Input, c.prev, tc.BodyFile(), nil, privKey, false)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("%s: error mismatch. expected: '%s', got: '%s'", tc.Name, c.err, err)
 			continue
@@ -260,6 +268,8 @@ func TestCreateDataset(t *testing.T) {
 			panic(err)
 		}
 	}
+
+	// case: previous dataset isn't valid
 }
 
 func TestWriteDataset(t *testing.T) {
@@ -385,5 +395,75 @@ func TestWriteDataset(t *testing.T) {
 			t.Log(string(d))
 			continue
 		}
+	}
+}
+
+func TestGenerateCommitMessage(t *testing.T) {
+	cases := []struct {
+		ds, prev *dataset.Dataset
+		expected string
+		errMsg   string
+	}{
+		// empty prev
+		{&dataset.Dataset{Meta: &dataset.Meta{Title: "new dataset"}}, &dataset.Dataset{}, "created dataset", ""},
+		// different datasets
+		{&dataset.Dataset{Meta: &dataset.Meta{Title: "changes to dataset"}}, &dataset.Dataset{Meta: &dataset.Meta{Title: "new dataset"}}, "Meta: 1 change\n\t- modified title", ""},
+		// same datasets
+		{&dataset.Dataset{Meta: &dataset.Meta{Title: "same dataset"}}, &dataset.Dataset{Meta: &dataset.Meta{Title: "same dataset"}}, "", "no changes detected"},
+	}
+
+	for i, c := range cases {
+		got, err := generateCommitMsg(c.ds, c.prev)
+		if err != nil && c.errMsg != err.Error() {
+			t.Errorf("case %d, error mismatch, expect: %s, got: %s", i, c.errMsg, err.Error())
+			continue
+		}
+		if c.expected != got {
+			t.Errorf("case %d, message mismatch, expect: %s, got: %s", i, c.expected, got)
+		}
+	}
+}
+
+func TestCleanTitleAndMessage(t *testing.T) {
+	ds := &dataset.Dataset{Commit: &dataset.Commit{}}
+	cases := []struct {
+		title         string
+		message       string
+		description   string
+		expectTitle   string
+		expectMessage string
+	}{
+		// all should be over 70 characters
+		// no title, no message, no description
+		{"", "", "", "", ""},
+		// no title, no message, description
+		{"", "", "This is the description we are adding woooo", "This is the description we are adding woooo", ""},
+		// no title, no message, long description
+		{"", "", "need to make sure this description is over 70 characters long so that we can test to see if the cleaning of the title works", "need to make sure this description is over 70 characters long so ...", "...that we can test to see if the cleaning of the title works"},
+		// no title, message, no description
+		{"", "This text should move to the title", "", "This text should move to the title", ""},
+		// title, no message, no description
+		{"Yay, a title", "", "", "Yay, a title", ""},
+		// no title, message, description
+		{"", "And this text should stay in the message", "This description should move to the title", "This description should move to the title", "And this text should stay in the message"},
+		// title, message, no description
+		{"We have a title", "And we have a message", "", "We have a title", "And we have a message"},
+		// title, no message, description
+		{"We have a title", "", "This description will get squashed which I'm not sure what I feel about that", "We have a title", ""},
+		// long title, and message
+		{"This title is very long and I want to make sure that it works correctly with also having a message. wooo", "This message should still exist", "", "This title is very long and I want to make sure that it works ...", "...correctly with also having a message. wooo\nThis message should still exist"},
+	}
+	for i, c := range cases {
+		ds.Commit.Title = c.title
+		ds.Commit.Message = c.message
+
+		cleanTitleAndMessage(&ds.Commit.Title, &ds.Commit.Message, c.description)
+		if c.expectTitle != ds.Commit.Title {
+			t.Errorf("case %d, title mismatch, expect: %s, got: %s", i, c.expectTitle, ds.Commit.Title)
+		}
+		if c.expectMessage != ds.Commit.Message {
+			t.Errorf("case %d, message mismatch, expect: %s, got: %s", i, c.expectMessage, ds.Commit.Message)
+		}
+
 	}
 }

--- a/dsfs/testdata/cities_no_commit_title/input.dataset.json
+++ b/dsfs/testdata/cities_no_commit_title/input.dataset.json
@@ -38,10 +38,5 @@
         ]
       }
     }
-  },
-  "visconfig": {
-    "qri": "vc:0",
-    "format": "example format",
-    "visualizations": "example visualization"
   }
 }

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -106,7 +106,7 @@ func TestLoadTransformScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	path, err := CreateDataset(store, tc.Input, tc.BodyFile(), privKey, true)
+	path, err := CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -125,7 +125,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	tc.Input.Transform.ScriptPath = transformPath.String()
-	path, err = CreateDataset(store, tc.Input, tc.BodyFile(), privKey, true)
+	path, err = CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/dsfs/viz_test.go
+++ b/dsfs/viz_test.go
@@ -48,7 +48,7 @@ func TestLoadVizScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	path, err := CreateDataset(store, tc.Input, tc.BodyFile(), privKey, true)
+	path, err := CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -67,7 +67,7 @@ func TestLoadVizScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	tc.Input.Viz.ScriptPath = vizPath.String()
-	path, err = CreateDataset(store, tc.Input, tc.BodyFile(), privKey, true)
+	path, err = CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/subset/subset_test.go
+++ b/subset/subset_test.go
@@ -23,7 +23,7 @@ func addMovies(t *testing.T, s cafs.Filestore) string {
 		t.Fatal(err)
 	}
 
-	path, err := dsfs.CreateDataset(s, tc.Input, tc.BodyFile(), dstest.PrivKey, true)
+	path, err := dsfs.CreateDataset(s, tc.Input, nil, tc.BodyFile(), nil, dstest.PrivKey, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
closes #164 

This fixes a bug in Qri, where you can't do a dry-run on a dataset that has a previous version.

This also changes some of how our commit message is generated. Removed references to adding a commit title from qri, and put it all in `generateCommitMsg`

Also made a note where we can perhaps use another wrapper function `generateCommit` that takes a dataset and a previous dataset, and runs `generateCommitMsg`, cleans the title and message, signs the commit, etc.

Also pushes the test coverage back up to 80% what whaaaat