### PR TITLE
feat(dsviz): add bodyEntries and allBodyEntries template funcs

### DIFF
--- a/dsviz/testdata/custom/rendered.html
+++ b/dsviz/testdata/custom/rendered.html
@@ -5,6 +5,13 @@
 </head>
 <body>
   <h1>World Population</h1>
+  <h3>First Row:</h3>
+  <table>
+  <tr>
+    <td>2017</td><td>7500000000</td>
+  </tr>
+  </table>
+  <h3>Full Body:</h3>
   <table>
   <tr>
     <td>2017</td><td>7500000000</td>

--- a/dsviz/testdata/custom/template.html
+++ b/dsviz/testdata/custom/template.html
@@ -5,8 +5,17 @@
 </head>
 <body>
   <h1>{{ ds.meta.title }}</h1>
+  <h3>First Row:</h3>
   <table>
-  {{- range getBody }}
+  {{- range bodyEntries 0 1 }}
+  <tr>
+    {{ range . }}<td>{{ . }}</td>{{ end }}
+  </tr>
+  {{- end }}
+  </table>
+  <h3>Full Body:</h3>
+  <table>
+  {{- range allBodyEntries }}
   <tr>
     {{ range . }}<td>{{ . }}</td>{{ end }}
   </tr>


### PR DESCRIPTION
having "paginated" access to template functions is important for fixed record sampling. While here I've taken the liberty of renaming `getBody` to `allBodyEntries` to clearly label for template readers that 'hey, this is going to read all the body'. With these in place we can remove the all,limit, and offset parameters from `qri render`.

They'd be used like this in template funcs:
```html
// grab the first 10 rows, printing all data in paragraph tags
{{ range bodyEntries 0 10 }} 
<p>{{ . }}</p>
{{ end }}

// print the whole body as JSON:
<script>
window.data = {{ allBodyEntries }}
</script>
```

@dustmop b/c this is a public-facing API with offset & limit params, I've put them in offset-then-limit order, as we've discussed earlier. This makes it a bit confusing for us codebase maintainers, but I think is important to get right here.

I'm specifically seeking feedback on the function names: `bodyEntries` and `allBodyEntries`.