### PR TITLE
fix(save): Fix deadlock when saving invalid file

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -308,6 +308,8 @@ func prepareDataset(store cafs.Filestore, ds, dsPrev *dataset.Dataset, privKey c
 
 // setErrCount consumes sets the ErrCount field of a dataset's Structure
 func setErrCount(ds *dataset.Dataset, data qfs.File, mu *sync.Mutex, done chan error) {
+	defer data.Close()
+
 	er, err := dsio.NewEntryReader(ds.Structure, data)
 	if err != nil {
 		log.Debug(err.Error())
@@ -331,6 +333,8 @@ func setErrCount(ds *dataset.Dataset, data qfs.File, mu *sync.Mutex, done chan e
 
 // setDepthAndEntryCount set the Entries field of a ds.Structure
 func setDepthAndEntryCount(ds *dataset.Dataset, data qfs.File, mu *sync.Mutex, done chan error) {
+	defer data.Close()
+
 	er, err := dsio.NewEntryReader(ds.Structure, data)
 	if err != nil {
 		log.Debug(err.Error())
@@ -390,6 +394,8 @@ func getDepth(x interface{}, depth int) int {
 
 // setChecksumAndStats
 func setChecksumAndStats(ds *dataset.Dataset, data qfs.File, buf *bytes.Buffer, mu *sync.Mutex, done chan error) {
+	defer data.Close()
+
 	if _, err := io.Copy(buf, data); err != nil {
 		done <- err
 		return


### PR DESCRIPTION
If a user tries to save a file consisting of line-delimited json structures, prepareDataset has the possibility of deadlocking. The reason is that `setErrCount` and `setDepthAndEntryCount` use EntryReaders, and will only consume the first json object. However `setChecksumAndStats` uses a normal byte based file reader, so it will attempt to read the entire file. The io.MultiWriter that is supplying these three goroutines will be writing data to each of them, which will fill up the I/O buffers for `setErrCount` and `setDepthAndEntryCount`, eventually causing `Write` within the
io.MultiWriter to block.

Fix this by closing the file handles in `setErrCount` and `setDepthAndEntryCount` when they are done. A future improvement would be detecting this situation somewhere and returning an error due to the trailing content.

Fixes https://github.com/qri-io/qri/issues/660