### PR TITLE
fix(loadDatasetRefs): add correct path to dataset

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -23,7 +23,6 @@ import (
 // LoadDataset reads a dataset from a cafs and dereferences structure, transform, and commitMsg if they exist,
 // returning a fully-hydrated dataset
 func LoadDataset(store cafs.Filestore, path string) (*dataset.Dataset, error) {
-	path = PackageFilepath(store, path, PackageFileDataset)
 	ds, err := LoadDatasetRefs(store, path)
 	if err != nil {
 		log.Debug(err.Error())
@@ -42,8 +41,8 @@ func LoadDataset(store cafs.Filestore, path string) (*dataset.Dataset, error) {
 func LoadDatasetRefs(store cafs.Filestore, path string) (*dataset.Dataset, error) {
 	ds := dataset.NewDatasetRef(path)
 
-	path = PackageFilepath(store, path, PackageFileDataset)
-	data, err := fileBytes(store.Get(path))
+	pathWithExt := PackageFilepath(store, path, PackageFileDataset)
+	data, err := fileBytes(store.Get(pathWithExt))
 	// if err != nil {
 	// 	return nil, fmt.Errorf("error getting file bytes: %s", err.Error())
 	// }
@@ -51,7 +50,7 @@ func LoadDatasetRefs(store cafs.Filestore, path string) (*dataset.Dataset, error
 	// TODO - for some reason files are sometimes coming back empty from IPFS,
 	// every now & then. In the meantime, let's give a second try if data is empty
 	if err != nil || len(data) == 0 {
-		data, err = fileBytes(store.Get(path))
+		data, err = fileBytes(store.Get(pathWithExt))
 		if err != nil {
 			log.Debug(err.Error())
 			return nil, fmt.Errorf("error getting file bytes: %s", err.Error())

--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -41,8 +41,8 @@ func LoadDataset(store cafs.Filestore, path string) (*dataset.Dataset, error) {
 func LoadDatasetRefs(store cafs.Filestore, path string) (*dataset.Dataset, error) {
 	ds := dataset.NewDatasetRef(path)
 
-	pathWithExt := PackageFilepath(store, path, PackageFileDataset)
-	data, err := fileBytes(store.Get(pathWithExt))
+	pathWithBasename := PackageFilepath(store, path, PackageFileDataset)
+	data, err := fileBytes(store.Get(pathWithBasename))
 	// if err != nil {
 	// 	return nil, fmt.Errorf("error getting file bytes: %s", err.Error())
 	// }
@@ -50,7 +50,7 @@ func LoadDatasetRefs(store cafs.Filestore, path string) (*dataset.Dataset, error
 	// TODO - for some reason files are sometimes coming back empty from IPFS,
 	// every now & then. In the meantime, let's give a second try if data is empty
 	if err != nil || len(data) == 0 {
-		data, err = fileBytes(store.Get(pathWithExt))
+		data, err = fileBytes(store.Get(pathWithBasename))
 		if err != nil {
 			log.Debug(err.Error())
 			return nil, fmt.Errorf("error getting file bytes: %s", err.Error())

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,10 +54,14 @@ func TestLoadDataset(t *testing.T) {
 		return
 	}
 
-	_, err = LoadDataset(store, apath)
+	loadedDataset, err := LoadDataset(store, apath)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
+	}
+	// prove we aren't returning a path to a dataset that ends with `/dataset.json`
+	if strings.Contains(loadedDataset.Path, "/dataset.json") {
+		t.Errorf("path should not contain the basename of the dataset file: %s", loadedDataset.Path)
 	}
 
 	cases := []struct {

--- a/dsfs/package.go
+++ b/dsfs/package.go
@@ -86,7 +86,8 @@ func getHashBase(in, network string) string {
 
 // PackageFilepath returns the path to a package file for a given base path
 // It relies relies on package storage conventions and cafs.Filestore path prefixes
-// A path that does not match the filestore's naming conventions will return an invalid path
+// If you supply a path that does not match the filestore's naming conventions will
+// return an invalid path
 func PackageFilepath(store cafs.Filestore, path string, pf PackageFile) string {
 	prefix := store.PathPrefix()
 	if prefix == "" {

--- a/dsfs/package.go
+++ b/dsfs/package.go
@@ -23,7 +23,7 @@ const (
 	// should be erroneous, as there is no sensible default
 	// for PackageFile
 	PackageFileUnknown PackageFile = iota
-	// PackageFileDataset is the maind dataset.json file
+	// PackageFileDataset is the main dataset.json file
 	// that contains all dataset metadata, and is the only
 	// required file to constitute a dataset
 	PackageFileDataset
@@ -76,22 +76,21 @@ func (p PackageFile) Filename() string {
 	return filenames[p]
 }
 
-// PackageFilepath relies on package storage conventions and cafs.Filestore path prefixes
-// to deliver the path to a package file for a given base path
-func PackageFilepath(store cafs.Filestore, path string, pf PackageFile) string {
-	switch store.PathPrefix() {
-	case "ipfs":
-		// TODO (b5): this convention should be generalized for other stores,
-		// may be a source of bugs, especially when working with mapstore
-		return filepath.Join("/ipfs", ipfsHashBase(path), pf.String())
-	default:
-		return path
-	}
+// getHashBase strips paths to return just the hash
+func getHashBase(in, network string) string {
+	in = strings.TrimLeft(in, "/")
+	in = strings.TrimPrefix(in, network)
+	in = strings.TrimLeft(in, "/")
+	return strings.Split(in, "/")[0]
 }
 
-// ipfsHashBase strips paths to return just the hash
-func ipfsHashBase(in string) string {
-	in = strings.TrimLeft(in, "/")
-	in = strings.TrimPrefix(in, "ipfs/")
-	return strings.Split(in, "/")[0]
+// PackageFilepath returns the path to a package file for a given base path
+// It relies relies on package storage conventions and cafs.Filestore path prefixes
+// A path that does not match the filestore's naming conventions will return an invalid path
+func PackageFilepath(store cafs.Filestore, path string, pf PackageFile) string {
+	prefix := store.PathPrefix()
+	if prefix == "" {
+		return path
+	}
+	return filepath.Join("/", prefix, getHashBase(path, prefix), pf.String())
 }

--- a/dsfs/package_test.go
+++ b/dsfs/package_test.go
@@ -17,7 +17,7 @@ func TestPackageFilepath(t *testing.T) {
 	}
 	defer destroy()
 
-	mem := cafs.NewMapstore()
+	// mem := cafs.NewMapstore()
 
 	cases := []struct {
 		store cafs.Filestore
@@ -31,9 +31,9 @@ func TestPackageFilepath(t *testing.T) {
 		{ipfs, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/meta.json"},
 		{ipfs, "QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
 
-		{mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M"},
-		{mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
-		{mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
+		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M"},
+		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
+		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
 	}
 
 	for i, c := range cases {

--- a/dsfs/package_test.go
+++ b/dsfs/package_test.go
@@ -17,7 +17,7 @@ func TestPackageFilepath(t *testing.T) {
 	}
 	defer destroy()
 
-	// mem := cafs.NewMapstore()
+	mem := cafs.NewMapstore()
 
 	cases := []struct {
 		store cafs.Filestore
@@ -31,9 +31,9 @@ func TestPackageFilepath(t *testing.T) {
 		{ipfs, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/meta.json"},
 		{ipfs, "QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/ipfs/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
 
-		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M"},
-		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileDataset, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
-		// {mem, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/mem/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
+		{mem, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M", PackageFileDataset, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
+		{mem, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileDataset, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json"},
+		{mem, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/dataset.json", PackageFileMeta, "/map/QmZfwmhbcgSDGqGaoMMYx8jxBGauZw75zPjnZAyfwPso7M/meta.json"},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
In order to load the dataset from the store, we need to append the `/dataset.json` suffix to the path. However, we were incorrectly adding that same path (with the extension) to the dataset as the path.

Created another var `pathWithExt` that we use to get the dataset from the store.

closes qri-io/qri#700