### PR TITLE
doc(dsviz): add outline doc.go for dsviz

### DIFF
--- a/dsviz/doc.go
+++ b/dsviz/doc.go
@@ -1,0 +1,32 @@
+/*Package dsviz renders the viz component of a dataset, returning a qfs.File of
+data
+
+HTML rendering uses go's html/template package to generate html documents from
+an input dataset. It's API has been adjusted to use lowerCamelCase instead of
+UpperCamelCase naming conventions
+
+	outline: html viz templates
+		HTML template should expose a number of helper template functions, along
+		with a  dataset document at ds. Exposing the dataset  document as "ds"
+		matches our conventions for referring to a dataset elsewhere, and allows
+		access to all defined parts of a dataset.
+		HTML visualization is built atop the
+		[go template syntax](https://golang.org/pkg/text/template/#hdr-Functions)
+		types:
+			{{ ds }}
+				the dataset being visualized, ds can have a number of components like
+				commit, meta, transform, body, all of which have helpful fields for
+				visualization. Details of the dataset document are outlined in the
+				dataset document definition
+		functions:
+			{{ allBodyEntries }}
+				load the full dataset body
+			{{ bodyEntries offset limit }}
+				get body entries within an offset/limit range. passing offset: 0,
+				limit: -1 returns the entire body
+			{{ filesize }}
+				convert byte count to kb/mb/etc string
+			{{ title }}
+				give the title of a dataset
+*/
+package dsviz

--- a/dsviz/render.go
+++ b/dsviz/render.go
@@ -1,4 +1,3 @@
-// Package dsviz performs actions on viz components of a dataset
 package dsviz
 
 import (
@@ -73,6 +72,12 @@ func renderHTML(ds *dataset.Dataset) (qfs.File, error) {
 			}
 			return fmt.Sprintf("%s/%s", ds.Peername, ds.Name)
 		},
+		// TODO (b5):
+		// {{ timeParse }}
+		// 	parse a timestamp string, returning a golang *time.Time struct
+		// {{ timeFormat }}
+		// 	convert the textual representation of the datetime into the specified
+		// 	format using a template date
 	})
 
 	for name, tmplText := range PredefinedHTMLTemplates {


### PR DESCRIPTION
this defines the base API for viz templating. qri makes a few special partials available that we can document by copy-pasting this & adding to