### PR TITLE
refactor(CreateDataset): add `shouldRender` flag

### DIFF
--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -128,7 +128,7 @@ func TestCreateDataset(t *testing.T) {
 		return
 	}
 
-	_, err = CreateDataset(store, nil, nil, nil, false, false)
+	_, err = CreateDataset(store, nil, nil, nil, false, false, true)
 	if err == nil {
 		t.Errorf("expected call without prvate key to error")
 		return
@@ -174,7 +174,7 @@ func TestCreateDataset(t *testing.T) {
 			continue
 		}
 
-		path, err := CreateDataset(store, tc.Input, c.prev, privKey, false, false)
+		path, err := CreateDataset(store, tc.Input, c.prev, privKey, false, false, true)
 		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
 			t.Errorf("%s: error mismatch. expected: '%s', got: '%s'", tc.Name, c.err, err)
 			continue
@@ -226,7 +226,7 @@ func TestCreateDataset(t *testing.T) {
 		t.Errorf("case nil body and previous body files, error reading data file: %s", err.Error())
 	}
 	expectedErr := "bodyfile or previous bodyfile needed"
-	_, err = CreateDataset(store, ds, nil, privKey, false, false)
+	_, err = CreateDataset(store, ds, nil, privKey, false, false, true)
 	if err.Error() != expectedErr {
 		t.Errorf("case nil body and previous body files, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	}
@@ -245,7 +245,7 @@ func TestCreateDataset(t *testing.T) {
 	}
 	ds.SetBodyFile(qfs.NewMemfileBytes("body.csv", bodyBytes))
 
-	_, err = CreateDataset(store, ds, dsPrev, privKey, false, false)
+	_, err = CreateDataset(store, ds, dsPrev, privKey, false, false, true)
 	if err != nil && err.Error() != expectedErr {
 		t.Errorf("case no changes in dataset, error mismatch: expected '%s', got '%s'", expectedErr, err.Error())
 	} else if err == nil {

--- a/dsfs/transform_test.go
+++ b/dsfs/transform_test.go
@@ -93,7 +93,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	path, err := CreateDataset(store, tc.Input, nil, privKey, true, false)
+	path, err := CreateDataset(store, tc.Input, nil, privKey, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -112,7 +112,7 @@ func TestLoadTransformScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	tc.Input.Transform.ScriptPath = transformPath
-	path, err = CreateDataset(store, tc.Input, nil, privKey, true, false)
+	path, err = CreateDataset(store, tc.Input, nil, privKey, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/dsfs/viz_test.go
+++ b/dsfs/viz_test.go
@@ -47,7 +47,7 @@ func TestLoadVizScript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	path, err := CreateDataset(store, tc.Input, nil, privKey, true, false)
+	path, err := CreateDataset(store, tc.Input, nil, privKey, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -66,7 +66,7 @@ func TestLoadVizScript(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	tc.Input.Viz.ScriptPath = vizPath
-	path, err = CreateDataset(store, tc.Input, nil, privKey, true, false)
+	path, err = CreateDataset(store, tc.Input, nil, privKey, true, false, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/subset/subset_test.go
+++ b/subset/subset_test.go
@@ -23,7 +23,7 @@ func addMovies(t *testing.T, s cafs.Filestore) string {
 		t.Fatal(err)
 	}
 
-	path, err := dsfs.CreateDataset(s, tc.Input, nil, dstest.PrivKey, true, false)
+	path, err := dsfs.CreateDataset(s, tc.Input, nil, dstest.PrivKey, true, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/viz.go
+++ b/viz.go
@@ -47,7 +47,7 @@ func (v *Viz) DropTransientValues() {
 // passed-in resolver otherwise
 func (v *Viz) OpenScriptFile(resolver qfs.PathResolver) (err error) {
 	if v.ScriptBytes != nil {
-		v.scriptFile = qfs.NewMemfileBytes("transform.star", v.ScriptBytes)
+		v.scriptFile = qfs.NewMemfileBytes("template.html", v.ScriptBytes)
 		return nil
 	}
 
@@ -66,6 +66,20 @@ func (v *Viz) OpenScriptFile(resolver qfs.PathResolver) (err error) {
 // SetScriptFile assigns the unexported scriptFile
 func (v *Viz) SetScriptFile(file qfs.File) {
 	v.scriptFile = file
+}
+
+// OpenRenderedFile generates a byte stream of the rendered data
+func (v *Viz) OpenRenderedFile(resolver qfs.PathResolver) (err error) {
+	if v.RenderedPath == "" {
+		// nothing to resolve
+		return nil
+	}
+
+	if resolver == nil {
+		return ErrNoResolver
+	}
+	v.renderedFile, err = resolver.Get(v.RenderedPath)
+	return err
 }
 
 // SetRenderedFile assigns the unexported renderedFile


### PR DESCRIPTION
Adds `shouldRender` flag to `CreateDataset` and `prepareDataset`. If `true`, `shouldRender` indicates we should render the template and store it as part of the dataset package.

Adds `OpenRenderedFile` function to generate a byte stream of the rendered file