### PR TITLE
refactor: change path representations to string values

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -5,17 +5,15 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
-
-	"github.com/ipfs/go-datastore"
 )
 
 func TestCommit(t *testing.T) {
-	ref := NewCommitRef(datastore.NewKey("a"))
+	ref := NewCommitRef("a")
 	if !ref.IsEmpty() {
 		t.Errorf("expected reference to be empty")
 	}
 
-	if !ref.Path().Equal(datastore.NewKey("a")) {
+	if ref.path != "a" {
 		t.Errorf("expected ref path to equal /a")
 	}
 }
@@ -25,8 +23,8 @@ func TestCommitSetPath(t *testing.T) {
 		path   string
 		expect *Commit
 	}{
-		{"", &Commit{path: datastore.Key{}}},
-		{"path", &Commit{path: datastore.NewKey("path")}},
+		{"", &Commit{}},
+		{"path", &Commit{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -43,7 +41,7 @@ func TestCommitAssign(t *testing.T) {
 	t1 := time.Now()
 	doug := &User{ID: "doug_id", Email: "doug@example.com"}
 	expect := &Commit{
-		path:      datastore.NewKey("a"),
+		path:      "a",
 		Qri:       KindCommit,
 		Author:    doug,
 		Timestamp: t1,
@@ -62,7 +60,7 @@ func TestCommitAssign(t *testing.T) {
 		Qri:    KindCommit,
 		Title:  "expect title",
 	}, &Commit{
-		path:      datastore.NewKey("a"),
+		path:      "a",
 		Timestamp: t1,
 		Message:   "expect message",
 		Signature: "sig",
@@ -127,7 +125,7 @@ func TestCommitMarshalJSON(t *testing.T) {
 		}
 	}
 
-	strbytes, err := json.Marshal(&Commit{path: datastore.NewKey("/path/to/dataset")})
+	strbytes, err := json.Marshal(&Commit{path: "/path/to/dataset"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return
@@ -199,7 +197,7 @@ func TestCommitUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if strq.path.String() != path {
+	if strq.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strq.path)
 		return
 	}
@@ -236,7 +234,7 @@ func TestCommitCoding(t *testing.T) {
 		{},
 		{Author: &User{Email: "foo"}},
 		{Message: "foo"},
-		{path: datastore.NewKey("/foo")},
+		{path: "/foo"},
 		{Qri: KindCommit},
 		{Signature: "foo"},
 		{Timestamp: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC)},

--- a/compare_test.go
+++ b/compare_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/dataset/compression"
 	"github.com/qri-io/jsonschema"
 )
@@ -120,7 +119,7 @@ func TestCompareVizs(t *testing.T) {
 
 func TestCompareCommits(t *testing.T) {
 	c1 := &Commit{
-		path:    datastore.NewKey("/foo"),
+		path:    "/foo",
 		Title:   "foo",
 		Message: "message",
 		Qri:     KindCommit,
@@ -163,7 +162,7 @@ func TestCompareTransforms(t *testing.T) {
 		ScriptPath:    "foo.star",
 		Structure:     AirportCodes.Structure,
 		Resources: map[string]*TransformResource{
-			"airports": &TransformResource{Path: AirportCodes.Path().String()},
+			"airports": &TransformResource{Path: AirportCodes.Path()},
 		},
 	}
 	cases := []struct {
@@ -181,7 +180,7 @@ func TestCompareTransforms(t *testing.T) {
 		{&Transform{ScriptPath: "a"}, &Transform{ScriptPath: "b"}, "ScriptPath: a != b"},
 		{&Transform{}, &Transform{Structure: AirportCodes.Structure}, "Structure: nil: <nil> != <not nil>"},
 		{&Transform{Resources: map[string]*TransformResource{
-			"airports": &TransformResource{Path: AirportCodes.Path().String()},
+			"airports": &TransformResource{Path: AirportCodes.Path()},
 		}}, &Transform{Resources: map[string]*TransformResource{}}, "Resource 'airports': nil: <not nil> != <nil>"},
 	}
 

--- a/data_format_config_test.go
+++ b/data_format_config_test.go
@@ -79,7 +79,7 @@ func TestNewCSVOptions(t *testing.T) {
 			}
 
 			if csvo.HeaderRow != c.res.HeaderRow {
-				fmt.Errorf("case %d HeaderRow expected: %t, got: %t", i, csvo.HeaderRow, c.res.HeaderRow)
+				t.Errorf("case %d HeaderRow expected: %t, got: %t", i, csvo.HeaderRow, c.res.HeaderRow)
 				continue
 			}
 		}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -7,8 +7,6 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
-
-	"github.com/ipfs/go-datastore"
 )
 
 func TestDatasetSetPath(t *testing.T) {
@@ -16,8 +14,8 @@ func TestDatasetSetPath(t *testing.T) {
 		path   string
 		expect *Dataset
 	}{
-		{"", &Dataset{path: datastore.Key{}}},
-		{"path", &Dataset{path: datastore.NewKey("path")}},
+		{"", &Dataset{}},
+		{"path", &Dataset{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -35,7 +33,7 @@ func TestDatasetAssign(t *testing.T) {
 	cases := []struct {
 		in *Dataset
 	}{
-		{&Dataset{path: datastore.NewKey("/a")}},
+		{&Dataset{path: "/a"}},
 		{&Dataset{Structure: &Structure{Format: CSVDataFormat}}},
 		{&Dataset{Transform: &Transform{ScriptPath: "some_transform_script.star"}}},
 		{&Dataset{Commit: &Commit{Title: "foo"}}},
@@ -146,7 +144,7 @@ func TestDatasetMarshalJSON(t *testing.T) {
 		return
 	}
 
-	strbytes, err := json.Marshal(&Dataset{path: datastore.NewKey("/path/to/dataset")})
+	strbytes, err := json.Marshal(&Dataset{path: "/path/to/dataset"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return
@@ -194,7 +192,7 @@ func TestDatasetUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if strds.path.String() != path {
+	if strds.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strds.path)
 		return
 	}

--- a/dsfs/body.go
+++ b/dsfs/body.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
@@ -12,7 +11,7 @@ import (
 
 // LoadBody loads the data this dataset points to from the store
 func LoadBody(store cafs.Filestore, ds *dataset.Dataset) (cafs.File, error) {
-	return store.Get(datastore.NewKey(ds.BodyPath))
+	return store.Get(ds.BodyPath)
 }
 
 // LoadRows loads a slice of raw bytes inside a limit/offset row range

--- a/dsfs/commit_msg.go
+++ b/dsfs/commit_msg.go
@@ -3,29 +3,28 @@ package dsfs
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 )
 
 // SaveCommit writes a commit message to a cafs
-func SaveCommit(store cafs.Filestore, s *dataset.Commit, pin bool) (path datastore.Key, err error) {
+func SaveCommit(store cafs.Filestore, s *dataset.Commit, pin bool) (path string, err error) {
 	file, err := JSONFile(PackageFileCommit.String(), s)
 	if err != nil {
 		log.Debug(err.Error())
-		return datastore.NewKey(""), fmt.Errorf("error saving json commit file: %s", err.Error())
+		return "", fmt.Errorf("error saving json commit file: %s", err.Error())
 	}
 	return store.Put(file, pin)
 }
 
 // LoadCommit loads a commit from a given path in a store
-func LoadCommit(store cafs.Filestore, path datastore.Key) (st *dataset.Commit, err error) {
-	path = PackageKeypath(store, path, PackageFileCommit)
+func LoadCommit(store cafs.Filestore, path string) (st *dataset.Commit, err error) {
+	path = PackageFilepath(store, path, PackageFileCommit)
 	return loadCommit(store, path)
 }
 
 // loadCommit assumes the provided path is valid
-func loadCommit(store cafs.Filestore, path datastore.Key) (st *dataset.Commit, err error) {
+func loadCommit(store cafs.Filestore, path string) (st *dataset.Commit, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		log.Debug(err.Error())

--- a/dsfs/commit_msg_test.go
+++ b/dsfs/commit_msg_test.go
@@ -1,11 +1,10 @@
 package dsfs
 
 import (
-	"github.com/qri-io/dataset"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
+	"github.com/qri-io/dataset"
 )
 
 func TestSaveCommit(t *testing.T) {
@@ -49,13 +48,13 @@ func TestLoadCommit(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	_, err = LoadCommit(store, datastore.NewKey("/bad/path"))
+	_, err = LoadCommit(store, "/bad/path")
 	if err == nil {
 		t.Errorf("expected loading a bad path to error. got nil")
 		return
 	}
 
-	expect := "error loading commit file: datastore: key not found"
+	expect := "error loading commit file: cafs: path not found"
 	if err.Error() != expect {
 		t.Errorf("error mismatch. expected: '%s', got: '%s'", expect, err.Error())
 	}

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
@@ -63,26 +62,26 @@ func TestLoadDataset(t *testing.T) {
 		ds  *dataset.Dataset
 		err string
 	}{
-		{dataset.NewDatasetRef(datastore.NewKey("/bad/path")),
-			"error loading dataset: error getting file bytes: datastore: key not found"},
+		{dataset.NewDatasetRef("/bad/path"),
+			"error loading dataset: error getting file bytes: cafs: path not found"},
 		{&dataset.Dataset{
-			Meta: dataset.NewMetaRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset metadata: error loading metadata file: datastore: key not found"},
+			Meta: dataset.NewMetaRef("/bad/path"),
+		}, "error loading dataset metadata: error loading metadata file: cafs: path not found"},
 		{&dataset.Dataset{
-			Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset structure: error loading structure file: datastore: key not found"},
+			Structure: dataset.NewStructureRef("/bad/path"),
+		}, "error loading dataset structure: error loading structure file: cafs: path not found"},
 		{&dataset.Dataset{
-			Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset structure: error loading structure file: datastore: key not found"},
+			Structure: dataset.NewStructureRef("/bad/path"),
+		}, "error loading dataset structure: error loading structure file: cafs: path not found"},
 		{&dataset.Dataset{
-			Transform: dataset.NewTransformRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset transform: error loading transform raw data: datastore: key not found"},
+			Transform: dataset.NewTransformRef("/bad/path"),
+		}, "error loading dataset transform: error loading transform raw data: cafs: path not found"},
 		{&dataset.Dataset{
-			Commit: dataset.NewCommitRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset commit: error loading commit file: datastore: key not found"},
+			Commit: dataset.NewCommitRef("/bad/path"),
+		}, "error loading dataset commit: error loading commit file: cafs: path not found"},
 		{&dataset.Dataset{
-			Viz: dataset.NewVizRef(datastore.NewKey("/bad/path")),
-		}, "error loading dataset viz: error loading viz file: datastore: key not found"},
+			Viz: dataset.NewVizRef("/bad/path"),
+		}, "error loading dataset viz: error loading viz file: cafs: path not found"},
 	}
 
 	for i, c := range cases {
@@ -143,7 +142,7 @@ func TestCreateDataset(t *testing.T) {
 		err        string
 	}{
 		{"invalid_reference",
-			"", nil, 0, "error loading dataset commit: error loading commit file: datastore: key not found"},
+			"", nil, 0, "error loading dataset commit: error loading commit file: cafs: path not found"},
 		{"invalid",
 			"", nil, 0, "commit is required"},
 		{"cities",
@@ -156,7 +155,7 @@ func TestCreateDataset(t *testing.T) {
 			"/map/QmUAn7Fm8KF2uVDSoafXfEvJj6EErRF9WxiCQtNED2k8HE", nil, 20, ""},
 		// should error when previous dataset won't dereference.
 		{"craigslist",
-			"", &dataset.Dataset{Structure: dataset.NewStructureRef(datastore.NewKey("/bad/path"))}, 20, "error loading dataset structure: error loading structure file: datastore: key not found"},
+			"", &dataset.Dataset{Structure: dataset.NewStructureRef("/bad/path")}, 20, "error loading dataset structure: error loading structure file: cafs: path not found"},
 		// should error when previous dataset isn't valid. Aka, when it isn't empty, but missing
 		// either structure or commit. Commit is checked for first.
 		{"craigslist",
@@ -193,9 +192,8 @@ func TestCreateDataset(t *testing.T) {
 		}
 
 		if c.err == "" {
-			resultPath := datastore.NewKey(c.resultPath)
-			if !resultPath.Equal(path) {
-				t.Errorf("%s: result path mismatch: expected: '%s', got: '%s'", tc.Name, resultPath, path)
+			if c.resultPath != path {
+				t.Errorf("%s: result path mismatch: expected: '%s', got: '%s'", tc.Name, c.resultPath, path)
 			}
 
 			if len(store.Files) != c.repoFiles {
@@ -207,7 +205,7 @@ func TestCreateDataset(t *testing.T) {
 				continue
 			}
 
-			ds, err := LoadDataset(store, resultPath)
+			ds, err := LoadDataset(store, c.resultPath)
 			if err != nil {
 				t.Errorf("%s: error loading dataset: %s", tc.Name, err.Error())
 				continue
@@ -242,7 +240,7 @@ func TestCreateDataset(t *testing.T) {
 
 	// Case: no changes in dataset
 	expectedErr = "error saving: no changes detected"
-	dsPrev, err := LoadDataset(store, datastore.NewKey(cases[2].resultPath))
+	dsPrev, err := LoadDataset(store, cases[2].resultPath)
 	ds.PreviousPath = cases[2].resultPath
 	if err != nil {
 		t.Errorf("case no changes in dataset, error loading previous dataset file: %s", err.Error())

--- a/dsfs/meta.go
+++ b/dsfs/meta.go
@@ -3,29 +3,28 @@ package dsfs
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 )
 
 // SaveMeta saves a query's metadata to a given store
-func SaveMeta(store cafs.Filestore, s *dataset.Meta, pin bool) (path datastore.Key, err error) {
+func SaveMeta(store cafs.Filestore, s *dataset.Meta, pin bool) (path string, err error) {
 	file, err := JSONFile(PackageFileMeta.String(), s)
 	if err != nil {
 		log.Debug(err.Error())
-		return datastore.NewKey(""), fmt.Errorf("error saving json metadata file: %s", err.Error())
+		return "", fmt.Errorf("error saving json metadata file: %s", err.Error())
 	}
 	return store.Put(file, pin)
 }
 
 // LoadMeta loads a metadata from a given path in a store
-func LoadMeta(store cafs.Filestore, path datastore.Key) (md *dataset.Meta, err error) {
-	path = PackageKeypath(store, path, PackageFileMeta)
+func LoadMeta(store cafs.Filestore, path string) (md *dataset.Meta, err error) {
+	path = PackageFilepath(store, path, PackageFileMeta)
 	return loadMeta(store, path)
 }
 
 // loadMeta assumes the provided path is valid
-func loadMeta(store cafs.Filestore, path datastore.Key) (md *dataset.Meta, err error) {
+func loadMeta(store cafs.Filestore, path string) (md *dataset.Meta, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		log.Debug(err.Error())

--- a/dsfs/package.go
+++ b/dsfs/package.go
@@ -1,7 +1,6 @@
 package dsfs
 
 import (
-	"github.com/ipfs/go-datastore"
 	"path/filepath"
 	"strings"
 
@@ -82,6 +81,8 @@ func (p PackageFile) Filename() string {
 func PackageFilepath(store cafs.Filestore, path string, pf PackageFile) string {
 	switch store.PathPrefix() {
 	case "ipfs":
+		// TODO (b5): this convention should be generalized for other stores,
+		// may be a source of bugs, especially when working with mapstore
 		return filepath.Join("/ipfs", ipfsHashBase(path), pf.String())
 	default:
 		return path
@@ -93,9 +94,4 @@ func ipfsHashBase(in string) string {
 	in = strings.TrimLeft(in, "/")
 	in = strings.TrimPrefix(in, "ipfs/")
 	return strings.Split(in, "/")[0]
-}
-
-// PackageKeypath wraps PackageFilepath to work with datastore.Keys instead
-func PackageKeypath(store cafs.Filestore, path datastore.Key, pf PackageFile) datastore.Key {
-	return datastore.NewKey(PackageFilepath(store, path.String(), pf))
 }

--- a/dsfs/package_test.go
+++ b/dsfs/package_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	ipfsfs "github.com/qri-io/cafs/ipfs"
 )
@@ -43,15 +42,6 @@ func TestPackageFilepath(t *testing.T) {
 			t.Errorf("case %d result mismatch. expected: '%s', got: '%s'", i, c.path, c.pf)
 			continue
 		}
-	}
-}
-
-func TestPackageKeyPath(t *testing.T) {
-	mem := cafs.NewMapstore()
-	p := datastore.NewKey("/mem/foo")
-	got := PackageKeypath(mem, p, PackageFileDataset)
-	if !got.Equal(p) {
-		t.Errorf("key mismatch. expected: %s, got %s", p, got)
 	}
 }
 

--- a/dsfs/structure.go
+++ b/dsfs/structure.go
@@ -3,29 +3,28 @@ package dsfs
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 )
 
 // SaveStructure saves a query's structure to a given store
-func SaveStructure(store cafs.Filestore, s *dataset.Structure, pin bool) (path datastore.Key, err error) {
+func SaveStructure(store cafs.Filestore, s *dataset.Structure, pin bool) (path string, err error) {
 	file, err := JSONFile(PackageFileStructure.String(), s)
 	if err != nil {
 		log.Debug(err.Error())
-		return datastore.NewKey(""), fmt.Errorf("error saving json structure file: %s", err.Error())
+		return "", fmt.Errorf("error saving json structure file: %s", err.Error())
 	}
 	return store.Put(file, pin)
 }
 
 // LoadStructure loads a structure from a given path in a store
-func LoadStructure(store cafs.Filestore, path datastore.Key) (st *dataset.Structure, err error) {
-	path = PackageKeypath(store, path, PackageFileStructure)
+func LoadStructure(store cafs.Filestore, path string) (st *dataset.Structure, err error) {
+	path = PackageFilepath(store, path, PackageFileStructure)
 	return loadStructure(store, path)
 }
 
 // loadStructure assumes path is valid
-func loadStructure(store cafs.Filestore, path datastore.Key) (st *dataset.Structure, err error) {
+func loadStructure(store cafs.Filestore, path string) (st *dataset.Structure, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		log.Debug(err.Error())

--- a/dsfs/testdata_test.go
+++ b/dsfs/testdata_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/jsonschema"
@@ -127,7 +126,7 @@ var Hours = &dataset.Dataset{
 	Meta: &dataset.Meta{
 		Title: "hours",
 	},
-	// Data:   datastore.NewKey("/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ"),
+	// Body:   "/ipfs/QmS1dVa1xemo7gQzJgjimj1WwnVBF3TwRTGsyKa1uEBWbJ",
 }
 
 var HoursStructure = &dataset.Structure{
@@ -146,12 +145,12 @@ var HoursStructure = &dataset.Structure{
 	}`),
 }
 
-func makeFilestore() (map[string]datastore.Key, cafs.Filestore, error) {
+func makeFilestore() (map[string]string, cafs.Filestore, error) {
 	fs := cafs.NewMapstore()
 
-	datasets := map[string]datastore.Key{
-		"movies": datastore.NewKey(""),
-		"cities": datastore.NewKey(""),
+	datasets := map[string]string{
+		"movies": "",
+		"cities": "",
 	}
 
 	for k := range datasets {

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
@@ -29,13 +28,8 @@ func TestLoadTransform(t *testing.T) {
 	// TODO - other tests & stuff
 }
 
-func TestTransformLoadAbstract(t *testing.T) {
-	// store := datastore.NewMapDatastore()
-	// TODO - finish dis test
-}
-
 func TestSaveTransform(t *testing.T) {
-	dsa := dataset.NewDatasetRef(datastore.NewKey("/path/to/dataset/a"))
+	dsa := dataset.NewDatasetRef("/path/to/dataset/a")
 	dsa.Assign(&dataset.Dataset{Meta: &dataset.Meta{Title: "now dataset isn't empty"}})
 
 	store := cafs.NewMapstore()
@@ -46,7 +40,7 @@ func TestSaveTransform(t *testing.T) {
 			Schema: jsonschema.Must(`true`),
 		},
 		Resources: map[string]*dataset.TransformResource{
-			"a": &dataset.TransformResource{Path: dsa.Path().String()},
+			"a": &dataset.TransformResource{Path: dsa.Path()},
 		},
 	}
 
@@ -57,8 +51,8 @@ func TestSaveTransform(t *testing.T) {
 	}
 
 	hash := "/map/QmS7xBzqKfRzdhZgSt69JMzUDdrPfoY3Z6EgroiQGjHhj8"
-	if hash != key.String() {
-		t.Errorf("key mismatch: %s != %s", hash, key.String())
+	if hash != key {
+		t.Errorf("key mismatch: %s != %s", hash, key)
 		return
 	}
 
@@ -68,7 +62,7 @@ func TestSaveTransform(t *testing.T) {
 		return
 	}
 
-	f, err := store.Get(datastore.NewKey(hash))
+	f, err := store.Get(hash)
 	if err != nil {
 		t.Errorf("error getting dataset file: %s", err.Error())
 		return
@@ -97,7 +91,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatalf("error unmarshaling private key: %s", err.Error())
 	}
 
-	_, err = LoadTransformScript(store, datastore.NewKey(""))
+	_, err = LoadTransformScript(store, "")
 	if err == nil {
 		t.Error("expected load empty key to fail")
 	}
@@ -124,7 +118,7 @@ func TestLoadTransformScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	tc.Input.Transform.ScriptPath = transformPath.String()
+	tc.Input.Transform.ScriptPath = transformPath
 	path, err = CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/dsfs/viz.go
+++ b/dsfs/viz.go
@@ -3,29 +3,28 @@ package dsfs
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 )
 
 // SaveViz saves a query's viz to a given store
-func SaveViz(store cafs.Filestore, v *dataset.Viz, pin bool) (path datastore.Key, err error) {
+func SaveViz(store cafs.Filestore, v *dataset.Viz, pin bool) (path string, err error) {
 	file, err := JSONFile(PackageFileViz.String(), v)
 	if err != nil {
 		log.Debug(err.Error())
-		return datastore.NewKey(""), fmt.Errorf("error saving json viz file: %s", err.Error())
+		return "", fmt.Errorf("error saving json viz file: %s", err.Error())
 	}
 	return store.Put(file, pin)
 }
 
 // LoadViz loads a viz from a given path in a store
-func LoadViz(store cafs.Filestore, path datastore.Key) (st *dataset.Viz, err error) {
-	path = PackageKeypath(store, path, PackageFileViz)
+func LoadViz(store cafs.Filestore, path string) (st *dataset.Viz, err error) {
+	path = PackageFilepath(store, path, PackageFileViz)
 	return loadViz(store, path)
 }
 
 // loadViz assumes the provided path is valid
-func loadViz(store cafs.Filestore, path datastore.Key) (st *dataset.Viz, err error) {
+func loadViz(store cafs.Filestore, path string) (st *dataset.Viz, err error) {
 	data, err := fileBytes(store.Get(path))
 	if err != nil {
 		log.Debug(err.Error())
@@ -39,7 +38,7 @@ var ErrNoViz = fmt.Errorf("this dataset has no viz component")
 
 // LoadVizScript loads script data from a dataset path if the given dataset has a viz script is specified
 // the returned cafs.File will be the value of dataset.Viz.ScriptPath
-func LoadVizScript(store cafs.Filestore, dspath datastore.Key) (cafs.File, error) {
+func LoadVizScript(store cafs.Filestore, dspath string) (cafs.File, error) {
 	ds, err := LoadDataset(store, dspath)
 	if err != nil {
 		return nil, err
@@ -49,5 +48,5 @@ func LoadVizScript(store cafs.Filestore, dspath datastore.Key) (cafs.File, error
 		return nil, ErrNoViz
 	}
 
-	return store.Get(datastore.NewKey(ds.Viz.ScriptPath))
+	return store.Get(ds.Viz.ScriptPath)
 }

--- a/dsfs/viz_test.go
+++ b/dsfs/viz_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
@@ -39,7 +38,7 @@ func TestLoadVizScript(t *testing.T) {
 		t.Fatalf("error unmarshaling private key: %s", err.Error())
 	}
 
-	_, err = LoadVizScript(store, datastore.NewKey(""))
+	_, err = LoadVizScript(store, "")
 	if err == nil {
 		t.Error("expected load empty key to fail")
 	}
@@ -66,7 +65,7 @@ func TestLoadVizScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	tc.Input.Viz.ScriptPath = vizPath.String()
+	tc.Input.Viz.ScriptPath = vizPath
 	path, err = CreateDataset(store, tc.Input, nil, tc.BodyFile(), nil, privKey, true)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/dsio/entry.go
+++ b/dsio/entry.go
@@ -45,5 +45,4 @@ func EachEntry(rr EntryReader, fn DataIteratorFunc) error {
 		num++
 	}
 
-	return fmt.Errorf("cannot parse data format '%s'", rr.Structure().Format.String())
 }

--- a/dsutil/dsutil_test.go
+++ b/dsutil/dsutil_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
@@ -45,12 +44,12 @@ func TestWriteDir(t *testing.T) {
 	}
 }
 
-func testStore() (cafs.Filestore, map[string]datastore.Key, error) {
+func testStore() (cafs.Filestore, map[string]string, error) {
 	dataf := cafs.NewMemfileBytes("movies.csv", []byte("movie\nup\nthe incredibles"))
 
 	// Map strings to ds.keys for convenience
-	ns := map[string]datastore.Key{
-		"movies": datastore.NewKey(""),
+	ns := map[string]string{
+		"movies": "",
 	}
 
 	ds := &dataset.Dataset{
@@ -78,7 +77,7 @@ func testStore() (cafs.Filestore, map[string]datastore.Key, error) {
 	return fs, ns, nil
 }
 
-func testStoreWithVizAndTransform() (cafs.Filestore, map[string]datastore.Key, error) {
+func testStoreWithVizAndTransform() (cafs.Filestore, map[string]string, error) {
 	ds := &dataset.Dataset{
 		Structure: &dataset.Structure{
 			Format: dataset.CSVDataFormat,
@@ -102,7 +101,7 @@ func testStoreWithVizAndTransform() (cafs.Filestore, map[string]datastore.Key, e
 		},
 	}
 	// Map strings to ds.keys for convenience
-	ns := map[string]datastore.Key{}
+	ns := map[string]string{}
 	// Store the files
 	fs := cafs.NewMapstore()
 	dataf := cafs.NewMemfileBytes("movies.csv", []byte("movie\nup\nthe incredibles"))
@@ -111,8 +110,8 @@ func testStoreWithVizAndTransform() (cafs.Filestore, map[string]datastore.Key, e
 		return fs, ns, err
 	}
 	ns["movies"] = dskey
-	ns["transform_script"] = datastore.NewKey(ds.Transform.ScriptPath)
-	ns["viz_template"] = datastore.NewKey(ds.Viz.ScriptPath)
+	ns["transform_script"] = ds.Transform.ScriptPath
+	ns["viz_template"] = ds.Viz.ScriptPath
 	return fs, ns, nil
 }
 

--- a/dsutil/zip.go
+++ b/dsutil/zip.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	datastore "github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
@@ -61,7 +60,7 @@ func WriteZipArchive(store cafs.Filestore, ds *dataset.Dataset, format string, r
 
 	// Transform script
 	if ds.Transform != nil && ds.Transform.ScriptPath != "" {
-		script, err := store.Get(datastore.NewKey(ds.Transform.ScriptPath))
+		script, err := store.Get(ds.Transform.ScriptPath)
 		if err != nil {
 			return err
 		}
@@ -77,7 +76,7 @@ func WriteZipArchive(store cafs.Filestore, ds *dataset.Dataset, format string, r
 
 	// Viz template
 	if ds.Viz != nil && ds.Viz.ScriptPath != "" {
-		script, err := store.Get(datastore.NewKey(ds.Viz.ScriptPath))
+		script, err := store.Get(ds.Viz.ScriptPath)
 		if err != nil {
 			return err
 		}

--- a/meta.go
+++ b/meta.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/ipfs/go-datastore"
 )
 
 // Meta contains human-readable descriptive metadata that qualifies and
@@ -18,7 +16,7 @@ import (
 // derived from existing metadata formats whenever possible
 type Meta struct {
 	// private storage for reference to this object
-	path datastore.Key
+	path string
 	// meta holds additional arbitrary metadata not covered by the spec when
 	// encoding & decoding json values here will be hoisted into the meta object
 	meta map[string]interface{}
@@ -83,13 +81,13 @@ func (md *Meta) IsEmpty() bool {
 }
 
 // Path gives the internal path reference for this dataset
-func (md *Meta) Path() datastore.Key {
+func (md *Meta) Path() string {
 	return md.path
 }
 
 // NewMetaRef creates a Meta pointer with the internal
 // path property specified, and no other fields.
-func NewMetaRef(path datastore.Key) *Meta {
+func NewMetaRef(path string) *Meta {
 	return &Meta{path: path}
 }
 
@@ -121,11 +119,7 @@ func UnmarshalMeta(v interface{}) (*Meta, error) {
 // SetPath sets the internal path property of a Meta
 // Use with caution. most users should never need to call SetPath
 func (md *Meta) SetPath(path string) {
-	if path == "" {
-		md.path = datastore.Key{}
-	} else {
-		md.path = datastore.NewKey(path)
-	}
+	md.path = path
 }
 
 // strVal confirms an interface is a string
@@ -248,7 +242,7 @@ func (md *Meta) Assign(metas ...*Meta) {
 			continue
 		}
 
-		if m.path.String() != "" {
+		if m.path != "" {
 			md.path = m.path
 		}
 		if m.Qri != "" {
@@ -310,8 +304,8 @@ func (md *Meta) Assign(metas ...*Meta) {
 func (md *Meta) MarshalJSON() ([]byte, error) {
 	// if we're dealing with an empty object that has a path specified
 	// marshal to a string instead
-	if md.path.String() != "" && md.IsEmpty() {
-		return md.path.MarshalJSON()
+	if md.path != "" && md.IsEmpty() {
+		return json.Marshal(md.path)
 	}
 
 	return md.MarshalJSONObject()
@@ -381,7 +375,7 @@ func (md *Meta) UnmarshalJSON(data []byte) error {
 	// first check to see if this is a valid path ref
 	var path string
 	if err := json.Unmarshal(data, &path); err == nil {
-		*md = Meta{path: datastore.NewKey(path)}
+		*md = Meta{path: path}
 		return nil
 	}
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -6,8 +6,6 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
-
-	"github.com/ipfs/go-datastore"
 )
 
 func TestMetaSetPath(t *testing.T) {
@@ -15,8 +13,8 @@ func TestMetaSetPath(t *testing.T) {
 		path   string
 		expect *Meta
 	}{
-		{"", &Meta{path: datastore.Key{}}},
-		{"path", &Meta{path: datastore.NewKey("path")}},
+		{"", &Meta{}},
+		{"path", &Meta{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -34,7 +32,7 @@ func TestMetaAssign(t *testing.T) {
 	cases := []struct {
 		in *Meta
 	}{
-		{&Meta{path: datastore.NewKey("/a")}},
+		{&Meta{path: "/a"}},
 		{&Meta{AccessURL: "foo"}},
 		{&Meta{DownloadURL: "foo"}},
 		{&Meta{ReadmeURL: "foo"}},
@@ -212,7 +210,7 @@ func TestMetaMarshalJSON(t *testing.T) {
 		return
 	}
 
-	strbytes, err := json.Marshal(&Meta{path: datastore.NewKey("/path/to/dataset")})
+	strbytes, err := json.Marshal(&Meta{path: "/path/to/dataset"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return
@@ -259,7 +257,7 @@ func TestMetaUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if strds.path.String() != path {
+	if strds.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strds.path)
 		return
 	}

--- a/structure_test.go
+++ b/structure_test.go
@@ -9,9 +9,6 @@ import (
 
 	"github.com/qri-io/dataset/compression"
 	"github.com/qri-io/jsonschema"
-
-	"github.com/ipfs/go-datastore"
-	// "github.com/qri-io/dataset/datatypes"
 )
 
 func TestStrucureHash(t *testing.T) {
@@ -94,8 +91,8 @@ func TestStructureSetPath(t *testing.T) {
 		path   string
 		expect *Structure
 	}{
-		{"", &Structure{path: datastore.Key{}}},
-		{"path", &Structure{path: datastore.NewKey("path")}},
+		{"", &Structure{}},
+		{"path", &Structure{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -187,7 +184,7 @@ func TestStructureUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if strq.path.String() != path {
+	if strq.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strq.path)
 		return
 	}
@@ -202,7 +199,7 @@ func TestStructureMarshalJSON(t *testing.T) {
 		{&Structure{Format: CSVDataFormat}, []byte(`{"errCount":0,"format":"csv","qri":"st:0"}`), nil},
 		{&Structure{Format: CSVDataFormat, Qri: KindStructure}, []byte(`{"errCount":0,"format":"csv","qri":"st:0"}`), nil},
 		{AirportCodesStructure, []byte(`{"errCount":5,"format":"csv","formatConfig":{"headerRow":true},"qri":"st:0","schema":{"items":{"items":[{"title":"ident","type":"string"},{"title":"type","type":"string"},{"title":"name","type":"string"},{"title":"latitude_deg","type":"string"},{"title":"longitude_deg","type":"string"},{"title":"elevation_ft","type":"string"},{"title":"continent","type":"string"},{"title":"iso_country","type":"string"},{"title":"iso_region","type":"string"},{"title":"municipality","type":"string"},{"title":"gps_code","type":"string"},{"title":"iata_code","type":"string"},{"title":"local_code","type":"string"}],"type":"array"},"type":"array"}}`), nil},
-		{&Structure{path: datastore.NewKey("/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD")}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), nil},
+		{&Structure{path: "/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), nil},
 	}
 
 	for i, c := range cases {
@@ -218,7 +215,7 @@ func TestStructureMarshalJSON(t *testing.T) {
 		}
 	}
 
-	strbytes, err := json.Marshal(&Structure{path: datastore.NewKey("/path/to/structure")})
+	strbytes, err := json.Marshal(&Structure{path: "/path/to/structure"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return

--- a/subset/subset.go
+++ b/subset/subset.go
@@ -19,7 +19,6 @@
 package subset
 
 import (
-	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsfs"
@@ -28,7 +27,7 @@ import (
 // LoadPreview loads a dataset preview for a given hash path
 func LoadPreview(s cafs.Filestore, path string) (*dataset.DatasetPod, error) {
 	// TODO - this is overfetching. Refine.
-	ds, err := dsfs.LoadDataset(s, datastore.NewKey(path))
+	ds, err := dsfs.LoadDataset(s, path)
 	if err != nil {
 		return nil, err
 	}

--- a/subset/subset_test.go
+++ b/subset/subset_test.go
@@ -28,7 +28,7 @@ func addMovies(t *testing.T, s cafs.Filestore) string {
 		t.Fatal(err)
 	}
 
-	return path.String()
+	return path
 }
 
 func TestLoadPreview(t *testing.T) {

--- a/transform_test.go
+++ b/transform_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/ipfs/go-datastore"
 )
 
 func TestTransformSetPath(t *testing.T) {
@@ -15,8 +13,8 @@ func TestTransformSetPath(t *testing.T) {
 		path   string
 		expect *Transform
 	}{
-		{"", &Transform{path: datastore.Key{}}},
-		{"path", &Transform{path: datastore.NewKey("path")}},
+		{"", &Transform{}},
+		{"path", &Transform{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -31,7 +29,7 @@ func TestTransformSetPath(t *testing.T) {
 
 func TestTransformAssign(t *testing.T) {
 	expect := &Transform{
-		path:          datastore.NewKey("path"),
+		path:          "path",
 		Syntax:        "a",
 		SyntaxVersion: "change",
 		Config: map[string]interface{}{
@@ -58,7 +56,7 @@ func TestTransformAssign(t *testing.T) {
 		},
 		Resources: nil,
 	}, &Transform{
-		path: datastore.NewKey("path"),
+		path: "path",
 		Resources: map[string]*TransformResource{
 			"a": &TransformResource{Path: "/path/to/a"},
 		},
@@ -87,7 +85,7 @@ func TestTransformUnmarshalJSON(t *testing.T) {
 		err       string
 	}{
 		{`{}`, &Transform{}, ""},
-		{`{ "structure" : "/path/to/structure" }`, &Transform{Structure: &Structure{path: datastore.NewKey("/path/to/structure")}}, ""},
+		{`{ "structure" : "/path/to/structure" }`, &Transform{Structure: &Structure{path: "/path/to/structure"}}, ""},
 		{`{"resources":{"foo": "/not/a/real/path"}}`, &Transform{Resources: map[string]*TransformResource{"foo": &TransformResource{Path: "/not/a/real/path"}}}, ""},
 		{`{"resources":{"foo": { "path":     "/not/a/real/path"`, &Transform{}, "unexpected end of JSON input"},
 		{`{"resources":{"foo": { "path":"/not/a/real/path"}}}`, &Transform{Resources: map[string]*TransformResource{"foo": &TransformResource{Path: "/not/a/real/path"}}}, ""},
@@ -114,7 +112,7 @@ func TestTransformUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if strq.path.String() != path {
+	if strq.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, strq.path)
 		return
 	}
@@ -142,7 +140,7 @@ func TestTransformMarshalJSONObject(t *testing.T) {
 		}
 	}
 
-	strbytes, err := json.Marshal(&Transform{path: datastore.NewKey("/path/to/transform")})
+	strbytes, err := json.Marshal(&Transform{path: "/path/to/transform"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return
@@ -185,7 +183,7 @@ func TestTransformIsEmpty(t *testing.T) {
 		expected bool
 	}{
 		{&Transform{Qri: KindTransform}, true},
-		{&Transform{path: datastore.NewKey("foo")}, true},
+		{&Transform{path: "foo"}, true},
 		{&Transform{}, true},
 		{&Transform{Syntax: "foo"}, false},
 		{&Transform{SyntaxVersion: "0"}, false},
@@ -212,7 +210,7 @@ func TestTransformCoding(t *testing.T) {
 		{SyntaxVersion: "foo"},
 		{Config: map[string]interface{}{"foo": "foo"}},
 		{ScriptPath: "foo"},
-		{path: datastore.NewKey("/foo")},
+		{path: "/foo"},
 		{Qri: KindTransform},
 		{Resources: map[string]*TransformResource{"foo": &TransformResource{Path: "foo"}}},
 		{Syntax: "foo"},

--- a/viz.go
+++ b/viz.go
@@ -4,15 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"github.com/ipfs/go-datastore"
 )
 
 // Viz stores configuration data related to representing a dataset as a
 // visualization
 type Viz struct {
 	// private storage for reference to this object
-	path datastore.Key
+	path string
 	// Qri should always be "vc:0"
 	Qri Kind
 	// Format designates the visualization configuration syntax. currently the
@@ -27,12 +25,12 @@ type Viz struct {
 }
 
 // Path gives the internal path reference for this structure
-func (v *Viz) Path() datastore.Key {
+func (v *Viz) Path() string {
 	return v.path
 }
 
 // NewVizRef creates an empty struct with it's internal path set
-func NewVizRef(path datastore.Key) *Viz {
+func NewVizRef(path string) *Viz {
 	return &Viz{path: path}
 }
 
@@ -44,11 +42,7 @@ func (v *Viz) IsEmpty() bool {
 // SetPath sets the internal path property of a Viz
 // Use with caution. most callers should never need to call SetPath
 func (v *Viz) SetPath(path string) {
-	if path == "" {
-		v.path = datastore.Key{}
-	} else {
-		v.path = datastore.NewKey(path)
-	}
+	v.path = path
 }
 
 // Assign collapses all properties of a group of structures on to one this is
@@ -59,7 +53,7 @@ func (v *Viz) Assign(visConfigs ...*Viz) {
 			continue
 		}
 
-		if vs.path.String() != "" {
+		if vs.path != "" {
 			v.path = vs.path
 		}
 		if vs.Qri != "" {
@@ -90,8 +84,8 @@ type vizPod struct {
 func (v *Viz) MarshalJSON() ([]byte, error) {
 	// if we're dealing with an empty object that has a path specified, marshal
 	// to a string instead
-	if v.path.String() != "" && v.IsEmpty() {
-		return v.path.MarshalJSON()
+	if v.path != "" && v.IsEmpty() {
+		return json.Marshal(v.path)
 	}
 	return v.MarshalJSONObject()
 }
@@ -100,7 +94,7 @@ func (v *Viz) MarshalJSON() ([]byte, error) {
 func (v *Viz) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
-		*v = Viz{path: datastore.NewKey(s)}
+		*v = Viz{path: s}
 		return nil
 	}
 

--- a/viz_test.go
+++ b/viz_test.go
@@ -3,7 +3,6 @@ package dataset
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/ipfs/go-datastore"
 	"io/ioutil"
 	"testing"
 )
@@ -31,8 +30,8 @@ func TestVizSetPath(t *testing.T) {
 		path   string
 		expect *Viz
 	}{
-		{"", &Viz{path: datastore.Key{}}},
-		{"path", &Viz{path: datastore.NewKey("path")}},
+		{"", &Viz{}},
+		{"path", &Viz{path: "path"}},
 	}
 
 	for i, c := range cases {
@@ -67,14 +66,14 @@ func TestVizAssign(t *testing.T) {
 		},
 			viz2, viz3, "ScriptPath: three != two"},
 		{&Viz{
-			path:       datastore.NewKey("foo"),
+			path:       "foo",
 			Format:     "foo",
 			Qri:        KindViz,
 			ScriptPath: "bat",
 		},
-			&Viz{path: datastore.NewKey("bar"), Format: "bar"},
+			&Viz{path: "bar", Format: "bar"},
 			&Viz{
-				path:       datastore.NewKey("foo"),
+				path:       "foo",
 				Format:     "bar",
 				Qri:        KindViz,
 				ScriptPath: "bat",
@@ -98,7 +97,7 @@ func TestVizIsEmpty(t *testing.T) {
 		{&Viz{Qri: KindViz}, true},
 		{&Viz{ScriptPath: "foo"}, false},
 		{&Viz{}, true},
-		{&Viz{path: datastore.NewKey("foo")}, true},
+		{&Viz{path: "foo"}, true},
 	}
 
 	for i, c := range cases {
@@ -151,7 +150,7 @@ func TestVizUnmarshalJSON(t *testing.T) {
 		return
 	}
 
-	if vc.path.String() != path {
+	if vc.path != path {
 		t.Errorf("unmarshal didn't set proper path: %s != %s", path, vc.path)
 		return
 	}
@@ -167,8 +166,8 @@ func TestVizMarshalJSON(t *testing.T) {
 		{&Viz{Qri: KindViz}, []byte(`{"qri":"vz:0"}`), ""},
 		{&Viz{Format: "foo", Qri: KindViz}, []byte(`{"format":"foo","qri":"vz:0"}`), ""},
 		{viz1, []byte(`{"format":"foo","qri":"vz:0","scriptPath":"one"}`), ""},
-		{&Viz{path: datastore.NewKey("/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U")}, []byte(`"/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"`), ""},
-		{&Viz{path: datastore.NewKey("/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD")}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), ""},
+		{&Viz{path: "/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"}, []byte(`"/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"`), ""},
+		{&Viz{path: "/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), ""},
 	}
 
 	for i, c := range cases {
@@ -184,7 +183,7 @@ func TestVizMarshalJSON(t *testing.T) {
 		}
 	}
 
-	vcbytes, err := json.Marshal(&Viz{path: datastore.NewKey("/path/to/Viz")})
+	vcbytes, err := json.Marshal(&Viz{path: "/path/to/Viz"})
 	if err != nil {
 		t.Errorf("unexpected string marshal error: %s", err.Error())
 		return


### PR DESCRIPTION
Implement the cafs.Filestore interface refactor. depends on qri-io/cafs#22.

BREAKING CHANGE:

all "path" manipulation methods now accept and return strings instead of datastore.Key