### PR TITLE
structure.strict: true requires validation to pass 

### DIFF
--- a/dsfs/dataset.go
+++ b/dsfs/dataset.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p-crypto"
+	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/multiformats/go-multihash"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dsio"
@@ -327,6 +327,13 @@ func setErrCount(ds *dataset.Dataset, data qfs.File, mu *sync.Mutex, done chan e
 		log.Debug(err.Error())
 		done <- fmt.Errorf("validating data: %s", err.Error())
 		return
+	}
+
+	if ds.Structure != nil {
+		if ds.Structure.Strict && len(validationErrors) > 0 {
+			done <- fmt.Errorf("strict dataset body is invalid")
+			return
+		}
 	}
 
 	mu.Lock()

--- a/dsfs/dataset_test.go
+++ b/dsfs/dataset_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p-crypto"
+	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/qri-io/dataset"
 	"github.com/qri-io/dataset/dstest"
 	"github.com/qri-io/qfs"
@@ -150,6 +150,8 @@ func TestCreateDataset(t *testing.T) {
 			"", nil, 0, "error loading dataset commit: error loading commit file: cafs: path not found"},
 		{"invalid",
 			"", nil, 0, "commit is required"},
+		{"strict_fail",
+			"", nil, 0, "strict dataset body is invalid"},
 		{"cities",
 			"/map/QmYDVHBmGHWV7h8iCU9H6BrYoXXnm8pCFhhJzZw5jJitoq", nil, 6, ""},
 		{"all_fields",
@@ -233,8 +235,8 @@ func TestCreateDataset(t *testing.T) {
 
 	// Case: no changes in dataset
 	expectedErr = "error saving: no changes detected"
-	dsPrev, err := LoadDataset(store, cases[2].resultPath)
-	ds.PreviousPath = cases[2].resultPath
+	dsPrev, err := LoadDataset(store, cases[3].resultPath)
+	ds.PreviousPath = cases[3].resultPath
 	if err != nil {
 		t.Errorf("case no changes in dataset, error loading previous dataset file: %s", err.Error())
 	}

--- a/dsfs/testdata/strict_fail/body.csv
+++ b/dsfs/testdata/strict_fail/body.csv
@@ -1,0 +1,5044 @@
+movie_title,duration
+Avatar ,false
+Pirates of the Caribbean: At World's End ,169
+Spectre ,148
+The Dark Knight Rises ,164
+Star Wars: Episode VII - The Force Awakens             ,
+John Carter ,132
+Spider-Man 3 ,156
+Tangled ,100
+Avengers: Age of Ultron ,141
+Harry Potter and the Half-Blood Prince ,153
+Batman v Superman: Dawn of Justice ,183
+Superman Returns ,169
+Quantum of Solace ,106
+Pirates of the Caribbean: Dead Man's Chest ,151
+The Lone Ranger ,150
+Man of Steel ,143
+The Chronicles of Narnia: Prince Caspian ,150
+The Avengers ,173
+Pirates of the Caribbean: On Stranger Tides ,136
+Men in Black 3 ,106
+The Hobbit: The Battle of the Five Armies ,164
+The Amazing Spider-Man ,153
+Robin Hood ,156
+The Hobbit: The Desolation of Smaug ,186
+The Golden Compass ,113
+King Kong ,201
+Titanic ,194
+Captain America: Civil War ,147
+Battleship ,131
+Jurassic World ,124
+Skyfall ,143
+Spider-Man 2 ,135
+Iron Man 3 ,195
+Alice in Wonderland ,108
+X-Men: The Last Stand ,104
+Monsters University ,104
+Transformers: Revenge of the Fallen ,150
+Transformers: Age of Extinction ,165
+Oz the Great and Powerful ,130
+The Amazing Spider-Man 2 ,142
+TRON: Legacy ,125
+Cars 2 ,106
+Green Lantern ,123
+Toy Story 3 ,103
+Terminator Salvation ,118
+Furious 7 ,140
+World War Z ,123
+X-Men: Days of Future Past ,149
+Star Trek Into Darkness ,132
+Jack the Giant Slayer ,114
+The Great Gatsby ,143
+Prince of Persia: The Sands of Time ,116
+Pacific Rim ,131
+Transformers: Dark of the Moon ,154
+Indiana Jones and the Kingdom of the Crystal Skull ,122
+The Good Dinosaur ,93
+Brave ,93
+Star Trek Beyond ,122
+WALL·E ,98
+Rush Hour 3 ,91
+2012 ,158
+A Christmas Carol ,96
+Jupiter Ascending ,127
+The Legend of Tarzan ,110
+"The Chronicles of Narnia: The Lion, the Witch and the Wardrobe ",150
+X-Men: Apocalypse ,144
+The Dark Knight ,152
+Up ,96
+Monsters vs. Aliens ,94
+Iron Man ,126
+Hugo ,126
+Wild Wild West ,106
+The Mummy: Tomb of the Dragon Emperor ,112
+Suicide Squad ,123
+Evan Almighty ,96
+Edge of Tomorrow ,113
+Waterworld ,176
+G.I. Joe: The Rise of Cobra ,118
+Inside Out ,95
+The Jungle Book ,106
+Iron Man 2 ,124
+Snow White and the Huntsman ,132
+Maleficent ,97
+Dawn of the Planet of the Apes ,130
+The Lovers ,109
+47 Ronin ,128
+Captain America: The Winter Soldier ,136
+Shrek Forever After ,93
+Tomorrowland ,130
+Big Hero 6 ,102
+Wreck-It Ralph ,101
+The Polar Express ,100
+Independence Day: Resurgence ,120
+How to Train Your Dragon ,98
+Terminator 3: Rise of the Machines ,109
+Guardians of the Galaxy ,121
+Interstellar ,169
+Inception ,148
+Godzilla Resurgence ,120
+The Hobbit: An Unexpected Journey ,182
+The Fast and the Furious ,106
+The Curious Case of Benjamin Button ,166
+X-Men: First Class ,132
+The Hunger Games: Mockingjay - Part 2 ,137
+The Sorcerer's Apprentice ,109
+Poseidon ,98
+Alice Through the Looking Glass ,113
+Shrek the Third ,93
+Warcraft ,123
+Terminator Genisys ,126
+The Chronicles of Narnia: The Voyage of the Dawn Treader ,113
+Pearl Harbor ,184
+Transformers ,144
+Alexander ,206
+Harry Potter and the Order of the Phoenix ,138
+Harry Potter and the Goblet of Fire ,157
+Hancock ,102
+I Am Legend ,104
+Charlie and the Chocolate Factory ,115
+Ratatouille ,111
+Batman Begins ,128
+Madagascar: Escape 2 Africa ,89
+Night at the Museum: Battle of the Smithsonian ,105
+X-Men Origins: Wolverine ,119
+The Matrix Revolutions ,129
+Frozen ,102
+The Matrix Reloaded ,138
+Thor: The Dark World ,112
+Mad Max: Fury Road ,120
+Angels & Demons ,146
+Thor ,115
+Bolt ,96
+G-Force ,88
+Wrath of the Titans ,99
+Dark Shadows ,113
+Mission: Impossible - Rogue Nation ,131
+The Wolfman ,119
+The Legend of Tarzan ,110
+Bee Movie ,91
+Kung Fu Panda 2 ,90
+The Last Airbender ,103
+Mission: Impossible III ,124
+White House Down ,131
+Mars Needs Moms ,88
+Flushed Away ,85
+Pan ,111
+Mr. Peabody & Sherman ,92
+Troy ,196
+Madagascar 3: Europe's Most Wanted ,93
+Die Another Day ,133
+Ghostbusters ,116
+Armageddon ,153
+Men in Black II ,88
+Beowulf ,115
+Kung Fu Panda 3 ,95
+Mission: Impossible - Ghost Protocol ,133
+Rise of the Guardians ,97
+Fun with Dick and Jane ,90
+The Last Samurai ,154
+Exodus: Gods and Kings ,150
+Star Trek ,127
+Spider-Man ,121
+How to Train Your Dragon 2 ,102
+Gods of Egypt ,126
+Stealth ,121
+Watchmen ,215
+Lethal Weapon 4 ,127
+Hulk ,138
+G.I. Joe: Retaliation ,122
+Sahara ,124
+Final Fantasy: The Spirits Within ,106
+Captain America: The First Avenger ,124
+The World Is Not Enough ,128
+Master and Commander: The Far Side of the World ,138
+The Twilight Saga: Breaking Dawn - Part 2 ,115
+Happy Feet 2 ,100
+The Incredible Hulk ,135
+Miami Vice             ,60
+The BFG ,117
+The Revenant ,156
+Turbo ,96
+Rango ,107
+Penguins of Madagascar ,92
+The Bourne Ultimatum ,115
+Kung Fu Panda ,92
+Ant-Man ,117
+The Hunger Games: Catching Fire ,146
+The Twilight Saga: Breaking Dawn - Part 2 ,115
+Home ,94
+War of the Worlds ,116
+Bad Boys II ,147
+Puss in Boots ,90
+Salt ,101
+Noah ,138
+The Adventures of Tintin ,107
+Harry Potter and the Prisoner of Azkaban ,142
+Australia ,165
+After Earth ,100
+Dinosaur ,82
+Harry Potter and the Deathly Hallows: Part II ,
+Night at the Museum: Secret of the Tomb ,98
+Megamind ,95
+Harry Potter and the Sorcerer's Stone ,159
+R.I.P.D. ,96
+Godzilla Resurgence ,120
+Pirates of the Caribbean: The Curse of the Black Pearl ,143
+Harry Potter and the Deathly Hallows: Part I ,
+The Hunger Games: Mockingjay - Part 1 ,123
+The Da Vinci Code ,174
+Rio 2 ,101
+X-Men 2 ,134
+Fast Five ,132
+Sherlock Holmes: A Game of Shadows ,129
+Clash of the Titans ,106
+Total Recall ,113
+The 13th Warrior ,102
+The Bourne Legacy ,135
+Batman & Robin ,125
+How the Grinch Stole Christmas ,110
+The Day After Tomorrow ,124
+Mission: Impossible II ,123
+The Perfect Storm ,130
+Fantastic 4: Rise of the Silver Surfer ,92
+Life of Pi ,127
+Ghost Rider ,123
+Jason Bourne ,123
+Charlie's Angels: Full Throttle ,107
+Prometheus ,124
+Stuart Little 2 ,77
+Elysium ,109
+The Chronicles of Riddick ,134
+RoboCop ,117
+Speed Racer ,135
+How Do You Know ,121
+Knight and Day ,117
+Oblivion ,124
+Star Wars: Episode III - Revenge of the Sith ,140
+Star Wars: Episode II - Attack of the Clones ,142
+"Monsters, Inc. ",92
+The Wolverine ,138
+Star Wars: Episode I - The Phantom Menace ,136
+The Croods ,98
+Asterix at the Olympic Games ,116
+Windtalkers ,153
+The Huntsman: Winter's War ,120
+Teenage Mutant Ninja Turtles ,101
+Gravity ,91
+Dante's Peak ,108
+Teenage Mutant Ninja Turtles: Out of the Shadows ,112
+Fantastic Four ,100
+Night at the Museum ,108
+San Andreas ,114
+Tomorrow Never Dies ,119
+The Patriot ,142
+Ocean's Twelve ,125
+Mr. & Mrs. Smith ,126
+Insurgent ,119
+The Aviator ,170
+Gulliver's Travels ,85
+The Green Hornet ,119
+The A-Team             ,60
+300: Rise of an Empire ,102
+The Smurfs ,103
+Home on the Range ,76
+Allegiant ,120
+Real Steel ,127
+The Smurfs 2 ,105
+Speed 2: Cruise Control ,121
+Ender's Game ,114
+Live Free or Die Hard ,129
+The Lord of the Rings: The Fellowship of the Ring ,171
+Around the World in 80 Days ,120
+Ali ,165
+The Cat in the Hat ,82
+"I, Robot ",115
+Kingdom of Heaven ,194
+Stuart Little ,84
+The Princess and the Frog ,97
+The Martian ,151
+"10,000 B.C.             ",22
+The Island ,136
+Town & Country ,104
+Gone in Sixty Seconds ,127
+Gladiator ,171
+Minority Report ,145
+Harry Potter and the Chamber of Secrets ,174
+Casino Royale ,144
+Planet of the Apes ,119
+Terminator 2: Judgment Day ,153
+Public Enemies ,140
+American Gangster ,176
+True Lies ,141
+The Taking of Pelham 1 2 3 ,106
+Little Fockers ,98
+The Other Guys ,116
+Eraser ,115
+Django Unchained ,165
+The Hunchback of Notre Dame ,91
+The Emperor's New Groove ,78
+The Expendables 2 ,103
+National Treasure ,131
+Eragon ,104
+Where the Wild Things Are ,101
+Pan ,111
+Epic ,102
+The Tourist ,103
+End of Days ,121
+Blood Diamond ,143
+The Wolf of Wall Street ,240
+Batman Forever ,121
+Starship Troopers ,129
+Cloud Atlas ,172
+Legend of the Guardians: The Owls of Ga'Hoole ,101
+Catwoman ,87
+Hercules ,101
+Treasure Planet ,95
+Land of the Lost ,102
+The Expendables 3 ,131
+Point Break ,114
+Son of the Mask ,94
+In the Heart of the Sea ,122
+The Adventures of Pluto Nash ,95
+Green Zone ,115
+The Peanuts Movie ,88
+The Spanish Prisoner ,110
+The Mummy Returns ,130
+Gangs of New York ,216
+The Flowers of War ,146
+Surf's Up ,85
+The Stepford Wives ,93
+Black Hawk Down ,152
+The Campaign ,85
+The Fifth Element ,126
+Sex and the City 2 ,146
+The Road to El Dorado ,89
+Ice Age: Continental Drift ,88
+Cinderella ,105
+The Lovely Bones ,135
+Finding Nemo ,100
+The Lord of the Rings: The Return of the King ,192
+The Lord of the Rings: The Two Towers ,172
+Seventh Son ,102
+Lara Croft: Tomb Raider ,100
+Transcendence ,119
+Jurassic Park III ,92
+Rise of the Planet of the Apes ,105
+The Spiderwick Chronicles ,107
+A Good Day to Die Hard ,101
+The Alamo ,137
+The Incredibles ,115
+Cutthroat Island ,124
+Percy Jackson & the Olympians: The Lightning Thief ,118
+Men in Black ,98
+Toy Story 2 ,82
+Unstoppable ,98
+Rush Hour 2 ,90
+What Lies Beneath ,130
+Cloudy with a Chance of Meatballs ,90
+Ice Age: Dawn of the Dinosaurs ,94
+The Secret Life of Walter Mitty ,114
+Charlie's Angels ,94
+The Departed ,151
+Mulan ,88
+Tropic Thunder ,121
+The Girl with the Dragon Tattoo ,158
+Die Hard with a Vengeance ,128
+Sherlock Holmes ,128
+Ben-Hur ,141
+Atlantis: The Lost Empire ,95
+Alvin and the Chipmunks: The Road Chip ,92
+Valkyrie ,121
+You Don't Mess with the Zohan ,113
+Pixels ,106
+A.I. Artificial Intelligence ,146
+The Haunted Mansion ,88
+Contact ,150
+Hollow Man ,119
+The Interpreter ,128
+Percy Jackson: Sea of Monsters ,106
+Lara Croft Tomb Raider: The Cradle of Life ,117
+Now You See Me 2 ,129
+The Saint ,116
+Spy Game ,114
+Mission to Mars ,114
+Rio ,96
+Bicentennial Man ,132
+Volcano ,104
+The Devil's Own ,111
+K-19: The Widowmaker ,138
+Fantastic Four ,100
+Conan the Barbarian ,129
+Cinderella Man ,144
+The Nutcracker in 3D ,110
+Seabiscuit ,140
+Twister ,113
+The Fast and the Furious ,106
+Cast Away ,143
+Happy Feet ,108
+The Bourne Supremacy ,108
+Air Force One ,124
+Ocean's Eleven ,116
+The Three Musketeers ,110
+Hotel Transylvania ,91
+Enchanted ,107
+Hannibal             ,44
+Safe House ,115
+102 Dalmatians ,100
+Tower Heist ,104
+The Holiday ,138
+Enemy of the State ,140
+It's Complicated ,120
+Ocean's Thirteen ,122
+Open Season ,83
+Divergent ,139
+Enemy at the Gates ,131
+The Rundown ,104
+Last Action Hero ,130
+Memoirs of a Geisha ,145
+The Fast and the Furious: Tokyo Drift ,104
+Arthur Christmas ,97
+Meet Joe Black ,178
+Collateral Damage ,108
+All That Jazz ,123
+Mirror Mirror ,106
+Scott Pilgrim vs. the World ,112
+The Core ,135
+Nutty Professor II: The Klumps ,109
+Scooby-Doo ,86
+Dredd ,95
+Click ,107
+Creepshow ,130
+Cats & Dogs: The Revenge of Kitty Galore ,82
+Jumper ,88
+Hellboy II: The Golden Army ,120
+Zodiac ,162
+The 6th Day ,123
+Bruce Almighty ,101
+The Expendables ,113
+Mission: Impossible ,110
+The Hunger Games ,142
+The Hangover Part II ,102
+Batman Returns ,126
+Over the Hedge ,83
+Lilo & Stitch ,85
+Charlotte's Web ,97
+Deep Impact ,120
+RED 2 ,116
+The Longest Yard ,113
+Alvin and the Chipmunks: Chipwrecked ,87
+Grown Ups 2 ,101
+Get Smart ,110
+Something's Gotta Give ,128
+Shutter Island ,138
+Four Christmases ,88
+Robots ,91
+Face/Off ,138
+Bedtime Stories ,99
+Road to Perdition ,117
+Just Go with It ,117
+Daredevil             ,54
+Con Air ,123
+Eagle Eye ,118
+Cold Mountain ,154
+The Book of Eli ,118
+Flubber ,90
+The Haunting ,113
+Space Jam ,88
+The Pink Panther ,93
+The Day the Earth Stood Still ,104
+Conspiracy Theory ,135
+Fury ,134
+Six Days Seven Nights ,98
+Yogi Bear ,80
+Spirit: Stallion of the Cimarron ,83
+Zookeeper ,102
+Lost in Space ,130
+The Manchurian Candidate ,129
+Déjà Vu ,117
+Hotel Transylvania 2 ,89
+Bewitched             ,25
+Fantasia 2000 ,74
+The Time Machine ,96
+Mighty Joe Young ,114
+Swordfish ,99
+The Legend of Zorro ,129
+What Dreams May Come ,113
+Little Nicky ,90
+The Brothers Grimm ,118
+Mars Attacks! ,106
+Evolution ,81
+The Edge ,117
+Surrogates ,89
+Thirteen Days ,145
+Daylight ,114
+Walking with Dinosaurs 3D ,87
+Battlefield Earth ,119
+Looney Tunes: Back in Action ,91
+Nine ,118
+Timeline ,116
+The Postman ,177
+Babe: Pig in the City ,97
+The Last Witch Hunter ,106
+Red Planet ,106
+Arthur and the Invisibles ,94
+Oceans ,104
+A Sound of Thunder ,102
+Pompeii ,105
+Top Cat Begins ,89
+A Beautiful Mind ,135
+The Lion King ,73
+Journey 2: The Mysterious Island ,94
+Cloudy with a Chance of Meatballs 2 ,95
+Red Dragon ,124
+Hidalgo ,136
+Jack and Jill ,91
+2 Fast 2 Furious ,107
+The Little Prince ,108
+The Invasion ,99
+The Adventures of Rocky & Bullwinkle ,92
+The Secret Life of Pets ,87
+The League of Extraordinary Gentlemen ,110
+Despicable Me 2 ,98
+Independence Day ,154
+The Lost World: Jurassic Park ,129
+Madagascar ,86
+Children of Men ,109
+X-Men ,104
+Wanted ,110
+The Rock ,136
+Ice Age: The Meltdown ,115
+50 First Dates ,99
+Hairspray ,117
+Exorcist: The Beginning ,125
+Inspector Gadget ,110
+Now You See Me ,125
+Grown Ups ,102
+The Terminal ,128
+Constantine             ,43
+Hotel for Dogs ,100
+Vertical Limit ,124
+Charlie Wilson's War ,102
+Shark Tale ,90
+Dreamgirls ,130
+Life             ,45
+Be Cool ,118
+Munich ,163
+Tears of the Sun ,142
+Killers ,100
+The Man from U.N.C.L.E. ,116
+Spanglish ,131
+Monster House ,91
+Bandits ,123
+First Knight ,134
+Anna and the King ,148
+Immortals ,110
+Hostage ,113
+Titan A.E. ,94
+Hollywood Homicide ,116
+Soldier ,99
+Carriers ,84
+Monkeybone ,93
+Flight of the Phoenix ,113
+Unbreakable ,106
+Minions ,91
+Sucker Punch ,128
+Snake Eyes ,98
+Sphere ,134
+The Angry Birds Movie ,97
+Fool's Gold ,112
+Funny People ,153
+The Kingdom ,110
+Talladega Nights: The Ballad of Ricky Bobby ,122
+Dr. Dolittle 2 ,87
+Braveheart ,178
+Jarhead ,125
+The Simpsons Movie ,87
+The Majestic ,152
+Driven ,116
+Two Brothers ,109
+The Village ,108
+Doctor Dolittle ,85
+Signs ,106
+Shrek 2 ,93
+Cars ,117
+Runaway Bride ,116
+xXx ,132
+The SpongeBob Movie: Sponge Out of Water ,92
+Ransom ,139
+Inglourious Basterds ,153
+Hook ,142
+Hercules ,101
+Die Hard 2 ,124
+S.W.A.T. ,117
+Sleepy Hollow             ,45
+Vanilla Sky ,141
+Lady in the Water ,110
+AVP: Alien vs. Predator ,109
+Alvin and the Chipmunks: The Squeakquel ,88
+We Were Soldiers ,124
+Olympus Has Fallen ,119
+Star Trek: Insurrection ,103
+Battle Los Angeles ,116
+Big Fish ,125
+Wolf ,125
+War Horse ,146
+The Monuments Men ,118
+The Abyss ,171
+Wall Street: Money Never Sleeps ,136
+Dracula Untold ,92
+The Siege ,116
+Stardust ,127
+Seven Years in Tibet ,136
+The Dilemma ,111
+Bad Company ,116
+Doom ,113
+I Spy ,97
+Underworld: Awakening ,88
+Rock of Ages ,136
+Hart's War ,125
+Killer Elite ,116
+Rollerball ,98
+Ballistic: Ecks vs. Sever ,91
+Hard Rain ,97
+Osmosis Jones ,95
+Legends of Oz: Dorothy's Return ,88
+Blackhat ,133
+Sky Captain and the World of Tomorrow ,106
+Basic Instinct 2 ,116
+Escape Plan ,115
+The Legend of Hercules ,99
+The Sum of All Fears ,124
+The Twilight Saga: Eclipse ,124
+The Score ,124
+Despicable Me ,87
+Money Train ,105
+Ted 2 ,125
+Agora ,141
+Mystery Men ,121
+Hall Pass ,111
+The Insider ,157
+The Finest Hours ,117
+Body of Lies ,128
+Dinner for Schmucks ,114
+Abraham Lincoln: Vampire Hunter ,105
+Entrapment ,113
+Last Man Standing             ,30
+The X Files ,121
+The Last Legion ,102
+Saving Private Ryan ,169
+Need for Speed ,132
+What Women Want ,127
+Ice Age ,103
+Dreamcatcher ,136
+Lincoln ,150
+The Matrix ,136
+Apollo 13 ,140
+Total Recall ,113
+The Santa Clause 2 ,104
+Les Misérables ,158
+You've Got Mail ,119
+Step Brothers ,106
+The Mask of Zorro ,136
+Due Date ,95
+Unbroken ,137
+Space Cowboys ,130
+Cliffhanger ,124
+Broken Arrow ,108
+The Kid ,104
+World Trade Center ,129
+Mona Lisa Smile ,117
+The Dictator ,99
+Eyes Wide Shut ,159
+Annie ,118
+Focus ,105
+This Means War ,103
+Blade: Trinity ,122
+Red Dawn ,114
+Primary Colors ,143
+Resident Evil: Retribution ,96
+Death Race ,111
+The Long Kiss Goodnight ,121
+Proof of Life ,135
+Zathura: A Space Adventure ,101
+Fight Club ,151
+We Are Marshall ,131
+The Missing             ,60
+Hudson Hawk ,100
+Lucky Numbers ,105
+"I, Frankenstein ",92
+Oliver Twist ,130
+Elektra ,100
+Sin City: A Dame to Kill For ,102
+Random Hearts ,133
+Everest ,121
+Perfume: The Story of a Murderer ,147
+Austin Powers in Goldmember ,94
+Astro Boy ,94
+Jurassic Park ,127
+Wyatt Earp ,212
+Clear and Present Danger ,141
+Dragon Blade ,103
+Littleman ,98
+U-571 ,116
+The American President ,114
+The Love Guru ,87
+3000 Miles to Graceland ,125
+The Hateful Eight ,187
+Blades of Glory ,93
+Hop ,95
+300 ,117
+Meet the Fockers ,106
+Marley & Me ,115
+The Green Mile ,189
+Wild Hogs ,100
+Chicken Little ,81
+Gone Girl ,149
+The Bourne Identity ,119
+GoldenEye ,130
+The General's Daughter ,116
+The Truman Show ,103
+The Prince of Egypt ,99
+Daddy Day Care ,92
+2 Guns ,109
+Cats & Dogs ,87
+The Italian Job ,111
+Two Weeks Notice ,101
+Antz ,83
+Couples Retreat ,113
+Days of Thunder ,107
+Cheaper by the Dozen 2 ,94
+The Scorch Trials ,132
+Eat Pray Love ,140
+The Family Man ,125
+RED ,111
+Any Given Sunday ,156
+The Horse Whisperer ,170
+Collateral ,120
+The Scorpion King ,100
+Ladder 49 ,115
+Jack Reacher ,130
+Deep Blue Sea ,105
+This Is It ,111
+Contagion ,106
+Kangaroo Jack ,89
+Coraline ,100
+The Happening ,91
+Man on Fire ,146
+The Shaggy Dog ,98
+Starsky & Hutch ,101
+Jingle All the Way ,94
+Hellboy ,132
+A Civil Action ,115
+ParaNorman ,92
+The Jackal ,124
+Paycheck ,119
+Up Close & Personal ,124
+The Tale of Despereaux ,93
+Rules of Engagement             ,22
+The Tuxedo ,98
+Under Siege 2: Dark Territory ,92
+Jack Ryan: Shadow Recruit ,105
+Joy ,124
+London Has Fallen ,99
+Alien: Resurrection ,116
+Shooter ,124
+The Boxtrolls ,96
+Practical Magic ,104
+The Lego Movie ,100
+Miss Congeniality 2: Armed and Fabulous ,115
+Reign of Fire ,101
+Gangster Squad ,113
+Year One ,100
+Invictus ,134
+State of Play ,127
+Duplicity ,125
+My Favorite Martian ,94
+The Sentinel ,107
+Planet 51 ,91
+Star Trek: Nemesis ,116
+Intolerable Cruelty ,100
+Trouble with the Curve ,111
+Edge of Darkness ,117
+The Relic ,110
+Analyze That ,96
+Righteous Kill ,101
+Mercury Rising ,111
+The Soloist ,117
+The Legend of Bagger Vance ,126
+Almost Famous ,152
+Garfield 2 ,86
+xXx: State of the Union ,101
+Priest ,87
+Sinbad: Legend of the Seven Seas ,85
+Event Horizon ,130
+The Avengers ,173
+Dragonfly ,104
+The Black Dahlia ,121
+Flyboys ,140
+The Last Castle ,131
+Supernova ,91
+Winter's Tale ,118
+The Mortal Instruments: City of Bones ,130
+Meet Dave ,90
+Dark Water ,103
+Edtv ,122
+Inkheart ,106
+The Spirit ,103
+Mortdecai ,107
+In the Name of the King: A Dungeon Siege Tale ,156
+Beyond Borders ,127
+Xi you ji zhi: Sun Wukong san da Baigu Jing ,119
+The Great Raid ,132
+Deadpool ,108
+Holy Man ,114
+American Sniper ,133
+Goosebumps ,103
+"Sabrina, the Teenage Witch             ",22
+Just Like Heaven ,95
+The Flintstones in Viva Rock Vegas ,90
+Rambo III ,87
+Leatherheads ,114
+The Ridiculous 6 ,119
+Did You Hear About the Morgans? ,103
+The Internship ,125
+Resident Evil: Afterlife ,97
+Red Tails ,125
+Sex and the City             ,30
+The Devil's Advocate ,136
+That's My Boy ,116
+DragonHeart ,103
+After the Sunset ,97
+Ghost Rider: Spirit of Vengeance ,96
+Captain Corelli's Mandolin ,131
+Anger Management             ,22
+The Pacifier ,95
+Walking Tall ,86
+Forrest Gump ,142
+Alvin and the Chipmunks ,92
+Meet the Parents ,108
+Pocahontas ,84
+Superman ,188
+The Nutty Professor ,95
+Hitch ,118
+George of the Jungle ,92
+American Wedding ,74
+Captain Phillips ,134
+Date Night ,101
+Casper ,100
+The Equalizer ,132
+Maid in Manhattan ,105
+Crimson Tide ,123
+The Pursuit of Happyness ,117
+Flightplan ,98
+Disclosure ,128
+City of Angels ,114
+Kill Bill: Vol. 1 ,111
+Bowfinger ,85
+Stargate SG-1             ,44
+Kill Bill: Vol. 2 ,137
+Tango & Cash ,97
+Death Becomes Her ,104
+Shanghai Noon ,110
+Executive Decision ,133
+Mr. Popper's Penguins ,94
+The Forbidden Kingdom ,104
+Free Birds ,91
+Alien 3 ,145
+Evita ,135
+Ronin ,122
+The Ghost and the Darkness ,110
+Paddington ,95
+The Watch ,102
+The Hunted ,94
+Instinct ,126
+Stuck on You ,118
+Semi-Pro ,99
+The Pirates! Band of Misfits ,88
+Changeling ,141
+Chain Reaction ,107
+The Fan ,116
+The Phantom of the Opera ,143
+Elizabeth: The Golden Age ,114
+Æon Flux ,93
+Gods and Generals ,280
+Turbulence ,100
+Imagine That ,107
+Muppets Most Wanted ,119
+Thunderbirds ,95
+Burlesque ,119
+A Very Long Engagement ,133
+Lolita ,152
+Eye See You ,96
+Blade II ,117
+Seven Pounds ,123
+Bullet to the Head ,92
+The Godfather: Part III ,170
+Elizabethtown ,123
+"You, Me and Dupree ",110
+Superman II ,116
+Gigli ,121
+All the King's Men ,128
+Shaft ,99
+Anastasia ,94
+Moulin Rouge! ,127
+Domestic Disturbance ,89
+Black Mass ,123
+Flags of Our Fathers ,135
+Law Abiding Citizen ,118
+Grindhouse ,189
+Beloved ,172
+Lucky You ,124
+Catch Me If You Can ,141
+Zero Dark Thirty ,157
+The Break-Up ,106
+Mamma Mia! ,108
+Valentine's Day ,125
+The Dukes of Hazzard ,107
+The Thin Red Line ,215
+The Change-Up ,118
+Man on the Moon ,118
+Casino ,178
+From Paris with Love ,92
+Bulletproof Monk ,104
+"Me, Myself & Irene ",116
+Barnyard ,90
+Deck the Halls ,93
+The Twilight Saga: New Moon ,130
+Shrek ,90
+The Adjustment Bureau ,106
+Robin Hood: Prince of Thieves ,155
+Jerry Maguire ,139
+Ted ,112
+As Good as It Gets ,139
+Patch Adams ,115
+Anchorman 2: The Legend Continues ,143
+Mr. Deeds ,96
+Super 8 ,112
+Erin Brockovich ,131
+How to Lose a Guy in 10 Days ,116
+22 Jump Street ,112
+Interview with the Vampire: The Vampire Chronicles ,123
+Yes Man ,104
+Central Intelligence ,107
+Stepmom ,124
+Daddy's Home ,96
+Into the Woods ,125
+Inside Man ,129
+Payback ,90
+Congo ,109
+We Bought a Zoo ,124
+Knowing ,121
+Failure to Launch ,95
+The Ring Two ,128
+"Crazy, Stupid, Love. ",118
+Garfield ,80
+Christmas with the Kranks ,99
+Moneyball ,133
+Outbreak ,127
+Non-Stop ,106
+Race to Witch Mountain ,98
+V for Vendetta ,132
+Shanghai Knights ,114
+Unforgotten             ,45
+Curious George ,78
+Herbie Fully Loaded ,101
+Don't Say a Word ,113
+Hansel & Gretel: Witch Hunters ,98
+Unfaithful ,124
+I Am Number Four ,109
+Syriana ,128
+13 Hours ,144
+The Book of Life ,95
+Firewall ,105
+Absolute Power ,121
+G.I. Jane ,125
+The Game ,129
+Silent Hill ,132
+The Replacements ,118
+American Reunion ,113
+The Negotiator ,140
+Into the Storm ,89
+Beverly Hills Cop III ,104
+Gremlins 2: The New Batch ,106
+The Judge ,141
+The Peacemaker ,124
+Resident Evil: Apocalypse ,98
+Bridget Jones: The Edge of Reason ,108
+Out of Time ,114
+On Deadly Ground ,101
+The Adventures of Sharkboy and Lavagirl 3-D ,93
+The Beach ,119
+Raising Helen ,119
+Ninja Assassin ,99
+For Love of the Game ,137
+A Touch of Frost             ,105
+Striptease ,117
+Marmaduke ,87
+Hereafter ,129
+Murder by Numbers ,115
+Assassins ,132
+Hannibal Rising ,131
+The Story of Us ,95
+The Host ,125
+Basic ,98
+Blood Work ,110
+The International ,118
+Escape from L.A. ,101
+Twisted             ,60
+The Iron Giant ,90
+The Life Aquatic with Steve Zissou ,119
+Free State of Jones ,139
+The Life of David Gale ,130
+Man of the House ,100
+Run All Night ,114
+Eastern Promises ,96
+Into the Blue ,110
+The Messenger: The Story of Joan of Arc ,158
+Your Highness ,102
+Dream House ,84
+Mad City ,115
+Baby's Day Out ,99
+The Scarlet Letter ,135
+Fair Game ,108
+Defiance             ,43
+Domino ,127
+Jade ,107
+Gamer ,95
+Beautiful Creatures ,124
+Death to Smoochy ,109
+Zoolander 2 ,102
+The Big Bounce ,88
+What Planet Are You From? ,87
+Drive Angry ,104
+Street Fighter: The Legend of Chun-Li ,96
+The One ,85
+Outlander             ,64
+The Adventures of Ford Fairlane ,104
+Pirate Radio ,135
+Traffic ,190
+Indiana Jones and the Last Crusade ,127
+Anna Karenina ,129
+Chappie ,120
+The Bone Collector ,118
+Panic Room ,112
+The Tooth Fairy ,89
+Three Kings ,114
+Child 44 ,137
+Rat Race ,112
+K-PAX ,120
+Kate & Leopold ,123
+Bedazzled ,93
+The Cotton Club ,123
+3:10 to Yuma ,122
+Taken 3 ,115
+Out of Sight ,123
+The Cable Guy ,96
+Earth ,110
+Dick Tracy ,105
+The Thomas Crown Affair ,113
+Riding in Cars with Boys ,132
+First Blood ,93
+Solaris ,115
+Happily N'Ever After ,75
+Mary Reilly ,108
+My Best Friend's Wedding ,105
+America's Sweethearts ,102
+Insomnia ,118
+Star Trek: First Contact ,111
+Jonah Hex ,81
+Courage Under Fire ,116
+Liar Liar ,86
+The Infiltrator ,127
+Inchon ,140
+The Flintstones ,91
+Taken 2 ,98
+Scary Movie 3 ,84
+Miss Congeniality ,109
+Journey to the Center of the Earth ,93
+The Princess Diaries 2: Royal Engagement ,113
+The Pelican Brief ,141
+The Client ,119
+The Bucket List ,97
+Patriot Games ,117
+Monster-in-Law ,101
+Prisoners ,153
+Training Day ,122
+Galaxy Quest ,102
+Scary Movie 2 ,83
+The Muppets ,103
+Blade ,110
+Coach Carter ,136
+Changing Lanes ,91
+Anaconda ,89
+Coyote Ugly ,107
+Love Actually ,129
+A Bug's Life ,95
+From Hell ,122
+The Specialist ,110
+Tin Cup ,135
+"Yours, Mine and Ours ",111
+Kicking & Screaming ,95
+The Hitchhiker's Guide to the Galaxy ,109
+Fat Albert ,93
+Resident Evil: Extinction ,94
+Blended ,117
+Last Holiday ,112
+The River Wild ,111
+The Indian in the Cupboard ,96
+Savages ,141
+Cellular ,94
+Johnny English ,87
+The Ant Bully ,88
+Dune ,177
+Across the Universe ,133
+Revolutionary Road ,119
+16 Blocks ,102
+Babylon A.D. ,101
+The Glimmer Man ,91
+Multiplicity ,117
+Aliens in the Attic ,86
+The Pledge ,124
+The Producers ,134
+Dredd ,95
+The Phantom ,100
+All the Pretty Horses ,220
+Nixon ,212
+The Ghost Writer ,128
+Deep Rising ,106
+Miracle at St. Anna ,160
+Curse of the Golden Flower ,114
+Bangkok Dangerous ,99
+Big Trouble ,74
+Love in the Time of Cholera ,139
+The Returned             ,52
+Shadow Conspiracy ,103
+Johnny English Reborn ,101
+Foodfight! ,91
+Argo ,130
+The Fugitive ,130
+The Bounty Hunter ,110
+Sleepers ,147
+Rambo: First Blood Part II ,96
+The Juror ,118
+Pinocchio ,88
+Heaven's Gate ,325
+Underworld: Evolution ,102
+Victor Frankenstein ,110
+Finding Forrester ,136
+28 Days ,103
+Unleashed ,103
+The Sweetest Thing ,90
+The Firm ,154
+Charlie St. Cloud ,99
+The Mechanic ,93
+21 Jump Street ,109
+Notting Hill ,124
+Chicken Run ,84
+Along Came Polly ,90
+Boomerang ,117
+The Heat ,123
+Cleopatra ,251
+Here Comes the Boom ,105
+High Crimes ,115
+The Mirror Has Two Faces ,122
+The Mothman Prophecies ,119
+Brüno ,81
+Licence to Kill ,133
+Red Riding Hood ,100
+15 Minutes ,120
+Super Mario Bros. ,104
+Lord of War ,122
+Hero ,80
+One for the Money ,91
+The Interview ,112
+The Warrior's Way ,100
+McHale's Navy             ,30
+Micmacs ,105
+8 Mile ,110
+Animal Kingdom: Let's go Ape ,101
+A Knight's Tale ,144
+The Medallion ,108
+The Sixth Sense ,107
+Man on a Ledge ,102
+The Big Year ,100
+The Karate Kid ,126
+American Hustle ,138
+The Proposal ,108
+Double Jeopardy ,105
+Back to the Future Part II ,108
+Lucy ,89
+Fifty Shades of Grey ,129
+Spy Kids 3-D: Game Over ,84
+A Time to Kill ,149
+Cheaper by the Dozen ,94
+Lone Survivor ,121
+A League of Their Own ,128
+The Conjuring 2 ,134
+The Social Network ,120
+He's Just Not That Into You ,129
+Scary Movie 4 ,89
+Scream 3 ,116
+Back to the Future Part III ,118
+Get Hard ,107
+Bram Stoker's Dracula ,155
+Julie & Julia ,123
+42 ,128
+The Talented Mr. Ripley ,139
+Dumb and Dumber To ,109
+Eight Below ,120
+The Intern ,121
+Ride Along 2 ,102
+The Last of the Mohicans ,117
+Ray ,178
+Sin City ,147
+Vantage Point ,90
+"I Love You, Man ",105
+Shallow Hal ,114
+JFK ,206
+Big Momma's House 2 ,99
+The Mexican ,123
+Unbroken ,137
+17 Again ,102
+The Other Woman ,109
+The Final Destination ,82
+Bridge of Spies ,142
+Behind Enemy Lines ,106
+Get Him to the Greek ,114
+Shall We Dance ,106
+Small Soldiers ,108
+Spawn ,98
+The Count of Monte Cristo ,131
+The Lincoln Lawyer ,118
+Unknown ,113
+The Prestige ,130
+Horrible Bosses 2 ,116
+Escape from Planet Earth ,89
+Apocalypto ,139
+The Living Daylights ,130
+Predators ,107
+Legal Eagles ,116
+Secret Window ,96
+The Lake House ,99
+The Skeleton Key ,104
+The Odd Life of Timothy Green ,105
+Made of Honor ,101
+Jersey Boys ,134
+The Rainmaker ,135
+Gothika ,98
+Amistad ,155
+Medicine Man ,106
+Aliens vs. Predator: Requiem ,102
+Ri¢hie Ri¢h ,95
+Autumn in New York ,103
+Music and Lyrics ,95
+Paul ,109
+The Guilt Trip ,95
+Scream 4 ,111
+8MM ,123
+The Doors ,140
+Sex Tape ,94
+Hanging Up ,94
+Final Destination 5 ,92
+Mickey Blue Eyes ,102
+Pay It Forward ,123
+Fever Pitch ,104
+Arthur             ,30
+Drillbit Taylor ,102
+A Million Ways to Die in the West ,136
+The Shadow ,93
+Extremely Loud & Incredibly Close ,129
+Morning Glory ,107
+Get Rich or Die Tryin' ,117
+The Art of War ,116
+Rent ,135
+Bless the Child ,107
+The Out-of-Towners ,90
+The Island of Dr. Moreau ,99
+The Musketeer ,104
+The Other Boleyn Girl ,115
+Sweet November ,119
+The Reaping ,99
+Mean Streets ,112
+Renaissance Man ,128
+Colombiana ,112
+The Magic Sword: Quest for Camelot ,86
+City by the Sea ,108
+At First Sight ,128
+Torque ,84
+City Hall ,111
+Showgirls ,131
+Marie Antoinette ,123
+Kiss of Death ,101
+Get Carter ,102
+The Impossible ,114
+Ishtar ,107
+Fantastic Mr. Fox ,87
+Life or Something Like It ,103
+Memoirs of an Invisible Man ,99
+Amélie ,122
+New York Minute ,91
+Alfie ,103
+Big Miracle ,107
+The Deep End of the Ocean ,106
+Feardotcom ,101
+Cirque du Freak: The Vampire's Assistant ,109
+Victor Frankenstein ,110
+Duplex ,89
+Soul Men ,100
+Raise the Titanic ,119
+Universal Soldier: The Return ,83
+Pandorum ,108
+Impostor ,102
+Extreme Ops ,93
+Just Visiting ,84
+Sunshine ,107
+A Thousand Words ,91
+Delgo ,94
+The Gunman ,115
+Alex Rider: Operation Stormbreaker ,93
+Disturbia ,105
+Hackers ,107
+The Hunting Party ,101
+The Hudsucker Proxy ,111
+The Warlords ,113
+Nomad: The Warrior ,112
+Snowpiercer ,126
+A Monster in Paris ,90
+The Last Shot ,93
+The Crow ,98
+Baahubali: The Beginning ,159
+The Time Traveler's Wife ,107
+Because I Said So ,102
+The Fast and the Furious ,106
+Frankenweenie ,87
+Serenity ,119
+Against the Ropes ,110
+Superman III ,125
+Grudge Match ,113
+Red Cliff ,150
+Sweet Home Alabama ,108
+The Ugly Truth ,96
+Sgt. Bilko ,93
+Spy Kids 2: Island of Lost Dreams ,100
+Star Trek: Generations ,118
+The Grandmaster ,122
+Water for Elephants ,120
+3rd Rock from the Sun             ,60
+Dragon Nest: Warriors' Dawn ,88
+The Hurricane ,146
+Enough ,115
+Heartbreakers ,123
+Paul Blart: Mall Cop 2 ,94
+Angel Eyes ,102
+Joe Somebody ,98
+The Ninth Gate ,133
+Extreme Measures ,118
+Rock Star ,105
+Precious ,109
+White Squall ,129
+The Thing ,109
+Riddick ,127
+Switchback ,118
+Texas Rangers ,110
+City of Ember ,90
+The Master ,144
+Virgin Territory ,97
+The Express ,130
+The 5th Wave ,112
+Creed ,133
+The Town ,150
+What to Expect When You're Expecting ,110
+Burn After Reading ,96
+Nim's Island ,96
+Rush ,123
+Magnolia ,188
+Cop Out ,107
+How to Be Single ,110
+Dolphin Tale ,113
+Twilight ,122
+John Q ,116
+Blue Streak ,93
+We're the Millers ,118
+Obitaemyy ostrov ,115
+Breakdown ,93
+Never Say Never Again ,121
+Hot Tub Time Machine ,101
+Dolphin Tale 2 ,107
+Reindeer Games ,124
+A Man Apart ,109
+Aloha ,105
+Ghosts of Mississippi ,130
+Snow Falling on Cedars ,127
+The Rite ,114
+Gattaca ,106
+Isn't She Great ,95
+Space Chimps ,81
+Head of State ,95
+The Hangover ,108
+Ip Man 3 ,105
+Austin Powers: The Spy Who Shagged Me ,95
+Batman ,126
+There Be Dragons ,102
+Lethal Weapon 3 ,121
+The Blind Side ,129
+Rush Hour             ,43
+Spy Kids ,88
+Horrible Bosses ,106
+True Grit ,110
+The Devil Wears Prada ,109
+Star Trek: The Motion Picture ,143
+Identity Thief ,120
+Cape Fear ,128
+21 ,123
+Trainwreck ,129
+Guess Who ,105
+The English Patient ,162
+L.A. Confidential ,138
+Sky High ,100
+In & Out ,90
+Species ,108
+A Nightmare on Elm Street ,101
+The Cell ,109
+The Man in the Iron Mask ,132
+Secretariat ,123
+TMNT ,87
+Radio ,109
+Friends with Benefits ,109
+Neighbors 2: Sorority Rising ,92
+Saving Mr. Banks ,125
+Malcolm X ,202
+This Is 40 ,134
+Old Dogs ,88
+Underworld: Rise of the Lycans ,92
+License to Wed ,91
+The Benchwarmers ,75
+Must Love Dogs ,98
+Donnie Brasco ,147
+Resident Evil ,100
+Poltergeist ,120
+The Ladykillers ,104
+Max Payne ,103
+In Time ,109
+The Back-up Plan ,104
+Something Borrowed ,112
+Hit the Floor             ,60
+Black Knight ,95
+The Bad News Bears ,102
+Street Fighter ,102
+The Pianist ,150
+From Hell ,122
+The Nativity Story ,101
+House of Wax ,108
+Closer ,98
+J. Edgar ,137
+Mirrors ,112
+Queen of the Damned ,101
+Predator 2 ,103
+Untraceable ,101
+Blast from the Past ,112
+Flash Gordon ,111
+Jersey Girl ,102
+Alex Cross ,101
+Midnight in the Garden of Good and Evil ,155
+Heist ,93
+Nanny McPhee Returns ,109
+Hoffa ,140
+The X Files: I Want to Believe ,108
+Ella Enchanted ,96
+Concussion ,123
+Abduction ,106
+Valiant ,76
+Wonder Boys ,107
+Superhero Movie ,82
+Broken City ,109
+Cursed ,99
+Premium Rush ,91
+Hot Pursuit ,87
+The Four Feathers ,125
+Parker ,118
+Wimbledon ,98
+Furry Vengeance ,92
+Bait ,93
+Krull ,116
+Lions for Lambs ,92
+Flight of the Intruder ,115
+Walk Hard: The Dewey Cox Story ,120
+The Shipping News ,111
+American Outlaws ,94
+The Young Victoria ,100
+Whiteout ,101
+The Tree of Life ,139
+Knock Off ,91
+Sabotage ,109
+The Order ,102
+Punisher: War Zone ,103
+Zoom ,83
+The Walk ,123
+Warriors of Virtue ,101
+A Good Year ,117
+Luther             ,60
+Radio Flyer ,114
+"Blood In, Blood Out ",330
+Smilla's Sense of Snow ,121
+Femme Fatale ,114
+Lion of the Desert ,156
+The Horseman on the Roof ,135
+Ride with the Devil ,148
+Biutiful ,148
+The Lovers ,109
+Bandidas ,93
+Black Water Transit ,
+The Maze Runner ,113
+Unfinished Business ,91
+The Age of Innocence ,139
+The Fountain ,96
+Chill Factor ,102
+Stolen ,96
+Ponyo ,101
+The Longest Ride ,128
+The Astronaut's Wife ,109
+I Dreamed of Africa ,114
+Playing for Keeps ,105
+Mandela: Long Walk to Freedom ,141
+Reds ,195
+A Few Good Men ,138
+Exit Wounds ,101
+Big Momma's House ,99
+Thunder and the House of Magic ,85
+The Darkest Hour ,89
+Step Up Revolution ,99
+Snakes on a Plane ,105
+The Watcher ,97
+The Punisher ,140
+Goal! The Dream Begins ,118
+Safe ,94
+Pushing Tin ,124
+Star Wars: Episode VI - Return of the Jedi ,134
+Doomsday ,113
+The Reader ,124
+Wanderlust ,98
+Elf ,97
+Phenomenon ,123
+Snow Dogs ,99
+Scrooged ,101
+Nacho Libre ,92
+Bridesmaids ,131
+This Is the End ,107
+Stigmata ,103
+Men of Honor ,129
+Takers ,107
+The Big Wedding ,89
+"Big Mommas: Like Father, Like Son ",113
+Source Code ,93
+Alive ,120
+The Number 23 ,98
+The Young and Prodigious T.S. Spivet ,105
+1941 ,142
+Dreamer: Inspired by a True Story ,98
+A History of Violence ,96
+Transporter 2 ,87
+The Quick and the Dead ,107
+Laws of Attraction ,90
+Bringing Out the Dead ,121
+Repo Men ,119
+Dragon Wars: D-War ,107
+Bogus ,110
+The Incredible Burt Wonderstone ,100
+Cats Don't Dance ,75
+Cradle Will Rock ,132
+The Good German ,105
+George and the Dragon ,93
+Apocalypse Now ,289
+Going the Distance ,102
+Mr. Holland's Opus ,143
+Criminal ,113
+Out of Africa ,161
+Flight ,138
+Moonraker ,126
+The Grand Budapest Hotel ,99
+Hearts in Atlantis ,101
+Arachnophobia ,103
+Frequency ,118
+Ghostbusters ,116
+Vacation ,99
+Get Shorty ,105
+Chicago ,113
+Big Daddy ,93
+American Pie 2 ,108
+Toy Story ,74
+Speed ,116
+The Vow ,104
+Extraordinary Measures ,106
+Remember the Titans ,120
+The Hunt for Red October ,135
+Lee Daniels' The Butler ,132
+Dodgeball: A True Underdog Story ,92
+The Addams Family ,99
+Ace Ventura: When Nature Calls ,90
+The Princess Diaries ,111
+The First Wives Club ,103
+Se7en ,127
+District 9 ,112
+The SpongeBob SquarePants Movie ,87
+Mystic River ,138
+Million Dollar Baby ,132
+Analyze This ,103
+The Notebook ,123
+27 Dresses ,111
+Hannah Montana: The Movie ,102
+Rugrats in Paris: The Movie ,78
+The Prince of Tides ,132
+Legends of the Fall ,133
+Up in the Air ,108
+About Schmidt ,125
+Warm Bodies ,98
+Looper ,119
+Down to Earth ,87
+Babe ,91
+Hope Springs ,100
+Forgetting Sarah Marshall ,118
+Friday Night Lights             ,44
+Four Brothers ,109
+Baby Mama ,99
+Hope Floats ,114
+Bride Wars ,89
+Without a Paddle ,95
+13 Going on 30 ,98
+Midnight in Paris ,94
+The Nut Job ,85
+Blow ,124
+Message in a Bottle ,131
+Star Trek V: The Final Frontier ,107
+Like Mike ,99
+Naked Gun 33 1/3: The Final Insult ,83
+A View to a Kill ,131
+The Curse of the Were-Rabbit ,85
+P.S. I Love You ,126
+Racing Stripes ,102
+Atonement ,123
+Letters to Juliet ,105
+Black Rain ,125
+The Three Stooges ,92
+Corpse Bride ,77
+Glory Road ,118
+Sicario ,121
+Southpaw ,124
+Drag Me to Hell ,99
+The Age of Adaline ,112
+Secondhand Lions ,111
+Step Up 3D ,107
+Blue Crush ,104
+Stranger Than Fiction ,113
+30 Days of Night ,113
+The Cabin in the Woods ,95
+Meet the Spartans ,86
+Midnight Run ,126
+The Running Man ,101
+Little Shop of Horrors ,102
+Hanna ,111
+The Family             ,60
+Mortal Kombat: Annihilation ,95
+Larry Crowne ,98
+Carrie ,100
+Take the Lead ,118
+Entourage             ,28
+Gridiron Gang ,125
+What's the Worst That Could Happen? ,94
+9 ,79
+Side Effects ,106
+The Prince and Me ,111
+Winnie the Pooh ,63
+Dumb and Dumberer: When Harry Met Lloyd ,85
+Bulworth ,108
+Get on Up ,139
+One True Thing ,127
+Virtuosity ,106
+My Super Ex-Girlfriend ,95
+Deliver Us from Evil ,118
+Sanctum ,108
+Little Black Book ,105
+The Five-Year Engagement ,131
+Mr 3000 ,104
+The Next Three Days ,133
+Ultraviolet ,94
+Assault on Precinct 13 ,109
+The Replacement Killers ,96
+Fled ,105
+Eight Legged Freaks ,99
+Love & Other Drugs ,112
+88 Minutes ,108
+North Country ,126
+The Whole Ten Yards ,98
+Splice ,104
+Howard the Duck ,110
+Pride and Glory ,130
+The Cave ,93
+Alex & Emma ,96
+Wicker Park ,114
+Fright Night ,106
+The New World ,150
+Wing Commander ,100
+In Dreams ,100
+Dragonball: Evolution ,100
+The Last Stand ,107
+Godsend ,102
+Chasing Liberty ,101
+Hoodwinked Too! Hood vs. Evil ,86
+An Unfinished Life ,108
+The Imaginarium of Doctor Parnassus ,123
+Barney's Version ,134
+Trapped             ,511
+Runner Runner ,88
+Antitrust ,109
+Glory ,122
+Once Upon a Time in America ,251
+Dead Man Down ,118
+The Merchant of Venice ,131
+The Good Thief ,109
+Supercross ,80
+Miss Potter ,88
+The Promise ,103
+DOA: Dead or Alive ,87
+The Assassination of Jesse James by the Coward Robert Ford ,160
+1911 ,121
+Little Nicholas ,91
+Wild Card ,92
+Machine Gun Preacher ,129
+Animals United ,93
+The Color of Freedom ,118
+United Passions ,110
+Grace of Monaco ,103
+A Warrior's Tail ,85
+Ripley's Game ,110
+Sausage Party ,89
+Pitch Perfect 2 ,115
+Walk the Line ,153
+12 Monkeys             ,42
+Keeping the Faith ,128
+The Borrowers ,89
+Frost/Nixon ,122
+Confessions of a Dangerous Mind ,113
+Serving Sara ,99
+The Boss ,99
+Cry Freedom ,147
+Mumford ,112
+Seed of Chucky ,88
+The Jacket ,94
+Aladdin ,90
+Straight Outta Compton ,167
+Indiana Jones and the Temple of Doom ,118
+The Rugrats Movie ,83
+Along Came a Spider ,104
+Florence Foster Jenkins ,110
+Once Upon a Time in Mexico ,102
+Die Hard ,131
+Role Models ,101
+The Big Short ,130
+Taking Woodstock ,120
+Miracle ,135
+Dawn of the Dead ,110
+The Wedding Planner ,103
+Harlock: Space Pirate ,115
+The Royal Tenenbaums ,110
+Identity ,91
+Last Vegas ,105
+For Your Eyes Only ,127
+Serendipity ,82
+Timecop ,99
+Zoolander ,90
+Safe Haven ,115
+Hocus Pocus ,96
+No Reservations ,104
+Kick-Ass ,117
+30 Minutes or Less ,83
+Dracula 2000 ,99
+"Alexander and the Terrible, Horrible, No Good, Very Bad Day ",81
+Pride & Prejudice ,135
+Blade Runner ,117
+Rob Roy ,139
+3 Days to Kill ,123
+We Own the Night ,117
+Lost Souls ,97
+Winged Migration ,81
+Just My Luck ,103
+"Mystery, Alaska ",119
+The Spy Next Door ,94
+A Simple Wish ,89
+Ghosts of Mars ,98
+Our Brand Is Crisis ,107
+Pride and Prejudice and Zombies ,108
+Kundun ,134
+How to Lose Friends & Alienate People ,110
+Kick-Ass 2 ,103
+Captain Alatriste: The Spanish Musketeer ,145
+Brick Mansions ,100
+Octopussy ,131
+Knocked Up ,133
+My Sister's Keeper ,109
+"Welcome Home, Roscoe Jenkins ",114
+A Passage to India ,164
+Notes on a Scandal ,92
+Rendition ,122
+Limitless             ,42
+Star Trek VI: The Undiscovered Country ,110
+Divine Secrets of the Ya-Ya Sisterhood ,116
+The Jungle Book ,106
+Kiss the Girls ,115
+The Blues Brothers ,148
+The Sisterhood of the Traveling Pants 2 ,119
+Joyful Noise ,118
+About a Boy ,101
+Lake Placid ,82
+Lucky Number Slevin ,110
+The Right Stuff ,193
+Anonymous ,130
+The NeverEnding Story ,94
+Dark City ,111
+The Duchess ,110
+The Honeymooners             ,30
+Return to Oz ,109
+The Newton Boys ,123
+Case 39 ,109
+Suspect Zero ,99
+Martian Child ,106
+Spy Kids: All the Time in the World in 4D ,89
+Money Monster ,98
+Formula 51 ,93
+Flawless ,112
+Mindhunters ,101
+What Just Happened ,104
+The Statement ,120
+The Magic Flute ,135
+Paul Blart: Mall Cop ,91
+Freaky Friday ,97
+The 40-Year-Old Virgin ,133
+Shakespeare in Love ,123
+A Walk Among the Tombstones ,114
+Kindergarten Cop ,111
+Pineapple Express ,117
+Ever After: A Cinderella Story ,121
+Open Range ,139
+Flatliners ,115
+It's Always Sunny in Philadelphia             ,22
+A Bridge Too Far ,175
+Red Eye ,85
+Final Destination 2 ,90
+"O Brother, Where Art Thou? ",107
+Legion ,100
+Pain & Gain ,129
+In Good Company ,109
+Clockstoppers ,94
+Silverado ,133
+Brothers ,105
+Agent Cody Banks 2: Destination London ,100
+New Year's Eve ,113
+Original Sin ,118
+The Raven ,110
+Welcome to Mooseport ,110
+Highlander: The Final Dimension ,99
+Blood and Wine ,101
+Snow White: A Tale of Terror ,100
+The Curse of the Jade Scorpion ,103
+Accidental Love ,100
+Flipper ,95
+Self/less ,117
+The Constant Gardener ,129
+The Passion of the Christ ,120
+Mrs. Doubtfire ,125
+Rain Man ,133
+Gran Torino ,116
+W. ,129
+Taken ,93
+The Best of Me ,118
+The Bodyguard ,129
+Schindler's List ,185
+The Help ,146
+The Fifth Estate ,128
+Scooby-Doo 2: Monsters Unleashed ,93
+Viy ,107
+Freddy vs. Jason ,97
+The Face of an Angel ,101
+Jimmy Neutron: Boy Genius ,82
+Cloverfield ,85
+Teenage Mutant Ninja Turtles II: The Secret of the Ooze ,88
+The Untouchables ,119
+No Country for Old Men ,122
+Ride Along ,99
+Bridget Jones's Diary ,97
+Chocolat ,121
+"Legally Blonde 2: Red, White & Blonde ",95
+Parental Guidance ,105
+Reno 911!: Miami ,84
+Tombstone ,134
+Romeo Must Die ,115
+The Omen ,107
+Final Destination 3 ,86
+The Lucky One ,101
+Bridge to Terabithia ,96
+Finding Neverland ,101
+A Madea Christmas ,100
+The Grey ,117
+Hide and Seek ,101
+Anchorman: The Legend of Ron Burgundy ,98
+Goodfellas ,146
+Agent Cody Banks ,102
+Nanny McPhee ,97
+Scarface ,142
+Nothing to Lose ,98
+The Last Emperor ,219
+Contraband ,109
+Money Talks ,97
+There Will Be Blood ,158
+The Wild Thornberrys Movie ,85
+Rugrats Go Wild ,80
+Undercover Brother ,86
+The Sisterhood of the Traveling Pants ,119
+Kiss of the Dragon ,98
+The House Bunny ,97
+Beauty Shop ,105
+Million Dollar Arm ,124
+The Giver ,97
+What a Girl Wants ,105
+Jeepers Creepers II ,104
+Good Luck Chuck ,101
+Cradle 2 the Grave ,101
+The Hours ,114
+She's the Man ,105
+Mr. Bean's Holiday ,90
+Anacondas: The Hunt for the Blood Orchid ,97
+Blood Ties ,144
+August Rush ,114
+Elizabeth ,124
+Bride of Chucky ,89
+Tora! Tora! Tora! ,160
+Spice World ,93
+The Sitter ,87
+Dance Flick ,88
+The Shawshank Redemption ,142
+Crocodile Dundee in Los Angeles ,92
+Kingpin ,117
+The Gambler ,111
+August: Osage County ,121
+Ice Princess ,98
+A Lot Like Love ,107
+Eddie the Eagle ,106
+He Got Game ,136
+Don Juan DeMarco ,97
+Shaun the Sheep             ,7
+Dear John ,108
+The Losers ,97
+Don't Be Afraid of the Dark ,99
+War ,103
+Punch-Drunk Love ,95
+EuroTrip ,93
+Half Past Dead ,98
+Unaccompanied Minors ,90
+"Bright Lights, Big City ",107
+The Adventures of Pinocchio ,90
+The Greatest Game Ever Played ,120
+The Box ,115
+The Ruins ,93
+The Next Best Thing ,99
+My Soul to Take ,107
+The Girl Next Door ,110
+Maximum Risk ,101
+Stealing Harvard ,85
+Legend ,132
+Hot Rod ,88
+Shark Night 3D ,90
+Angela's Ashes ,145
+Draft Day ,110
+Lifeforce ,101
+The Powerpuff Girls             ,30
+The Conspirator ,122
+Lords of Dogtown ,107
+The 33 ,127
+Big Trouble in Little China ,99
+A Perfect Plan ,104
+Warrior ,140
+Michael Collins ,133
+Gettysburg ,271
+Stop-Loss ,112
+Abandon ,99
+Brokedown Palace ,100
+The Possession ,92
+Mrs. Winterbourne ,105
+Straw Dogs ,110
+The Hoax ,116
+Stone Cold ,88
+The Road ,111
+Sheena ,117
+Underclassman ,95
+Say It Isn't So ,95
+The World's Fastest Indian ,127
+Snakes on a Plane ,105
+Tank Girl ,104
+King's Ransom ,95
+Blindness ,121
+BloodRayne ,92
+Carnage ,80
+Where the Truth Lies ,107
+Cirque du Soleil: Worlds Away ,91
+Without Limits ,117
+Me and Orson Welles ,107
+The Best Offer ,131
+Bad Lieutenant: Port of Call New Orleans ,122
+A Turtle's Tale: Sammy's Adventures ,88
+Little White Lies ,134
+Love Ranch ,117
+The True Story of Puss'N Boots ,80
+Space Dogs ,85
+The Counselor ,138
+Ironclad ,121
+Waterloo ,134
+Kung Fu Killer ,100
+Red Sky ,100
+Dangerous Liaisons ,119
+On the Road ,137
+Star Trek IV: The Voyage Home ,119
+Rocky Balboa ,139
+Point Break ,114
+Scream 2 ,120
+Jane Got a Gun ,98
+Think Like a Man Too ,106
+The Whole Nine Yards ,98
+Footloose ,107
+Old School ,88
+The Fisher King ,137
+I Still Know What You Did Last Summer ,100
+Return to Me ,115
+Zack and Miri Make a Porno ,101
+Nurse Betty ,110
+The Men Who Stare at Goats ,94
+Double Take ,88
+"Girl, Interrupted ",127
+Win a Date with Tad Hamilton! ,95
+Muppets from Space ,87
+The Wiz ,118
+Ready to Rumble ,107
+Play It to the Bone ,124
+I Don't Know How She Does It ,89
+Piranha 3D ,88
+Beyond the Sea ,118
+Meet the Deedles ,93
+The Princess and the Cobbler ,80
+The Bridge of San Luis Rey ,120
+Faster ,98
+Howl's Moving Castle ,119
+Zombieland ,88
+King Kong ,201
+The Waterboy ,90
+Star Wars: Episode V - The Empire Strikes Back ,127
+Bad Boys ,119
+The Naked Gun 2½: The Smell of Fear ,85
+Final Destination ,98
+The Ides of March ,101
+Pitch Black ,112
+Someone Like You... ,97
+Her ,126
+Eddie the Eagle ,106
+Joy Ride ,97
+The Adventurer: The Curse of the Midas Box ,100
+Anywhere But Here ,114
+Chasing Liberty ,101
+The Crew ,88
+Haywire ,93
+Jaws: The Revenge ,92
+Marvin's Room ,98
+The Longshots ,94
+The End of the Affair ,102
+Harley Davidson and the Marlboro Man ,98
+In the Valley of Elah ,121
+Coco Before Chanel ,111
+Forsaken ,90
+Chéri ,100
+Rogue             ,50
+Vanity Fair ,141
+Bodyguards and Assassins ,139
+1408 ,114
+Spaceballs ,96
+The Water Diviner ,111
+Ghost ,127
+There's Something About Mary ,107
+The Santa Clause ,97
+The Rookie ,127
+The Game Plan ,110
+The Bridges of Madison County ,135
+The Animal ,84
+Gandhi ,240
+The Hundred-Foot Journey ,122
+The Net ,114
+I Am Sam ,132
+Son of God ,170
+Underworld ,133
+Derailed ,112
+The Informant! ,108
+Shadowlands ,115
+Deuce Bigalow: European Gigolo ,83
+Delivery Man ,105
+Victor Frankenstein ,110
+Our Kind of Traitor ,108
+Saving Silverman ,96
+Diary of a Wimpy Kid: Dog Days ,94
+Summer of Sam ,142
+Jay and Silent Bob Strike Back ,104
+The Island ,136
+The Glass House ,106
+"Hail, Caesar! ",106
+Josie and the Pussycats ,98
+Homefront ,100
+The Little Vampire ,95
+I Heart Huckabees ,107
+RoboCop 3 ,104
+Megiddo: The Omega Code 2 ,104
+Darling Lili ,143
+Dudley Do-Right ,77
+The Transporter Refueled ,96
+The Libertine ,114
+Black Book ,145
+Joyeux Noel ,116
+Hit and Run ,100
+Mad Money ,104
+Before I Go to Sleep ,92
+Sorcerer ,92
+Stone ,105
+Molière ,120
+Out of the Furnace ,116
+Michael Clayton ,119
+My Fellow Americans ,101
+Arlington Road ,117
+Underdogs ,106
+To Rome with Love ,112
+Firefox ,136
+South Park: Bigger Longer & Uncut ,81
+Death at a Funeral ,87
+Teenage Mutant Ninja Turtles III ,96
+Hardball ,106
+Silver Linings Playbook ,122
+Freedom Writers ,123
+For Colored Girls ,133
+The Transporter ,92
+Never Back Down ,110
+The Rage: Carrie 2 ,104
+The Bachelor             ,60
+Away We Go ,98
+Swing Vote ,120
+Moonlight Mile ,112
+Tinker Tailor Soldier Spy ,127
+Molly ,102
+The Beaver ,91
+The Best Little Whorehouse in Texas ,114
+eXistenZ ,115
+Raiders of the Lost Ark ,115
+Home Alone 2: Lost in New York ,120
+Close Encounters of the Third Kind ,135
+Pulse ,90
+Beverly Hills Cop II ,100
+Bringing Down the House ,105
+The Silence of the Lambs ,138
+Wayne's World ,94
+Jackass 3D ,101
+Jaws 2 ,131
+Beverly Hills Chihuahua ,91
+The Conjuring ,112
+Are We There Yet? ,95
+Tammy ,100
+Disturbia ,105
+School of Rock ,108
+Mortal Kombat ,101
+Wicker Park ,114
+White Chicks ,109
+The Descendants ,115
+Holes ,117
+The Last Song ,107
+12 Years a Slave ,134
+Drumline ,118
+Why Did I Get Married Too? ,121
+Edward Scissorhands ,105
+Me Before You ,110
+Madea's Witness Protection ,114
+The French Connection ,104
+Bad Moms ,100
+Date Movie ,85
+Return to Never Land ,72
+Selma ,128
+The Jungle Book 2 ,72
+Boogeyman ,89
+Premonition ,96
+The Tigger Movie ,77
+Orphan ,123
+Max ,111
+Meet the Browns             ,30
+Epic Movie ,93
+Conan the Barbarian ,129
+Spotlight ,128
+Lakeview Terrace ,110
+The Grudge 2 ,137
+How Stella Got Her Groove Back ,124
+Bill & Ted's Bogus Journey ,93
+Man of the Year ,115
+The Black Hole ,98
+The American ,105
+Selena ,127
+Vampires Suck ,82
+Babel ,143
+This Is Where I Leave You ,103
+Doubt ,104
+Team America: World Police ,98
+Texas Chainsaw 3D ,92
+Copycat ,123
+Scary Movie 5 ,88
+Paint Your Wagon ,158
+Milk ,128
+Risen ,107
+Ghost Ship ,91
+A Very Harold & Kumar 3D Christmas ,90
+Wild Things ,115
+The Stepfather ,101
+The Debt ,113
+High Fidelity ,113
+One Missed Call ,87
+Eye for an Eye ,101
+The Bank Job ,111
+Eternal Sunshine of the Spotless Mind ,108
+You Again ,105
+Street Kings ,109
+The World's End ,109
+Nancy Drew ,99
+Daybreakers ,98
+She's Out of My League ,104
+Monte Carlo ,109
+Stay Alive ,75
+Quigley Down Under ,119
+Alpha and Omega ,90
+The Covenant ,97
+Stick It ,103
+Shorts ,89
+To Die For ,106
+Nerve ,96
+Appaloosa ,115
+Vampires ,104
+Yu-Gi-Oh! Duel Monsters             ,24
+Psycho ,108
+My Best Friend's Girl ,112
+Endless Love ,104
+Georgia Rule ,113
+Under the Rainbow ,98
+Ladyhawke ,121
+Simon Birch ,114
+Reign Over Me ,124
+Into the Wild ,148
+School for Scoundrels ,108
+Silent Hill: Revelation 3D ,95
+From Dusk Till Dawn ,108
+Pooh's Heffalump Movie ,68
+Home for the Holidays ,103
+Kung Fu Hustle ,99
+Fired Up             ,30
+The Country Bears ,88
+The Kite Runner ,128
+21 Grams ,124
+Paparazzi ,84
+Twilight ,122
+A Guy Thing ,101
+Loser ,98
+Capitalism: A Love Story ,105
+The Greatest Story Ever Told ,225
+Secret in Their Eyes ,111
+Disaster Movie ,88
+Armored ,88
+The Man Who Knew Too Little ,94
+What's Your Number? ,117
+Lockout ,95
+Envy ,99
+Crank: High Voltage ,96
+Bullets Over Broadway ,98
+One Night with the King ,123
+The Quiet American ,101
+The Weather Man ,102
+Undisputed ,94
+Ghost Town ,102
+12 Rounds ,108
+Let Me In ,116
+3 Ninjas Kick Back ,93
+Be Kind Rewind ,102
+Mrs Henderson Presents ,103
+Triple 9 ,115
+Deconstructing Harry ,96
+Three to Tango ,98
+Burnt ,101
+We're No Angels ,106
+Everyone Says I Love You ,101
+Death at a Funeral ,87
+Death Sentence ,111
+Everybody's Fine ,99
+Superbabies: Baby Geniuses 2 ,88
+The Man ,83
+Code Name: The Cleaner ,91
+Connie and Carla ,108
+Sweet Charity ,154
+Inherent Vice ,148
+Doogal ,77
+Battle of the Year ,110
+Perception             ,42
+An American Carol ,83
+Machete Kills ,107
+Willard ,100
+Strange Wilderness ,87
+Topsy-Turvy ,154
+Little Boy ,106
+A Dangerous Method ,99
+A Scanner Darkly ,100
+Chasing Mavericks ,116
+Alone in the Dark ,94
+Bandslam ,111
+Birth ,100
+A Most Violent Year ,125
+Passchendaele ,114
+Flash of Genius ,119
+I'm Not There. ,135
+The Cold Light of Day ,93
+The Brothers Bloom ,114
+"Synecdoche, New York ",124
+Princess Mononoke ,134
+Bon voyage ,114
+Can't Stop the Music ,124
+The Proposition ,104
+Courage ,118
+Marci X ,80
+Equilibrium ,107
+The Children of Huang Shi ,125
+The Yards ,115
+The Oogieloves in the Big Balloon Adventure ,88
+By the Sea ,122
+Steamboy ,103
+The Game of Their Lives ,101
+All Good Things ,101
+Rapa Nui ,107
+CJ7 ,86
+Les couloirs du temps: Les visiteurs II ,118
+Dylan Dog: Dead of Night ,107
+People I Know ,100
+The Doombolt Chase             ,30
+The Tempest ,110
+Regression ,106
+The Touch ,7
+Three Kingdoms: Resurrection of the Dragon ,102
+Shattered ,98
+Zambezia ,83
+Ramanujan ,153
+Dwegons and Leprechauns ,98
+Hands of Stone ,105
+Survivor ,96
+The Frozen Ground ,105
+The Painted Veil ,125
+The Baader Meinhof Complex ,184
+Dances with Wolves ,236
+Bad Teacher ,97
+Sea of Love ,113
+A Cinderella Story ,95
+Scream ,103
+Thir13en Ghosts ,91
+The Shining ,146
+Back to the Future ,116
+House on Haunted Hill ,93
+I Can Do Bad All by Myself ,113
+Fight Valley ,90
+The Switch ,101
+Just Married ,95
+The Devil's Double ,109
+"Gone, Baby, Gone             ",43
+Thomas and the Magic Railroad ,85
+The Crazies ,101
+Spirited Away ,125
+Firestorm ,118
+The Bounty ,132
+The Book Thief ,131
+Sex Drive ,129
+Leap Year ,100
+The Fall of the Roman Empire ,172
+Take Me Home Tonight ,97
+Won't Back Down ,121
+The Nutcracker ,92
+Kansas City ,116
+Indignation ,110
+The Amityville Horror ,90
+Adaptation. ,81
+Land of the Dead ,97
+Out of Inferno ,107
+Fear and Loathing in Las Vegas ,118
+The Invention of Lying ,100
+Neighbors ,97
+The Mask ,114
+Big ,130
+Borat: Cultural Learnings of America for Make Benefit Glorious Nation of Kazakhstan ,82
+Legally Blonde ,96
+Star Trek III: The Search for Spock ,105
+The Exorcism of Emily Rose ,122
+Deuce Bigalow: Male Gigolo ,88
+Left Behind ,110
+The Family Stone ,103
+Barbershop 2: Back in Business ,106
+Bad Santa ,98
+Austin Powers: International Man of Mystery ,68
+My Big Fat Greek Wedding 2 ,94
+Diary of a Wimpy Kid: Rodrick Rules ,99
+Predator ,107
+Amadeus ,180
+Prom Night ,89
+Mean Girls ,97
+Under the Tuscan Sun ,113
+Gosford Park ,131
+The O.C.             ,44
+Peggy Sue Got Married ,103
+Birdman or (The Unexpected Virtue of Ignorance) ,119
+Blue Jasmine ,98
+United 93 ,111
+Honey ,94
+Glory ,122
+Spy Hard ,81
+The Fog ,89
+Soul Surfer ,106
+Catch-22 ,122
+Observe and Report ,86
+Conan the Destroyer ,103
+Raging Bull ,121
+Love Happens ,109
+Young Sherlock Holmes ,109
+Fame ,123
+127 Hours ,94
+Small Time Crooks ,94
+Center Stage ,115
+Love the Coopers ,107
+Catch That Kid ,91
+Life as a House ,125
+Steve Jobs ,122
+"I Love You, Beth Cooper ",102
+Youth in Revolt ,90
+The Legend of the Lone Ranger ,98
+The Tailor of Panama ,109
+Blow Out ,107
+Getaway ,90
+The Ice Storm ,112
+And So It Goes ,94
+Troop Beverly Hills ,105
+Being Julia ,104
+9½ Weeks ,112
+Dragonslayer ,108
+The Last Station ,112
+Ed Wood ,127
+Labor Day ,111
+Mongol: The Rise of Genghis Khan ,126
+RocknRolla ,114
+Megaforce ,99
+Hamlet ,150
+Mao's Last Dancer ,117
+Midnight Special ,112
+Anything Else ,108
+The Railway Man ,116
+Unforgettable             ,60
+The White Ribbon ,144
+Restoration ,92
+The Wraith ,93
+The Salton Sea ,103
+Metallica Through the Never ,93
+The Informers ,98
+Carlos             ,334
+I Come with the Rain ,114
+One Man's Hero ,121
+Day of the Dead ,87
+I Am Wrath ,92
+Renaissance ,105
+Forsaken ,90
+Red Sonja ,89
+Red Lights ,114
+Superbad ,119
+Madea Goes to Jail ,103
+Wolves ,91
+Step Up 2: The Streets ,98
+Hoodwinked! ,80
+Hotel Rwanda ,121
+Hitman ,94
+Black Nativity ,93
+The Prince ,93
+City of Ghosts ,116
+The Others ,101
+Aliens ,154
+My Fair Lady ,170
+I Know What You Did Last Summer ,99
+Let's Be Cops ,104
+Sideways ,126
+Beerfest ,110
+Halloween ,101
+Hero ,80
+Good Boy! ,87
+The Best Man Holiday ,123
+Smokin' Aces ,109
+Saw 3D: The Final Chapter ,90
+40 Days and 40 Nights ,96
+TRON: Legacy ,125
+A Night at the Roxbury ,82
+Beastly ,86
+The Hills Have Eyes ,108
+Dickie Roberts: Former Child Star ,98
+"McFarland, USA ",129
+Lottery Ticket ,99
+ATL ,105
+Pitch Perfect ,112
+Summer Catch ,108
+A Simple Plan ,121
+They ,89
+Larry the Cable Guy: Health Inspector ,89
+The Adventures of Elmo in Grouchland ,73
+Brooklyn's Finest ,132
+55 Days at Peking ,154
+Evil Dead ,96
+My Life in Ruins ,98
+American Dreamz ,107
+Superman IV: The Quest for Peace ,134
+How She Move ,94
+Running Scared ,122
+No Strings Attached ,108
+Shanghai Surprise ,97
+The Illusionist ,110
+Roar ,102
+Veronica Guerin ,98
+Escobar: Paradise Lost ,120
+Southland Tales ,160
+Dragon Hunters ,80
+Damnation Alley ,91
+The Apparition ,83
+My Girl ,102
+Fur: An Imaginary Portrait of Diane Arbus ,122
+The Illusionist ,110
+Wall Street ,126
+Sense and Sensibility ,136
+Becoming Jane ,120
+Sydney White ,108
+House of Sand and Fog ,126
+Dead Poets Society ,128
+Dumb & Dumber ,113
+When Harry Met Sally... ,89
+The Verdict ,129
+Road Trip ,94
+Varsity Blues ,106
+The Artist ,100
+The Unborn ,89
+Moonrise Kingdom ,94
+The Texas Chainsaw Massacre: The Beginning ,83
+The Young Messiah ,111
+The Master of Disguise ,80
+Pan's Labyrinth ,112
+The Messengers             ,60
+See Spot Run ,94
+Baby Boy ,130
+The Roommate ,91
+Joe Dirt ,91
+Double Impact ,110
+Hot Fuzz ,121
+The Women ,114
+Vicky Cristina Barcelona ,96
+Arn: The Knight Templar ,270
+Bad Moms ,100
+Boys and Girls ,94
+White Oleander ,109
+Jennifer's Body ,107
+Drowning Mona ,96
+Radio Days ,88
+Left Behind ,110
+Remember Me ,113
+How to Deal ,101
+My Stepmother Is an Alien ,105
+Philadelphia ,125
+The Thirteenth Floor ,100
+The Cookout ,97
+Meteor ,108
+Duets ,112
+Hollywood Ending ,112
+Detroit Rock City ,95
+Highlander ,110
+Things We Lost in the Fire ,118
+Steel ,97
+The Immigrant ,120
+The White Countess ,135
+Trance ,101
+Soul Plane ,92
+Welcome to the Sticks ,106
+Good ,92
+Enter the Void ,161
+Vamps ,92
+Hachi: A Dog's Tale ,93
+Zulu ,110
+The Homesman ,122
+Juwanna Mann ,91
+Lilyhammer             ,45
+Ararat ,115
+Madison ,94
+Slow Burn ,93
+Wasabi ,94
+Slither ,95
+Beverly Hills Cop ,105
+Home Alone ,103
+3 Men and a Baby ,102
+Tootsie ,116
+Top Gun ,110
+"Crouching Tiger, Hidden Dragon ",120
+American Beauty ,122
+The King's Speech ,118
+Twins ,107
+Scream: The TV Series             ,45
+The Yellow Handkerchief ,102
+The Color Purple ,154
+Tidal Wave ,103
+Ben-Hur ,141
+The Imitation Game ,114
+Private Benjamin ,109
+Coal Miner's Daughter ,124
+Diary of a Wimpy Kid ,94
+Mama ,100
+Halloween ,101
+National Lampoon's Vacation ,98
+Bad Grandpa ,102
+The Queen ,94
+Beetlejuice ,92
+Why Did I Get Married? ,113
+Little Women ,115
+The Woman in Black ,95
+When a Stranger Calls ,87
+Big Fat Liar ,88
+The Deer Hunter ,183
+Wag the Dog ,97
+The Lizzie McGuire Movie ,94
+Snitch ,112
+Krampus ,98
+The Faculty ,104
+What's Love Got to Do with It ,118
+Cop Land ,120
+Not Another Teen Movie ,99
+End of Watch ,109
+Aloha ,105
+The Skulls ,106
+The Theory of Everything ,123
+Malibu's Most Wanted ,86
+Where the Heart Is ,120
+Lawrence of Arabia ,227
+Halloween II ,119
+Wild ,115
+The Last House on the Left ,114
+The Wedding Date ,90
+Halloween: Resurrection ,94
+Clash of the Titans ,106
+The Princess Bride ,98
+The Great Debaters ,126
+Drive ,100
+Confessions of a Teenage Drama Queen ,89
+The Object of My Affection ,111
+28 Weeks Later ,100
+When the Game Stands Tall ,115
+Because of Winn-Dixie ,106
+Love & Basketball ,124
+Grosse Pointe Blank ,107
+All About Steve ,99
+Book of Shadows: Blair Witch 2 ,90
+The Craft ,101
+Match Point ,119
+Ramona and Beezus ,103
+The Remains of the Day ,134
+Boogie Nights ,155
+Nowhere to Run ,94
+Flicka ,95
+The Hills Have Eyes II ,89
+Urban Legends: Final Cut ,97
+Tuck Everlasting ,90
+The Marine ,92
+Keanu ,100
+Country Strong ,117
+Disturbing Behavior ,84
+The Place Beyond the Pines ,140
+The November Man ,108
+Eye of the Beholder ,109
+The Hurt Locker ,131
+Firestarter ,114
+Killing Them Softly ,97
+A Most Wanted Man ,122
+Freddy Got Fingered ,87
+The Pirates Who Don't Do Anything: A VeggieTales Movie ,85
+U2 3D ,85
+Highlander: Endgame ,101
+Idlewild ,121
+One Day ,107
+Whip It ,111
+Knockaround Guys ,92
+Confidence ,97
+The Muse ,97
+De-Lovely ,125
+New York Stories ,124
+Barney's Great Adventure ,76
+The Man with the Iron Fists ,107
+Home Fries ,91
+Here on Earth ,96
+Brazil ,142
+Raise Your Voice ,103
+The Dead Zone             ,60
+The Big Lebowski ,117
+Black Snake Moan ,116
+Dark Blue ,118
+A Mighty Heart ,108
+Whatever It Takes ,94
+Boat Trip ,97
+The Importance of Being Earnest ,97
+The Love Letter ,99
+Hoot ,91
+In Bruges ,107
+Peeples ,95
+The Rocker ,102
+Post Grad ,88
+Promised Land ,106
+Whatever Works ,92
+The In Crowd ,105
+Three Burials ,107
+Jakob the Liar ,120
+Kiss Kiss Bang Bang ,103
+Idle Hands ,92
+Mulholland Drive ,147
+Blood and Chocolate ,98
+You Will Meet a Tall Dark Stranger ,98
+Never Let Me Go ,103
+The Company             ,286
+Transsiberian ,111
+The Clan of the Cave Bear ,98
+Crazy in Alabama ,111
+Funny Games ,111
+Listening ,100
+Felicia's Journey ,116
+Metropolis ,145
+District B13 ,84
+Things to Do in Denver When You're Dead ,115
+The Assassin ,105
+Buffalo Soldiers ,98
+The Return ,99
+Ong-bak 2 ,110
+Centurion ,97
+Silent Trigger ,88
+The Midnight Meat Train ,103
+Winnie Mandela ,104
+The Son of No One ,90
+All the Queen's Men ,105
+The Good Night ,93
+Bathory: Countess of Blood ,141
+Khumba ,85
+Automata ,109
+Dungeons & Dragons: Wrath of the Dragon God ,105
+Chiamatemi Francesco - Il Papa della gente ,98
+Shinjuku Incident ,119
+Pandaemonium ,124
+Groundhog Day ,101
+Magic Mike XXL ,115
+Romeo + Juliet ,120
+Sarah's Key ,111
+Freedom ,94
+Unforgiven ,131
+Manderlay ,139
+Slumdog Millionaire ,120
+Fatal Attraction ,119
+Pretty Woman ,125
+Towering Inferno             ,65
+Crocodile Dundee II ,108
+Broken Horses ,101
+Born on the Fourth of July ,145
+Cool Runnings ,98
+My Bloody Valentine ,101
+The Possession ,92
+First Blood ,93
+Stomp the Yard ,109
+The Spy Who Loved Me ,123
+Ghost Hunters             ,60
+Urban Legend ,99
+Dangerous Liaisons ,119
+Good Deeds ,110
+White Fang ,107
+Superstar ,81
+The Iron Lady ,105
+Jonah: A VeggieTales Movie ,82
+Poetic Justice ,109
+All About the Benjamins ,95
+Vampire in Brooklyn ,100
+Exorcist II: The Heretic ,118
+An American Haunting ,91
+My Boss's Daughter ,90
+A Perfect Getaway ,108
+Our Family Wedding ,103
+Dead Man on Campus ,96
+Tea with Mussolini ,117
+Thinner ,93
+"New York, New York ",136
+Crooklyn ,115
+I Think I Love My Wife ,94
+Jason X ,85
+Big Fat Liar ,88
+Bobby ,112
+Head Over Heels ,86
+Fun Size ,86
+The Diving Bell and the Butterfly ,112
+Little Children ,137
+Gossip ,90
+A Walk on the Moon ,107
+Catch a Fire ,98
+Soul Survivors ,84
+Jefferson in Paris ,139
+Easy Virtue ,97
+Caravans ,127
+Mr. Turner ,150
+Wild Grass ,104
+Amen. ,132
+Reign of Assassins ,117
+The Lucky Ones ,115
+Margaret ,186
+Stan Helsing ,90
+Flipped ,90
+Brokeback Mountain ,134
+Teenage Mutant Ninja Turtles ,101
+Clueless ,97
+Far from Heaven ,107
+Hot Tub Time Machine 2 ,99
+Dekalog             ,55
+Quills ,124
+Seven Psychopaths ,110
+The Caveman's Valentine ,105
+The Border             ,41
+Downfall ,178
+The Sea Inside ,125
+Under the Skin ,108
+"Good Morning, Vietnam ",121
+The Last Godfather ,100
+Justin Bieber: Never Say Never ,115
+Black Swan ,108
+RoboCop ,117
+The Godfather: Part II ,220
+Save the Last Dance ,112
+A Nightmare on Elm Street 4: The Dream Master ,99
+Miracles from Heaven ,109
+"Dude, Where's My Car? ",83
+Young Guns ,107
+St. Vincent ,102
+About Last Night ,100
+10 Things I Hate About You ,97
+The New Guy ,92
+Loaded Weapon 1 ,84
+The Shallows ,86
+The Butterfly Effect ,120
+Snow Day ,89
+This Christmas ,117
+Baby Geniuses ,97
+The Big Hit ,91
+Harriet the Spy ,100
+Child's Play 2 ,72
+No Good Deed ,84
+The Mist ,126
+Ex Machina ,108
+Being John Malkovich ,112
+Two Can Play That Game ,90
+Earth to Echo ,91
+Crazy/Beautiful ,135
+Letters from Iwo Jima ,141
+The Astronaut Farmer ,104
+Woo ,84
+Room ,118
+Dirty Work ,82
+Serial Mom ,95
+Dick ,94
+Del 1 - Män som hatar kvinnor             ,88
+Light It Up ,99
+54 ,121
+Bubble Boy ,84
+Birthday Girl ,93
+21 & Over ,93
+"Paris, je t'aime ",120
+Resurrecting the Champ ,112
+Admission ,107
+The Widow of Saint-Pierre ,112
+Chloe ,96
+Faithful ,91
+Brothers ,105
+Find Me Guilty ,125
+The Perks of Being a Wallflower ,102
+Excessive Force ,87
+Infamous ,118
+The Claim ,115
+The Vatican Tapes ,91
+Attack the Block ,88
+In the Land of Blood and Honey ,127
+The Call ,94
+Operation Chromite ,115
+The Crocodile Hunter: Collision Course ,90
+I Love You Phillip Morris ,102
+Quest for Fire ,100
+Antwone Fisher ,117
+The Emperor's Club ,109
+True Romance ,121
+Womb ,111
+Glengarry Glen Ross ,100
+The Killer Inside Me ,109
+Cat People ,93
+Sorority Row ,101
+The Prisoner of Zenda ,101
+Lars and the Real Girl ,106
+The Boy in the Striped Pajamas ,94
+Dancer in the Dark ,140
+Oscar and Lucinda ,132
+The Funeral ,99
+Solitary Man ,90
+Machete ,105
+Casino Jack ,108
+The Land Before Time ,69
+Tae Guk Gi: The Brotherhood of War ,148
+The Perfect Game ,118
+The Exorcist ,132
+Jaws ,130
+American Pie ,95
+Ernest & Celestine ,80
+The Golden Child ,94
+Think Like a Man ,122
+Barbershop ,102
+Star Trek II: The Wrath of Khan ,116
+Ace Ventura: Pet Detective ,78
+WarGames ,114
+Witness ,112
+Act of Valor ,110
+Step Up ,104
+Beavis and Butt-Head Do America ,81
+Jackie Brown ,154
+Harold & Kumar Escape from Guantanamo Bay ,102
+Chronicle ,89
+Yentl ,132
+Time Bandits ,103
+Crossroads ,93
+Project X ,93
+Patton ,172
+One Hour Photo ,96
+Quarantine ,89
+The Eye ,92
+Johnson Family Vacation ,97
+How High ,93
+The Muppet Christmas Carol ,89
+Casino Royale ,144
+Frida ,123
+Katy Perry: Part of Me ,93
+The Fault in Our Stars ,133
+Rounders ,121
+Top Five ,102
+Prophecy ,102
+Stir of Echoes ,99
+Spartacus: War of the Damned             ,55
+Philomena ,98
+The Upside of Anger ,118
+The Boys from Brazil ,125
+Aquamarine ,104
+Paper Towns ,109
+My Baby's Daddy ,86
+Nebraska ,115
+Tales from the Crypt: Demon Knight ,92
+Max Keeble's Big Move ,91
+Young Adult ,94
+Crank ,93
+How to Be a Player ,93
+Living Out Loud ,100
+Just Wright ,100
+Rachel Getting Married ,113
+The Postman Always Rings Twice ,122
+Girl with a Pearl Earring ,100
+Das Boot ,293
+The Alamo ,137
+Sorority Boys ,93
+About Time ,123
+House of Flying Daggers ,119
+Arbitrage ,107
+Project Almanac ,106
+Cadillac Records ,109
+Screwed ,81
+Fortress ,95
+For Your Consideration ,86
+Celebrity ,113
+Running with Scissors ,122
+From Justin to Kelly ,90
+Girl 6 ,108
+In the Cut ,113
+Two Lovers ,110
+Last Orders ,109
+The Host ,110
+The Pursuit of D.B. Cooper ,100
+Ravenous ,101
+Charlie Bartlett ,97
+The Great Beauty ,172
+The Dangerous Lives of Altar Boys ,104
+Stoker ,99
+2046 ,129
+Married Life ,91
+Duma ,100
+Ondine ,111
+Brother ,114
+Welcome to Collinwood ,86
+Critical Care ,107
+The Life Before Her Eyes ,90
+Darling Companion ,103
+Trade ,120
+Fateless ,134
+Breakfast of Champions ,110
+"A Woman, a Gun and a Noodle Shop ",95
+Cypher ,95
+City of Life and Death ,132
+Home ,94
+Legend of Kung Fu Rabbit ,89
+Space Battleship Yamato ,138
+5 Days of War ,113
+Triangle ,99
+10 Days in a Madhouse ,111
+Heaven Is for Real ,99
+Snatch ,104
+Dancin' It's On ,89
+Pet Sematary ,103
+Madadayo ,134
+The Cry of the Owl ,100
+A Tale of Three Cities ,130
+Gremlins ,106
+Star Wars: Episode IV - A New Hope ,125
+Dirty Grandpa ,109
+Doctor Zhivago ,200
+Trash ,114
+High School Musical 3: Senior Year ,112
+The Fighter ,116
+Jackass Number Two ,92
+My Cousin Vinny ,120
+If I Stay ,107
+Drive Hard ,92
+Major League ,107
+St. Trinian's ,100
+Phone Booth ,81
+A Walk to Remember ,101
+Dead Man Walking ,122
+Cruel Intentions ,97
+Saw VI ,92
+History of the World: Part I ,92
+The Secret Life of Bees ,110
+Corky Romano ,86
+Raising Cain ,91
+F.I.S.T. ,145
+Invaders from Mars ,100
+Brooklyn ,111
+Barry Lyndon ,184
+Out Cold ,89
+The Ladies Man ,84
+Quartet ,98
+Tomcats ,95
+Frailty ,100
+Woman in Gold ,109
+Kinsey ,118
+Army of Darkness ,88
+Slackers ,86
+What's Eating Gilbert Grape ,118
+The Visual Bible: The Gospel of John ,125
+Vera Drake ,125
+The Guru ,94
+The Perez Family ,113
+Inside Llewyn Davis ,104
+O ,95
+Return to the Blue Lagoon ,102
+The Molly Maguires ,124
+Romance & Cigarettes ,105
+Copying Beethoven ,104
+Poltergeist ,120
+Brighton Rock ,111
+Saw V ,95
+Machine Gun McCain ,96
+LOL ,97
+Jindabyne ,118
+Kabhi Alvida Naa Kehna ,193
+An Ideal Husband ,97
+The Last Days on Mars ,98
+Darkness ,103
+2001: A Space Odyssey ,161
+E.T. the Extra-Terrestrial ,120
+In the Land of Women ,97
+The Blue Butterfly ,97
+There Goes My Baby ,99
+Lovesick             ,24
+Housefull ,144
+September Dawn ,111
+For Greater Glory: The True Story of Cristiada ,145
+La Famille Bélier ,106
+Good Will Hunting ,126
+Misconduct ,106
+Saw III ,121
+Stripes ,117
+Bring It On ,98
+The Purge: Election Year ,109
+She's All That ,95
+Precious ,109
+Saw IV ,96
+White Noise ,101
+Madea's Family Reunion ,107
+The Color of Money ,119
+The Longest Day ,178
+The Mighty Ducks ,100
+The Grudge ,98
+Happy Gilmore ,92
+Jeepers Creepers ,90
+Bill & Ted's Excellent Adventure ,90
+Oliver! ,153
+The Best Exotic Marigold Hotel ,124
+Recess: School's Out ,82
+Mad Max Beyond Thunderdome ,107
+Commando ,75
+The Boy ,97
+Devil ,80
+Friday After Next ,85
+Insidious: Chapter 3 ,97
+The Last Dragon ,109
+Snatch ,104
+The Lawnmower Man ,140
+Nick and Norah's Infinite Playlist ,90
+Dogma ,130
+The Banger Sisters ,98
+Twilight Zone: The Movie ,101
+Road House ,114
+A Low Down Dirty Shame ,100
+Swimfan ,85
+Employee of the Month ,103
+Can't Hardly Wait ,100
+The Outsiders ,114
+Pete's Dragon ,102
+The Dead Zone ,103
+Sinister 2 ,97
+Sparkle ,116
+Valentine ,96
+The Fourth Kind ,98
+A Prairie Home Companion ,105
+Sugar Hill ,123
+Invasion U.S.A. ,107
+Roll Bounce ,112
+Rushmore ,93
+Skyline ,97
+The Second Best Exotic Marigold Hotel ,122
+Kit Kittredge: An American Girl ,101
+The Perfect Man ,100
+Mo' Better Blues ,129
+Kung Pow: Enter the Fist ,81
+Tremors ,96
+Wrong Turn ,84
+The Long Riders ,100
+The Corruptor ,110
+Mud ,130
+Bobby Jones: Stroke of Genius ,128
+One Direction: This Is Us ,106
+"The Goods: Live Hard, Sell Hard ",89
+Hey Arnold! The Movie ,76
+My Week with Marilyn ,99
+The Matador ,96
+Love Jones ,104
+The Gift ,108
+End of the Spear ,108
+Get Over It ,87
+Office Space ,89
+Drop Dead Gorgeous ,97
+Big Eyes ,106
+Very Bad Things ,100
+Sleepover ,89
+Body Double ,114
+MacGruber ,95
+Dirty Pretty Things ,97
+Movie 43 ,94
+The Tourist ,103
+Over Her Dead Body ,95
+Seeking a Friend for the End of the World ,101
+Cedar Rapids ,87
+Bones             ,40
+American History X ,101
+The Collection ,82
+Teacher's Pet ,74
+The Red Violin ,130
+The Straight Story ,112
+Deuces Wild ,96
+Bad Words ,89
+"Run, Fatboy, Run ",100
+Heartbeeps ,78
+Black or White ,121
+On the Line ,85
+Rescue Dawn ,120
+Danny Collins ,106
+"Jeff, Who Lives at Home ",83
+I Am Love ,120
+Atlas Shrugged II: The Strike ,111
+Romeo Is Bleeding ,100
+The Limey ,89
+Crash ,115
+The House of Mirth ,135
+Malone ,92
+Peaceful Warrior ,120
+Bucky Larson: Born to Be a Star ,97
+Bamboozled ,135
+The Forest ,93
+Sphinx ,118
+While We're Young ,97
+A Better Life ,98
+Spider ,98
+Gun Shy ,101
+Nicholas Nickleby ,132
+The Iceman ,106
+Dekalog             ,55
+Krrish ,168
+Cecil B. DeMented ,87
+Killer Joe ,98
+The Joneses ,96
+Owning Mahowny ,104
+The Brothers Solomon ,93
+My Blueberry Nights ,95
+Illuminata ,119
+Swept Away ,89
+"War, Inc. ",107
+Shaolin Soccer ,85
+The Brown Bunny ,93
+The Swindle ,101
+Rosewater ,103
+The Chambermaid on the Titanic ,101
+Coriolanus ,123
+Imaginary Heroes ,111
+High Heels and Low Lifes ,86
+World's Greatest Dad ,99
+Severance ,90
+Edmond ,82
+Welcome to the Rileys ,110
+Police Academy: Mission to Moscow ,83
+Blood Done Sign My Name ,128
+"Cinco de Mayo, La Batalla ",125
+Elsa & Fred ,97
+An Alan Smithee Film: Burn Hollywood Burn ,86
+The Open Road ,91
+The Good Guy ,90
+Motherhood ,90
+Free Style ,94
+Strangerland ,112
+The Janky Promoters ,85
+Blonde Ambition ,93
+The Oxford Murders ,104
+The Reef ,94
+Eulogy ,85
+White Noise 2: The Light ,99
+You Got Served: Beat the World ,91
+Fifty Dead Men Walking ,117
+Jungle Shuffle ,85
+Adam Resurrected ,106
+Of Horses and Men ,81
+It's a Wonderful Afterlife ,100
+The Devil's Tomb ,90
+Partition ,116
+Good Intentions ,84
+"The Good, the Bad, the Weird ",135
+Nurse 3D ,84
+Gunless ,89
+Adventureland ,107
+The Lost City ,144
+Next Friday ,98
+American Heist ,94
+You Only Live Twice ,117
+Plastic ,102
+Amour ,127
+Poltergeist III ,98
+Re-Kill ,88
+"It's a Mad, Mad, Mad, Mad World ",197
+Volver ,121
+Heavy Metal ,90
+Gentlemen Broncos ,89
+Richard III ,104
+Into the Grizzly Maze ,94
+Kites ,90
+Melancholia ,130
+Red Dog ,92
+Jab Tak Hai Jaan ,176
+Alien ,116
+The Texas Chain Saw Massacre ,88
+The Runaways ,106
+Fiddler on the Roof ,181
+Thunderball ,130
+Detention ,93
+Loose Cannons ,110
+Set It Off ,123
+The Best Man ,120
+Child's Play ,87
+Sicko ,123
+The Purge: Anarchy ,103
+Down to You ,91
+Harold & Kumar Go to White Castle ,88
+The Contender ,126
+Boiler Room ,120
+Trading Places ,116
+Black Christmas ,94
+Breakin' All the Rules ,85
+Henry V ,137
+The Savages ,114
+Chasing Papi ,76
+The Way of the Gun ,119
+Igby Goes Down ,99
+PCU ,79
+The Ultimate Gift ,114
+The Bold and the Beautiful             ,30
+The Ice Pirates ,91
+Gracie ,95
+Trust the Man ,103
+Hamlet 2 ,92
+Velvet Goldmine ,124
+The Wailing ,156
+Glee: The 3D Concert Movie ,84
+The Legend of Suriyothai ,300
+Two Evil Eyes ,120
+Barbecue ,98
+All or Nothing ,121
+Princess Kaiulani ,97
+Opal Dream ,86
+Heist ,93
+Flame and Citron ,45
+Undiscovered ,97
+Red Riding: In the Year of Our Lord 1974 ,102
+The Girl on the Train ,105
+Veronika Decides to Die ,103
+Crocodile Dundee ,93
+"Ultramarines: A Warhammer 40,000 Movie ",76
+The I Inside ,90
+Beneath Hill 60 ,122
+Polisse ,127
+Awake ,84
+Star Wars: The Clone Wars             ,23
+Skin Trade ,96
+The Lost Boys ,97
+Crazy Heart ,112
+The Rose ,125
+Baggage Claim ,96
+Barbarella ,98
+Shipwrecked ,92
+Election ,103
+The Namesake ,122
+The DUFF ,101
+Glitter ,104
+The Haunting in Connecticut 2: Ghosts of Georgia ,101
+Silmido ,135
+Bright Star ,119
+My Name Is Khan ,128
+Footloose ,107
+All Is Lost ,106
+Limbo ,126
+Namastey London ,128
+The Wind That Shakes the Barley ,127
+Yeh Jawaani Hai Deewani ,160
+The Karate Kid ,126
+Quo Vadis ,171
+Repo! The Genetic Opera ,150
+Valley of the Wolves: Iraq ,122
+Pulp Fiction ,178
+The Muppet Movie ,95
+Nightcrawler ,117
+Club Dread ,119
+The Sound of Music ,174
+Splash ,111
+Little Miss Sunshine ,101
+Stand by Me ,89
+28 Days Later... ,113
+You Got Served ,95
+Escape from Alcatraz ,112
+Brown Sugar ,109
+A Thin Line Between Love and Hate ,108
+50/50 ,100
+Shutter ,90
+Creepshow ,130
+That Awkward Moment ,94
+Modern Problems ,93
+Kicks ,80
+Much Ado About Nothing ,111
+On Her Majesty's Secret Service ,142
+The Player             ,60
+New Nightmare ,107
+Drive Me Crazy ,91
+Akeelah and the Bee ,112
+Half Baked ,82
+New in Town ,97
+Syriana ,128
+American Psycho ,102
+The Good Girl ,93
+Bon Cop Bad Cop ,116
+The Boondock Saints II: All Saints Day ,138
+The City of Your Final Destination ,117
+Enough Said ,93
+Easy A ,92
+The Inkwell ,110
+Shadow of the Vampire ,92
+Prom ,104
+The Pallbearer ,98
+Held Up ,89
+Woman on Top ,92
+Howards End ,140
+Preacher             ,60
+Anomalisa ,90
+Another Year ,129
+8 Women ,111
+Showdown in Little Tokyo ,79
+Clay Pigeons ,104
+It's Kind of a Funny Story ,101
+Made in Dagenham ,113
+When Did You Last See Your Father? ,92
+Prefontaine ,106
+The Wicked Lady ,98
+The Secret of Kells ,75
+Begin Again ,104
+Down in the Valley ,108
+Brooklyn Rules ,99
+Restless ,180
+The Singing Detective ,109
+The Land Girls ,111
+Fido ,93
+The Wendell Baker Story ,99
+Wild Target ,98
+Pathology ,95
+Wuthering Heights             ,142
+10th & Wolf ,107
+Dear Wendy ,102
+Aloft ,97
+Akira ,124
+The Death and Life of Bobby Z ,97
+The Rocket: The Legend of Rocket Richard ,124
+Swelter ,96
+My Lucky Star ,114
+Imagine Me & You ,90
+Mr. Church ,104
+Swimming Pool ,102
+Green Street 3: Never Back Down ,93
+The Blood of Heroes ,90
+Code of Honor ,106
+Driving Miss Daisy ,99
+Soul Food ,115
+Rumble in the Bronx ,89
+Far from Men ,101
+Thank You for Smoking ,92
+Hostel: Part II ,94
+An Education ,100
+Shopgirl ,106
+The Hotel New Hampshire ,109
+Narc ,105
+Men with Brooms ,102
+Witless Protection ,97
+The Work and the Glory ,118
+Extract ,92
+Masked and Anonymous ,112
+Alias Betty ,103
+Code 46 ,93
+Outside Bet ,101
+Crash ,115
+Albert Nobbs ,113
+Black November ,95
+Ta Ra Rum Pum ,153
+Persepolis ,89
+The Hole ,92
+The Wave ,107
+The Neon Demon ,118
+Harry Brown ,97
+Spider-Man 3 ,156
+The Omega Code ,100
+Juno ,96
+Pound of Flesh ,104
+Diamonds Are Forever ,120
+The Godfather ,175
+Flashdance ,95
+500 Days of Summer ,95
+The Piano ,121
+Magic Mike ,110
+Darkness Falls ,96
+Live and Let Die ,121
+My Dog Skip ,95
+"Definitely, Maybe ",112
+Jumping the Broom ,112
+The Great Gatsby ,143
+"Good Night, and Good Luck. ",93
+Capote ,110
+Desperado ,104
+The Claim ,115
+Fargo             ,53
+Logan's Run ,119
+The Man with the Golden Gun ,125
+Action Jackson ,96
+The Descent ,100
+Michael Jordan to the Max ,46
+Devil's Due ,89
+Flirting with Disaster ,92
+The Devil's Rejects ,109
+Buffy the Vampire Slayer             ,44
+Dope ,103
+In Too Deep ,95
+Skyfall ,143
+House of 1000 Corpses ,105
+Alien Zone ,79
+A Serious Man ,106
+Get Low ,100
+Warlock ,103
+Beyond the Lights ,116
+A Single Man ,99
+The Last Temptation of Christ ,164
+Outside Providence ,96
+Bride & Prejudice ,122
+Rabbit-Proof Fence ,94
+Who's Your Caddy? ,93
+Split Second ,96
+Nikita             ,60
+The Other Side of Heaven ,113
+Dark Angel             ,60
+Veer-Zaara ,192
+Redbelt ,99
+Cyrus ,91
+A Dog of Flanders ,100
+Auto Focus ,105
+Factory Girl ,99
+We Need to Talk About Kevin ,112
+The Christmas Candle ,100
+The Mighty Macs ,99
+Losin' It ,100
+Mother and Child ,125
+March or Die ,107
+Les visiteurs ,107
+Somewhere ,97
+I Hope They Serve Beer in Hell ,105
+Chairman of the Board ,95
+Hesher ,106
+Dom Hemingway ,93
+Gerry ,103
+The Heart of Me ,96
+Freeheld ,103
+The Extra Man ,108
+Hard to Be a God ,177
+Ca$h ,118
+Wah-Wah ,97
+The Boondock Saints ,102
+Z Storm ,92
+Twixt ,88
+Snow Queen ,80
+Alpha and Omega 4: The Legend of the Saw Toothed Cave ,45
+Pale Rider ,115
+Stargate: The Ark of Truth ,97
+Dazed and Confused ,102
+High School Musical 2 ,111
+Two Lovers and a Bear ,96
+Criminal Activities ,94
+Aimee & Jaguar ,125
+The Chumscrubber ,108
+Shade ,101
+House at the End of the Street ,101
+Incendies ,139
+"Remember Me, My Love ",125
+Perrier's Bounty ,88
+Elite Squad ,115
+Annabelle ,99
+Bran Nue Dae ,88
+Boyz n the Hood ,112
+La Bamba ,108
+The Four Seasons ,107
+Dressed to Kill ,104
+The Adventures of Huck Finn ,108
+Go ,102
+Friends with Money ,88
+The Andromeda Strain ,115
+Bats ,91
+Nowhere in Africa ,141
+Shame ,101
+Layer Cake ,105
+The Work and the Glory II: American Zion ,100
+The East ,116
+A Home at the End of the World ,97
+Aberdeen ,106
+The Messenger ,105
+Tracker ,102
+Control ,122
+The Terminator ,107
+Good Bye Lenin! ,121
+The Damned United ,98
+The Return of the Living Dead ,108
+Gomorrah             ,55
+Mallrats ,123
+Grease ,110
+Platoon ,120
+Fahrenheit 9/11 ,122
+Butch Cassidy and the Sundance Kid ,110
+Mary Poppins ,139
+Ordinary People ,124
+Around the World in 80 Days ,120
+West Side Story ,152
+Caddyshack ,98
+The Brothers ,106
+The Wood ,106
+The Usual Suspects ,106
+A Nightmare on Elm Street 5: The Dream Child ,89
+Van Wilder: Party Liaison ,94
+The Wrestler ,109
+Duel in the Sun ,144
+Best in Show ,90
+Escape from New York ,106
+School Daze ,121
+Daddy Day Camp ,89
+Mr. Nice Guy ,86
+A Mighty Wind ,91
+Mystic Pizza ,104
+War & Peace             ,
+Sliding Doors ,99
+Tales from the Hood ,98
+The Last King of Scotland ,121
+Halloween 5 ,96
+Bernie ,99
+Dolphins and Whales 3D: Tribes of the Ocean ,42
+Pollock ,122
+200 Cigarettes ,101
+The Words ,102
+Casa de mi Padre ,84
+City Island ,104
+The Guard ,96
+College ,94
+The Virgin Suicides ,90
+Little Voice ,97
+Miss March ,90
+Wish I Was Here ,106
+Simply Irresistible ,96
+Veronica Mars             ,44
+Hedwig and the Angry Inch ,95
+Only the Strong ,99
+Goddess of Love ,93
+Shattered Glass ,99
+Novocaine ,95
+The Business of Strangers ,84
+The Wild Bunch ,144
+The Wackness ,99
+The Great Train Robbery ,110
+Morvern Callar ,97
+Beastmaster 2: Through the Portal of Time ,107
+The 5th Quarter ,90
+The Flower of Evil ,104
+The Greatest ,96
+Snow Flower and the Secret Fan ,104
+Come Early Morning ,97
+Lucky Break ,107
+Julia ,117
+"Surfer, Dude ",85
+Lake of Fire ,152
+11:14 ,85
+Men of War ,76
+Don McKay ,87
+Deadfall ,95
+A Shine of Rainbows ,101
+The Hit List ,90
+Emma             ,240
+Videodrome ,89
+L'auberge espagnole ,111
+Song One ,86
+Murder by Numbers ,115
+Winter in Wartime ,103
+Freaky Deaky ,90
+The Train ,133
+Trade of Innocents ,88
+The Protector ,111
+Stiff Upper Lips ,94
+The Inbetweeners             ,25
+Bend It Like Beckham ,112
+Sunshine State ,141
+Crossover ,95
+Khiladi 786 ,141
+[Rec] 2 ,85
+Standing Ovation ,105
+The Sting ,129
+Chariots of Fire ,125
+Diary of a Mad Black Woman ,116
+Shine ,105
+Don Jon ,90
+High Plains Drifter ,105
+Ghost World ,111
+Iris ,91
+Galaxina ,95
+The Chorus ,97
+Mambo Italiano ,92
+Wonderland ,104
+Do the Right Thing ,120
+Harvard Man ,99
+Le Havre ,93
+Irreversible ,99
+R100 ,99
+Rang De Basanti ,157
+Animals ,90
+Salvation Boulevard ,96
+The Ten ,96
+A Room for Romeo Brass ,90
+Headhunters ,100
+Grabbers ,94
+Saint Ralph ,98
+Miss Julie ,129
+Somewhere in Time ,103
+Dum Maaro Dum ,128
+Insidious: Chapter 2 ,106
+Saw II ,95
+10 Cloverfield Lane ,104
+Jackass: The Movie ,87
+Lights Out ,81
+Paranormal Activity 3 ,94
+Ouija ,89
+A Nightmare on Elm Street 3: Dream Warriors ,88
+The Gift ,108
+Instructions Not Included ,115
+Paranormal Activity 4 ,96
+The Robe ,135
+The Return of the Pink Panther ,113
+Freddy's Dead: The Final Nightmare ,93
+Monster ,109
+"20,000 Leagues Under the Sea ",127
+Paranormal Activity: The Marked Ones ,101
+The Elephant Man ,124
+Dallas Buyers Club ,117
+The Lazarus Effect ,83
+Memento ,113
+Oculus ,104
+Clerks II ,97
+Billy Elliot ,110
+The Way Way Back ,103
+House Party 2 ,94
+The Man from Snowy River ,102
+Doug's 1st Movie ,77
+The Apostle ,134
+Mommie Dearest ,129
+Our Idiot Brother ,90
+Race ,134
+The Players Club ,104
+O ,95
+"As Above, So Below ",93
+Addicted ,106
+Eve's Bayou ,109
+Still Alice ,101
+The Egyptian ,139
+Nighthawks ,99
+Friday the 13th Part VIII: Jason Takes Manhattan ,100
+My Big Fat Greek Wedding ,95
+Spring Breakers ,94
+Halloween: The Curse of Michael Myers ,93
+Y Tu Mamá También ,106
+Shaun of the Dead ,99
+The Haunting of Molly Hartley ,82
+Lone Star ,135
+Halloween 4: The Return of Michael Myers ,88
+April Fool's Day ,89
+Diner ,110
+Lone Wolf McQuade ,107
+Apollo 18 ,86
+Sunshine Cleaning ,91
+No Escape ,103
+The Beastmaster ,90
+Solomon and Sheba ,141
+Fifty Shades of Black ,92
+Not Easily Broken ,99
+A Farewell to Arms ,79
+The Perfect Match ,96
+Digimon: The Movie ,82
+Saved! ,92
+The Barbarian Invasions ,112
+Robin and Marian ,106
+The Forsaken ,90
+Force 10 from Navarone ,126
+UHF ,150
+Grandma's Boy ,90
+Slums of Beverly Hills ,91
+Once Upon a Time in the West ,145
+Made ,95
+Moon ,97
+Keeping Up with the Steins ,90
+Sea Rex 3D: Journey to a Prehistoric World ,41
+The Sweet Hereafter ,112
+Of Gods and Men ,122
+Bottle Shock ,110
+Jekyll and Hyde... Together Again ,87
+Heavenly Creatures ,108
+90 Minutes in Heaven ,121
+Everything Must Go ,97
+Zero Effect ,116
+The Machinist ,94
+Light Sleeper ,103
+Kill the Messenger ,112
+Buffalo '66 ,110
+Party Monster ,98
+Green Room ,95
+The Oh in Ohio ,88
+Atlas Shrugged: Who Is John Galt? ,99
+Bottle Rocket ,91
+Albino Alligator ,97
+"Gandhi, My Father ",136
+Standard Operating Procedure ,118
+Out of the Blue ,94
+Tucker and Dale vs Evil ,89
+"Lovely, Still ",90
+Tycoon ,95
+Desert Blue ,90
+Decoys ,95
+The Visit ,94
+Redacted ,90
+Fascination ,103
+Saving Grace             ,60
+Area 51 ,91
+Sleep Tight ,102
+The Cottage ,92
+Dead Like Me: Life After Death ,87
+Farce of the Penguins ,80
+Flying By ,90
+Psych             ,44
+Rudderless ,105
+Henry & Me ,67
+Christmas Eve ,95
+We Have Your Husband ,87
+Dying of the Light ,94
+Born of War ,109
+Capricorn One ,130
+Should've Been Romeo ,
+Running Forever ,88
+Yoga Hosers ,88
+Navy Seals vs. Zombies ,97
+I Served the King of England ,113
+Soul Kitchen ,99
+Sling Blade ,148
+The Awakening ,107
+Hostel ,93
+Tristram Shandy: A Cock and Bull Story ,94
+Take Shelter ,121
+Lady in White ,118
+Driving Lessons ,98
+Let's Kill Ward's Wife ,82
+The Texas Chainsaw Massacre 2 ,101
+Pat Garrett & Billy the Kid ,106
+Only God Forgives ,90
+Camping sauvage ,79
+Without Men ,87
+Barfi ,
+Dear Frankie ,105
+All Hat ,89
+The Names of Love ,100
+Treading Water ,92
+Savage Grace ,97
+Out of the Blue ,100
+Police Academy ,96
+The Blue Lagoon ,104
+Four Weddings and a Funeral ,117
+Fast Times at Ridgemont High ,90
+Moby Dick ,115
+25th Hour ,108
+Secrets and Lies             ,43
+Bound ,109
+Requiem for a Dream ,102
+State Fair ,100
+Tango ,115
+Salvador ,122
+Moms' Night Out ,98
+Donnie Darko ,133
+Saving Private Perez ,105
+Character ,122
+Spun ,106
+Life During Wartime ,98
+Lady Vengeance ,112
+Mozart's Sister ,120
+Mean Machine ,99
+Exiled ,110
+Blackthorn ,102
+Lilya 4-Ever ,109
+After.Life ,104
+Fugly ,134
+One Flew Over the Cuckoo's Nest ,133
+R.L. Stine's Monsterville: The Cabinet of Souls ,85
+Silent Movie ,87
+Airlift ,130
+Anne of Green Gables             ,199
+Falcon Rising ,103
+The Sweeney ,112
+Sexy Beast ,89
+Easy Money ,124
+Whale Rider ,101
+Paa ,133
+Cargo ,112
+Pan ,111
+High School Musical ,98
+Animal Kingdom             ,60
+Love and Death on Long Island ,93
+Night Watch ,104
+The Crying Game ,112
+Porky's ,94
+Survival of the Dead ,90
+Night of the Living Dead ,96
+Lost in Translation ,101
+Annie Hall ,93
+The Greatest Show on Earth ,152
+Exodus: Gods and Kings ,150
+Monster's Ball ,112
+Maggie ,95
+Leaving Las Vegas ,111
+Hansel & Gretel Get Baked ,86
+The Return of the Living Dead ,108
+The Front Page ,105
+The Boy Next Door ,91
+Trapeze ,105
+Saving Grace             ,60
+The Kids Are All Right ,106
+They Live ,93
+The Great Escape ,172
+What the #$*! Do We (K)now!? ,109
+The Last Exorcism Part II ,93
+Boyhood ,165
+Scoop ,96
+Planet of the Apes ,119
+The Wash ,93
+3 Strikes ,82
+The Cooler ,101
+The Misfits ,120
+The Night Listener ,81
+The Jerky Boys ,82
+My Soul to Take ,107
+The Orphanage ,105
+A Haunted House 2 ,86
+The Rules of Attraction ,110
+Topaz ,127
+Let's Go to Prison ,90
+Four Rooms ,110
+Secretary ,104
+The Real Cancun ,96
+Talk Radio ,110
+Waiting for Guffman ,84
+Love Stinks ,94
+You Kill Me ,93
+Thumbsucker ,96
+Red State ,88
+Mirrormask ,101
+Samsara ,102
+The Barbarians ,87
+The Art of Getting By ,83
+Zipper ,103
+Poolhall Junkies ,99
+The Loss of Sexual Innocence ,106
+Holy Motors ,115
+Joe ,117
+Shooting Fish ,99
+Prison ,102
+Psycho Beach Party ,85
+The Big Tease ,86
+"Buen Día, Ramón ",120
+Trust ,106
+An Everlasting Piece ,103
+Among Giants ,93
+Adore ,112
+The Velocity of Gary ,100
+Mondays in the Sun ,113
+Stake Land ,98
+Sonny with a Chance             ,23
+The Last Time I Committed Suicide ,92
+Futuro Beach ,106
+Another Happy Day ,119
+A Lonely Place to Die ,99
+Nothing ,90
+The Geographer Drank His Globe Away ,120
+1776 ,168
+Inescapable ,93
+Hell's Angels ,96
+Purple Violets ,103
+The Veil ,93
+The Loved Ones ,84
+No Vacancy ,81
+How to Fall in Love ,84
+The Perfect Wave ,94
+Ben-Hur ,141
+A Man for All Seasons ,120
+Network ,121
+Gone with the Wind ,226
+Desert Dancer ,104
+Major Dundee ,152
+Down for Life ,92
+Annie Get Your Gun ,107
+Four Lions ,97
+House of Sand ,115
+Defendor ,95
+The Pirate ,102
+The Good Heart ,99
+The History Boys ,109
+Unknown ,113
+M*A*S*H             ,25
+Midnight Cowboy ,113
+The Full Monty ,91
+Airplane! ,88
+Chain of Command ,88
+Friday ,97
+Menace II Society ,97
+Empire             ,42
+Creepshow 2 ,85
+The Ballad of Cable Hogue ,121
+In Cold Blood ,134
+The Nun's Story ,149
+Harper ,121
+Frenzy ,116
+The Witch ,92
+I Got the Hook Up ,93
+She's the One ,96
+Gods and Monsters ,105
+The Secret in Their Eyes ,129
+Day of the Dead ,87
+Train ,94
+Evil Dead II ,37
+Pootie Tang ,81
+Sharknado ,97
+La otra conquista ,106
+Trollhunter ,103
+Ira & Abby ,101
+The Watch ,102
+Winter Passing ,98
+D.E.B.S. ,91
+The Masked Saint ,105
+The Betrayed ,98
+Taxman ,104
+The Secret             ,45
+2:13 ,96
+"Batman: The Dark Knight Returns, Part 2 ",148
+Time to Choose ,100
+In the Name of the King: The Last Job ,86
+Wicked Blood ,92
+Dawn Patrol ,88
+Lords of London ,90
+High Anxiety ,94
+March of the Penguins ,80
+Margin Call ,107
+August ,99
+Choke ,92
+Whiplash ,107
+City of God ,135
+Human Traffic ,99
+Day One ,102
+The Dead Girl ,93
+The Hunt ,115
+A Christmas Story ,94
+Bella ,91
+Class of 1984 ,98
+The Opposite Sex ,97
+Dreaming of Joseph Lees ,92
+The Class ,128
+Rosemary's Baby ,136
+The Man Who Shot Liberty Valance ,113
+Adam ,99
+Maria Full of Grace ,101
+Beginners ,105
+Feast ,95
+Animal House ,109
+Goldfinger ,110
+Antiviral ,108
+It's a Wonderful Life ,118
+Trainspotting ,94
+The Original Kings of Comedy ,115
+Paranormal Activity 2 ,98
+Waking Ned Devine ,91
+Bowling for Columbine ,120
+Coming Home ,109
+A Nightmare on Elm Street 2: Freddy's Revenge ,87
+A Room with a View ,117
+The Purge ,85
+Sinister ,110
+Martin Lawrence Live: Runteldat ,113
+Cat on a Hot Tin Roof ,108
+Beneath the Planet of the Apes ,95
+Air Bud ,98
+Pokémon 3: The Movie ,93
+Jason Lives: Friday the 13th Part VI ,86
+The Bridge on the River Kwai ,161
+Spaced Invaders ,100
+Family Plot ,120
+The Apartment ,125
+Jason Goes to Hell: The Final Friday ,91
+Torn Curtain ,128
+Dave Chappelle's Block Party ,100
+Slow West ,84
+Krush Groove ,97
+Next Day Air ,84
+Elmer Gantry ,146
+Judgment at Nuremberg ,186
+Trippin' ,94
+Robot Chicken             ,11
+Red River ,126
+Phat Girlz ,99
+Before Midnight ,109
+Teen Wolf Too ,95
+Phantasm II ,97
+Woman Thou Art Loosed ,94
+Real Women Have Curves ,90
+Deadline Gallipoli             ,197
+Water ,117
+East Is East ,96
+Whipped ,82
+Kama Sutra: A Tale of Love ,109
+Please Give ,90
+Willy Wonka & the Chocolate Factory ,89
+Warlock: The Armageddon ,98
+8 Heads in a Duffel Bag ,95
+Days of Heaven ,94
+Thirteen Conversations About One Thing ,104
+Jawbreaker ,87
+Basquiat ,108
+Frances Ha ,86
+Tsotsi ,94
+Happiness ,134
+DysFunktional Family ,89
+Tusk ,102
+Oldboy ,120
+Letters to God ,110
+Hobo with a Shotgun ,86
+Compadres ,101
+Freeway ,102
+Love's Abiding Joy ,87
+Fish Tank ,123
+Damsels in Distress ,99
+Creature             ,173
+Bachelorette ,87
+BrainDead             ,44
+Brave New Girl ,120
+Tim and Eric's Billion Dollar Movie ,93
+The Gambler ,111
+The Grand             ,60
+Summer Storm ,98
+Fort McCoy ,100
+Chain Letter ,88
+Just Looking ,97
+The Divide ,122
+The Eclipse ,86
+Demonic ,83
+My Big Fat Independent Movie ,80
+Alice in Wonderland ,108
+The Deported ,90
+Tanner Hall ,96
+Open Road ,85
+They Came Together ,83
+30 Nights of Paranormal Activity with the Devil Inside the Girl with the Dragon Tattoo ,80
+Never Back Down 2: The Beatdown ,90
+Point Blank ,92
+Four Single Fathers ,100
+Enter the Dangerous Mind ,88
+Something Wicked ,95
+AWOL-72 ,82
+Iguana ,97
+Cinderella ,105
+Chicago Overcoat ,94
+Barry Munday ,95
+Central Station ,113
+Pocketful of Miracles ,136
+Close Range ,80
+Boynton Beach Club ,105
+Amnesiac ,90
+Freakonomics ,93
+The Omen ,107
+High Tension ,89
+Griff the Invisible ,90
+Unnatural ,89
+Hustle & Flow ,116
+Some Like It Hot ,120
+Friday the 13th Part VII: The New Blood ,88
+The Wizard of Oz ,102
+Young Frankenstein ,106
+Diary of the Dead ,95
+Lage Raho Munna Bhai ,144
+Ulee's Gold ,113
+The Black Stallion ,118
+Sardaar Ji ,141
+Journey to Saturn ,90
+Donovan's Reef ,109
+The Dress ,95
+A Guy Named Joe ,122
+Blazing Saddles ,93
+Friday the 13th: The Final Chapter ,97
+Ida ,82
+Maurice ,140
+Beer League ,86
+The Astronaut's Wife ,109
+Riding Giants ,105
+Timecrimes ,66
+Silver Medallist ,99
+Timber Falls ,100
+Singin' in the Rain ,103
+"Fat, Sick & Nearly Dead ",97
+A Haunted House ,86
+2016: Obama's America ,87
+Halloween II ,119
+That Thing You Do! ,149
+Halloween III: Season of the Witch ,98
+Escape from the Planet of the Apes ,98
+Hud ,112
+Kevin Hart: Let Me Explain ,75
+My Own Private Idaho ,104
+Garden State ,102
+Before Sunrise ,105
+Sur le seuil ,99
+Jesus' Son ,107
+Saving Face ,96
+Brick Lane ,101
+Robot & Frank ,89
+My Life Without Me ,106
+The Spectacular Now ,95
+Marilyn Hotchkiss' Ballroom Dancing and Charm School ,34
+Religulous ,101
+Fuel ,112
+Valley of the Heart's Delight ,100
+Dodgeball: A True Underdog Story ,92
+Eye of the Dolphin ,100
+8: The Mormon Proposition ,80
+The Other End of the Line ,106
+Anatomy ,103
+Sleep Dealer ,90
+Super ,96
+Christmas Mail ,89
+Stung ,87
+Antibirth ,94
+Get on the Bus ,120
+Thr3e ,101
+Idiocracy ,84
+The Rise of the Krays ,110
+This Is England ,101
+Alien Uprising ,101
+Bathing Beauty ,101
+Go for It! ,105
+"Dancer, Texas Pop. 81 ",97
+Show Boat ,108
+Redemption Road ,95
+The Calling ,108
+The Brave Little Toaster ,90
+Fantasia ,120
+The French Connection ,104
+8 Days ,90
+Friday the 13th Part III ,91
+Friday the 13th: A New Beginning ,92
+The Last Sin Eater ,117
+Do You Believe? ,120
+Impact Point ,90
+The Valley of Decision ,119
+Eden ,90
+Chicken Tikka Masala ,90
+Always Woodstock ,97
+Jack Brooks: Monster Slayer ,90
+The Best Years of Our Lives ,172
+Bully ,115
+Elling ,89
+Mi America ,125
+[Rec] ,78
+Lies in Plain Sight ,89
+Sharkskin ,100
+Containment ,77
+The Timber ,81
+From Russia with Love ,115
+The Toxic Avenger Part II ,96
+In the Heat of the Night             ,60
+Sleeper ,89
+It Follows ,100
+Everything You Always Wanted to Know About Sex * But Were Afraid to Ask ,88
+To Kill a Mockingbird ,129
+Mad Max 2: The Road Warrior ,87
+The Legend of Drunken Master ,102
+Lolita ,152
+Boys Don't Cry ,118
+Silent House ,86
+The Lives of Others ,137
+Courageous ,129
+The Hustler ,134
+Boom Town ,119
+The Triplets of Belleville ,80
+Smoke Signals ,89
+American Splendor ,101
+Before Sunset ,80
+Amores Perros ,115
+Thirteen ,100
+Gentleman's Agreement ,118
+Winter's Bone ,100
+Touching the Void ,106
+Alexander's Ragtime Band ,106
+Me and You and Everyone We Know ,91
+Inside Job ,105
+We Are Your Friends ,96
+Ghost Dog: The Way of the Samurai ,116
+Harsh Times ,116
+Captive ,97
+Full Frontal ,101
+Witchboard ,98
+Strangers with Candy             ,22
+Hamlet ,150
+Shortbus ,101
+Waltz with Bashir ,90
+"The Book of Mormon Movie, Volume 1: The Journey ",120
+No End in Sight ,102
+The Diary of a Teenage Girl ,102
+Get Real             ,60
+In the Shadow of the Moon ,100
+Meek's Cutoff ,104
+Inside Deep Throat ,89
+Dinner Rush ,99
+Clockwatchers ,96
+The Virginity Hit ,86
+Subway ,98
+House of D ,96
+Teeth ,94
+Six-String Samurai ,91
+Hum To Mohabbat Karega ,
+It's All Gone Pete Tong ,90
+Saint John of Las Vegas ,85
+24 7: Twenty Four Seven ,96
+Stonewall ,129
+Eureka             ,60
+Roadside Romeo ,93
+This Thing of Ours ,100
+The Lost Medallion: The Adventures of Billy Stone ,97
+The Last Five Years ,94
+The Missing Person ,95
+Return of the Living Dead III ,97
+London ,92
+Sherrybaby ,96
+Stealing Harvard ,85
+Circle ,87
+Eden Lake ,91
+Plush ,99
+Vampire Killers ,88
+Gangster's Paradise: Jerusalema ,119
+Freeze Frame ,99
+Grave Encounters ,92
+Stitches ,86
+Nine Dead ,83
+"To Be Frank, Sinatra at 100 ",81
+Bananas ,82
+Supercapitalist ,102
+Rockaway ,90
+Wings             ,30
+The Lady from Shanghai ,92
+No Man's Land: The Rise of Reeker ,88
+Highway ,97
+Small Apartments ,96
+Coffee Town ,87
+The Ghastly Love of Johnny X ,106
+All Is Bright ,107
+The Torture Chamber of Dr. Sadism ,80
+Straight A's ,91
+A Funny Thing Happened on the Way to the Forum ,99
+Slacker Uprising ,102
+The Legend of Hell's Gate: An American Conspiracy ,108
+The Walking Deceased ,88
+The Curse of Downers Grove ,89
+Shark Lake ,92
+River's Edge ,99
+Northfork ,103
+The Marine 4: Moving Target ,90
+Buried ,95
+Submarine ,97
+The Square ,108
+One to Another ,95
+Carrie ,100
+ABCD (Any Body Can Dance) ,160
+A Nightmare on Elm Street ,101
+Man on Wire ,90
+Abandoned ,86
+Brotherly Love ,89
+The Last Exorcism ,87
+Nowhere Boy ,98
+A Streetcar Named Desire ,125
+Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb ,95
+El crimen del padre Amaro ,118
+Beasts of the Southern Wild ,93
+Battle for the Planet of the Apes ,96
+Songcatcher ,109
+Higher Ground ,109
+Vaalu ,155
+The Greatest Movie Ever Sold ,90
+Ed and His Dead Mother ,93
+Travelers and Magicians ,108
+Hang 'Em High ,114
+Deadline - U.S.A. ,87
+Sublime ,113
+A Beginner's Guide to Snuff ,87
+Independence Daysaster ,90
+Dysfunctional Friends ,111
+Run Lola Run ,81
+May ,93
+Against the Wild ,90
+Living Dark: The Story of Ted the Caver ,112
+Under the Same Moon ,106
+Conquest of the Planet of the Apes ,88
+In the Bedroom ,138
+I Spit on Your Grave ,105
+"Happy, Texas ",98
+My Summer of Love ,86
+The Lunchbox ,104
+Yes ,100
+You Can't Take It with You ,126
+From Here to Eternity ,118
+She Wore a Yellow Ribbon ,103
+Grace Unplugged ,102
+Foolish ,84
+N-Secure ,
+Caramel ,95
+Out of the Dark ,92
+The Bubble ,90
+The Conversation ,113
+Dil Jo Bhi Kahey... ,
+Mississippi Mermaid ,123
+I Love Your Work ,111
+Cabin Fever ,99
+Dawn of the Dead ,110
+Waitress ,108
+Bloodsport ,92
+Mr. Smith Goes to Washington ,120
+Kids ,91
+The Squid and the Whale ,88
+Kissing Jessica Stein ,97
+"A Woman, a Gun and a Noodle Shop ",95
+Kickboxer: Vengeance ,90
+Spellbound ,95
+Exotica ,103
+My Date with Drew ,90
+Insidious ,103
+Repo Man ,92
+Nine Queens ,114
+The Gatekeepers ,101
+The Ballad of Jack and Rose ,112
+The To Do List ,104
+Killing Zoe ,99
+The Believer ,98
+Snow Angels ,107
+Unsullied ,93
+Session 9 ,100
+I Want Someone to Eat Cheese With ,80
+Mooz-Lum ,94
+Hatchet ,93
+Modern Times ,87
+Stolen Summer ,91
+My Name Is Bruce ,84
+The Salon ,90
+Road Hard ,98
+Forty Shades of Blue ,108
+Amigo ,124
+Pontypool ,95
+Trucker ,90
+Me You and Five Bucks ,93
+The Lords of Salem ,101
+Housebound ,107
+Wal-Mart: The High Cost of Low Price ,20
+Fetching Cody ,87
+Once Upon a Time in Queens ,98
+Closer to the Moon ,112
+Mutant World ,82
+Growing Up Smith ,102
+Checkmate ,97
+Jack Reacher ,130
+#Horror ,101
+Wind Walkers ,93
+Snow White and the Seven Dwarfs ,83
+The Holy Girl ,106
+Shalako ,113
+Incident at Loch Ness ,94
+The Dog Lover ,101
+Girl House ,99
+The Blue Room ,76
+House at the End of the Drive ,91
+Batman: The Movie ,105
+"Lock, Stock and Two Smoking Barrels ",120
+The Ballad of Gregorio Cortez ,105
+The Streets of San Francisco             ,120
+The Celebration ,105
+Trees Lounge ,95
+Journey from the Fall ,135
+The Basket ,105
+Eddie: The Sleepwalking Cannibal ,83
+Mercury Rising ,111
+Space: Above and Beyond             ,60
+Queen of the Mountains ,135
+Def-Con 4 ,88
+The Hebrew Hammer ,87
+Neal 'N' Nikki ,97
+The 41-Year-Old Virgin Who Knocked Up Sarah Marshall and Felt Superbad About It ,82
+Forget Me Not ,103
+Rebecca ,130
+Friday the 13th Part 2 ,87
+The Lost Weekend ,101
+C.H.U.D. ,96
+Filly Brown ,80
+The Lion of Judah ,87
+Niagara ,92
+How Green Was My Valley ,118
+The Girlfriend Experience             ,27
+Da Sweet Blood of Jesus ,123
+"Sex, Lies, and Videotape ",100
+Saw ,103
+Super Troopers ,100
+The Algerian ,99
+The Amazing Catfish ,89
+The Day the Earth Stood Still ,104
+Monsoon Wedding ,114
+You Can Count on Me ,111
+The Trouble with Harry ,99
+Lucky Number Slevin ,110
+But I'm a Cheerleader ,85
+Home Run ,113
+Reservoir Dogs ,99
+The Blue Bird ,83
+"The Good, the Bad and the Ugly ",142
+The Second Mother ,112
+Blue Like Jazz ,108
+Down and Out with the Dolls ,88
+"Pink Ribbons, Inc. ",97
+Certifiably Jonathan ,85
+Q ,103
+The Knife of Don Juan ,110
+Grand Theft Parsons ,88
+Extreme Movie ,76
+The Charge of the Light Brigade ,100
+Below Zero ,99
+Crowsnest ,84
+Airborne ,91
+Cotton Comes to Harlem ,97
+The Wicked Within ,84
+Bleeding Hearts ,100
+Waiting... ,94
+Dead Man's Shoes ,90
+Wolf Creek             ,
+From a Whisper to a Scream ,92
+Sex with Strangers ,105
+Dracula: Pages from a Virgin's Diary ,73
+Faith Like Potatoes ,116
+Beyond the Black Rainbow ,110
+The Raid: Redemption ,102
+The Dead Undead ,89
+The Vatican Exorcisms ,76
+Casablanca ,82
+Lake Mungo ,89
+Rocket Singh: Salesman of the Year ,150
+Silent Running ,89
+Rocky ,145
+The Sleepwalker ,91
+The Fog ,89
+Tom Jones ,121
+Unfriended ,83
+Taxi Driver ,110
+The Howling ,91
+Dr. No ,110
+Chernobyl Diaries ,86
+Hellraiser ,86
+God's Not Dead 2 ,120
+Cry_Wolf ,90
+Godzilla 2000 ,99
+Blue Valentine ,112
+Transamerica ,103
+The Devil Inside ,83
+Beyond the Valley of the Dolls ,109
+Love Me Tender ,89
+An Inconvenient Truth ,96
+Sands of Iwo Jima ,109
+Shine a Light ,122
+The Green Inferno ,100
+Departure ,109
+The Sessions ,95
+"Food, Inc. ",94
+October Baby ,107
+Next Stop Wonderland ,104
+Juno ,96
+The Skeleton Twins ,93
+Martha Marcy May Marlene ,102
+Obvious Child ,84
+Frozen River ,97
+20 Feet from Stardom ,91
+Two Girls and a Guy ,84
+Walking and Talking ,86
+The Full Monty ,91
+Who Killed the Electric Car? ,92
+The Broken Hearts Club: A Romantic Comedy ,94
+Bubba Ho-Tep ,92
+Goosebumps ,103
+Slam ,100
+Brigham City ,119
+Fiza ,167
+History of the World: Part I ,92
+Orgazmo ,92
+All the Real Girls ,108
+Dream with the Fishes ,97
+Blue Car ,88
+Luminarias ,100
+Palo Alto ,100
+Ajami ,124
+Wristcutters: A Love Story ,88
+I Origins ,106
+The Battle of Shaker Heights ,79
+The Lovely Bones ,135
+The Act of Killing ,96
+Taxi to the Dark Side ,53
+Once in a Lifetime: The Extraordinary Story of the New York Cosmos ,97
+Guiana 1838 ,120
+Lisa Picard Is Famous ,90
+Antarctica: A Year on Ice ,91
+A Lego Brickumentary ,93
+Hardflip ,112
+Chocolate: Deep Dark Secrets ,160
+The House of the Devil ,95
+The Perfect Host ,93
+Safe Men ,88
+Speedway Junky ,105
+The Last Big Thing ,98
+The Specials ,82
+16 to Life ,89
+Alone with Her ,78
+Creative Control ,97
+Special ,81
+Sparkler ,90
+The Helix... Loaded ,97
+In Her Line of Fire ,88
+The Jimmy Show ,96
+Heli ,105
+Karachi se Lahore ,
+Loving Annabelle ,76
+Hits ,96
+Jimmy and Judy ,99
+Frat Party ,90
+The Party's Over ,94
+Proud ,87
+The Poker House ,93
+Childless ,90
+ZMD: Zombies of Mass Destruction ,89
+Snow White: A Deadly Summer ,83
+Hidden Away ,96
+My Last Day Without You ,90
+Steppin: The Movie ,138
+Doc Holliday's Revenge ,84
+Black Rock ,83
+Truth or Die ,96
+The Pet ,94
+Bang Bang Baby ,90
+Fear Clinic ,95
+Zombie Hunter ,93
+A Fine Step ,111
+Trance ,101
+Charly ,103
+Banshee Chapter ,87
+Jesse             ,30
+Ask Me Anything ,100
+And Then Came Love ,90
+Food Chains ,83
+On the Waterfront ,108
+L!fe Happens ,100
+"4 Months, 3 Weeks and 2 Days ",113
+The Horror Network Vol. 1 ,97
+Hard Candy ,104
+The Quiet ,91
+Circumstance ,107
+Fruitvale Station ,85
+The Brass Teapot ,101
+Bambi ,70
+The Hammer ,88
+Snitch ,112
+Latter Days ,107
+Elza ,78
+1982 ,90
+"For a Good Time, Call... ",88
+Celeste & Jesse Forever ,92
+Time Changer ,95
+London to Brighton ,85
+American Hero ,86
+Windsor Drive ,90
+A Separation ,123
+Crying with Laughter ,93
+Welcome to the Dollhouse ,88
+Ruby in Paradise ,114
+Raising Victor Vargas ,88
+Pandora's Box ,110
+Harrison Montgomery ,95
+Live-In Maid ,83
+Deterrence ,104
+The Mudge Boy ,94
+The Young Unknowns ,87
+Not Cool ,93
+Dead Snow ,91
+Saints and Soldiers ,90
+Vessel ,14
+American Graffiti ,112
+Iraq for Sale: The War Profiteers ,75
+Aqua Teen Hunger Force Colon Movie Film for Theaters ,86
+Safety Not Guaranteed ,86
+Kevin Hart: Laugh at My Pain ,89
+Kill List ,95
+The Innkeepers ,101
+The Unborn ,89
+The Conformist ,106
+Interview with the Assassin ,88
+Donkey Punch ,99
+All the Boys Love Mandy Lane ,90
+Bled ,95
+High Noon ,85
+Hoop Dreams ,170
+Rize ,86
+Destiny ,
+L.I.E. ,97
+The Sisterhood of Night ,104
+B-Girl ,88
+King Kong ,201
+House of Wax ,108
+Half Nelson ,106
+Naturally Native ,107
+Hav Plenty ,84
+Adulterers ,91
+Escape from Tomorrow ,90
+Starsuckers ,103
+The Hadza: Last of the First ,71
+After ,90
+Treachery ,67
+Walter ,94
+Top Hat ,81
+The Blair Witch Project ,81
+Woodstock ,215
+The Kentucky Fried Movie ,83
+Mercy Streets ,106
+Arnolds Park ,103
+Broken Vessels ,90
+Water & Power ,88
+They Will Have to Kill Us First ,105
+Crop Circles: Quest for Truth ,115
+Light from the Darkroom ,90
+Irreplaceable ,102
+The Maid's Room ,98
+A Hard Day's Night ,87
+The Harvest/La Cosecha ,80
+Love Letters ,88
+Julija in alfa Romeo ,83
+Fireproof ,122
+Faith Connections ,115
+Benji ,86
+Open Water ,79
+High Road ,87
+Kingdom of the Spiders ,97
+Mad Hot Ballroom ,105
+The Station Agent ,89
+To Save a Life ,120
+Wordplay ,94
+Beyond the Mat ,108
+The Singles Ward ,102
+Osama ,83
+Sholem Aleichem: Laughing in the Darkness ,93
+Groove ,86
+The R.M. ,101
+Twin Falls Idaho ,111
+Mean Creek ,90
+Hurricane Streets ,86
+Never Again ,98
+Civil Brand ,91
+Lonesome Jim ,91
+Drinking Buddies ,90
+Deceptive Practice: The Mysteries and Mentors of Ricky Jay ,88
+Seven Samurai ,202
+The Other Dream Team ,89
+Johnny Suede ,97
+Finishing the Game: The Search for a New Bruce Lee ,84
+Rubber ,82
+Home ,94
+Kiss the Bride ,100
+The Slaughter Rule ,112
+Monsters ,94
+The Californians ,87
+The Living Wake ,91
+Detention of the Dead ,87
+Crazy Stone ,98
+Scott Walker: 30 Century Man ,95
+Everything Put Together ,87
+Good Kill ,102
+Insomnia Manica ,127
+The Outrageous Sophie Tucker ,96
+Now Is Good ,103
+Girls Gone Dead ,104
+America Is Still the Place ,90
+Subconscious ,122
+Crossroads ,93
+Enter Nowhere ,90
+The King of Najayo ,101
+Fight to the Finish ,94
+Alleluia! The Devil's Carnival ,97
+The Sound and the Shadow ,90
+Rodeo Girl ,108
+Born to Fly: Elizabeth Streb vs. Gravity ,82
+The Little Ponderosa Zoo ,84
+Oz the Great and Powerful ,130
+The Toxic Avenger ,91
+Straight Out of Brooklyn ,91
+Bloody Sunday ,107
+Diamond Ruff ,82
+Conversations with Other Women ,84
+Poultrygeist: Night of the Chicken Dead ,103
+Mutual Friends ,86
+42nd Street ,89
+Rise of the Entrepreneur: The Search for a Better Way ,52
+Metropolitan ,98
+As It Is in Heaven ,133
+Roadside ,81
+Napoleon Dynamite ,92
+Blue Ruin ,90
+Paranormal Activity ,84
+Dogtown and Z-Boys ,91
+Monty Python and the Holy Grail ,91
+Quinceañera ,90
+Gory Gory Hallelujah ,96
+Heroes             ,60
+Tarnation ,88
+I Want Your Money ,92
+Love in the Time of Monsters ,97
+The Beyond ,82
+Home Movies             ,22
+What Happens in Vegas ,101
+The Dark Hours ,80
+My Beautiful Laundrette ,97
+Fabled ,84
+Show Me ,97
+Cries & Whispers ,91
+Intolerance: Love's Struggle Throughout the Ages ,123
+Trekkies ,86
+The Broadway Melody ,100
+The Evil Dead ,96
+Maniac ,89
+Censored Voices ,84
+Murderball ,88
+American Ninja 2: The Confrontation ,90
+51 Birch Street ,90
+Revolution             ,43
+Rotor DR1 ,98
+Halloween ,101
+12 Angry Men ,96
+My Dog Tulip ,83
+It Happened One Night ,65
+Dogtooth ,94
+Tupac: Resurrection ,112
+Tumbleweeds ,102
+The Prophecy ,98
+When the Cat's Away ,91
+Pieces of April ,80
+The Big Swap ,114
+Old Joy ,76
+Wendy and Lucy ,80
+3 Backyards ,88
+Pierrot le Fou ,110
+Sisters in Law ,104
+Ayurveda: Art of Being ,102
+Nothing But a Man ,95
+"First Love, Last Rites ",94
+Fighting Tommy Riley ,109
+Royal Kill ,90
+Across the Universe ,133
+The Looking Glass ,110
+Death Race 2000 ,80
+Locker 13 ,95
+Midnight Cabaret ,94
+Anderson's Cross ,98
+Bizarre ,98
+Graduation Day ,96
+Some Guy Who Kills People ,97
+Compliance ,90
+Chasing Amy ,113
+Lovely & Amazing ,91
+Death Calls ,90
+Better Luck Tomorrow ,98
+The Incredibly True Adventure of Two Girls in Love ,94
+Chuck & Buck ,96
+American Desi ,100
+Amidst the Devil's Wings ,90
+Cube ,90
+Love and Other Catastrophes ,76
+I Married a Strange Person! ,75
+November ,78
+Like Crazy ,90
+Teeth and Blood ,96
+Sugar Town ,92
+The Motel ,75
+The Canyons ,99
+Happy Valley             ,58
+On the Outs ,86
+Shotgun Stories ,92
+Exam ,101
+The Sticky Fingers of Time ,81
+Sunday School Musical ,93
+Rust ,95
+Ink ,107
+The Christmas Bunny ,98
+Jesus People ,35
+Butterfly ,108
+UnDivided ,66
+The Frozen ,95
+The Love Letter ,99
+Horse Camp ,108
+Give Me Shelter ,90
+The Big Parade ,151
+Little Big Top ,83
+Along the Roadside ,108
+Bronson ,92
+Western Religion ,105
+Burn ,86
+Urbania ,106
+The Stewardesses ,93
+"The Beast from 20,000 Fathoms ",80
+"20,000 Leagues Under the Sea ",127
+Mad Max ,93
+Swingers ,96
+A Fistful of Dollars ,99
+She Done Him Wrong ,66
+Short Cut to Nirvana: Kumbh Mela ,85
+The Grace Card ,101
+Middle of Nowhere ,97
+3 ,119
+The Business of Fancydancing ,103
+Call + Response ,86
+Side Effects ,106
+Malevolence ,90
+Shooting the Warwicks ,95
+Super Hybrid ,94
+Baghead ,84
+Solitude ,89
+The Case of the Grinning Cat ,59
+Ordet ,126
+Good Dick ,86
+The Man from Earth ,87
+The Trials of Darryl Hunt ,106
+An American Girl Holiday ,86
+Yesterday Was a Lie ,89
+Theresa Is a Mother ,105
+H. ,93
+Archaeology of a Woman ,94
+Children of Heaven ,89
+Weekend ,97
+She's Gotta Have It ,88
+Butterfly Girl ,78
+The World Is Mine ,104
+Another Earth ,92
+The Calling ,108
+Sweet Sweetback's Baadasssss Song ,97
+Perfect Cowboy ,109
+Tadpole ,78
+Once ,85
+The Woman Chaser ,88
+The Horse Boy ,93
+When the Lights Went Out ,86
+Heroes of Dirt ,98
+The Texas Chain Saw Massacre ,88
+A Charlie Brown Christmas ,25
+Antarctic Edge: 70° South ,72
+Aroused ,66
+Top Spin ,80
+Roger & Me ,91
+Cat People ,93
+An American in Hollywood ,89
+Sound of My Voice ,85
+The Brain That Sings ,62
+The Blood of My Brother ,90
+Your Sister's Sister ,90
+Romantic Schemer ,
+A Dog's Breakfast ,88
+A Dog's Breakfast ,88
+Night of the Living Dead ,96
+Une Femme Mariée ,94
+The Birth of a Nation ,120
+The Work and the Story ,77
+Facing the Giants ,111
+The Gallows ,81
+Eraserhead ,89
+Over the Hill to the Poorhouse ,110
+Hollywood Shuffle ,81
+The Mighty ,100
+Penitentiary ,99
+The Lost Skeleton of Cadavra ,90
+"Dude, Where's My Dog?! ",82
+Cheap Thrills ,88
+Indie Game: The Movie ,103
+Closure ,80
+Open Secret ,68
+Echo Dr. ,81
+The Night Visitor ,106
+The Past is a Grotesque Animal ,77
+The Last House on the Left ,114
+"Peace, Propaganda & the Promised Land ",80
+Pi ,84
+"I Love You, Don't Touch Me! ",86
+20 Dates ,87
+Queen Crab ,80
+Super Size Me ,100
+The FP ,82
+Happy Christmas ,82
+The Brain That Wouldn't Die ,70
+Tiger Orange ,75
+Supporting Characters ,87
+Absentia ,87
+The Brothers McMullen ,98
+The Dirties ,83
+Gabriela ,99
+Tiny Furniture ,98
+Hayride ,93
+The Naked Ape ,
+Counting ,111
+The Call of Cthulhu ,47
+Bending Steel ,92
+The Signal ,97
+The Image Revolution ,81
+This Is Martin Bonner ,83
+A True Story ,96
+George Washington ,90
+Smiling Fish & Goat on Fire ,90
+Dawn of the Crescent Moon ,95
+Raymond Did It ,83
+The Last Waltz ,117
+"Run, Hide, Die ",75
+The Exploding Girl ,79
+The Legend of God's Gun ,78
+Mutual Appreciation ,109
+Her Cry: La Llorona Investigation ,89
+Down Terrace ,93
+Clerks ,102
+Pink Narcissus ,65
+Funny Ha Ha ,85
+In the Company of Men ,97
+Sabotage ,109
+Manito ,79
+Rampage ,80
+Slacker ,100
+Dutch Kills ,90
+Dry Spell ,90
+Flywheel ,120
+Exeter ,91
+The Ridges ,143
+The Puffy Chair ,85
+Stories of Our Lives ,60
+Breaking Upwards ,88
+All Superheroes Must Die ,78
+Pink Flamingos ,108
+Clean ,110
+The Circle ,90
+Tin Can Man ,83
+The Cure ,111
+On the Downlow ,84
+Sanctuary; Quite a Conundrum ,82
+Bang ,98
+Primer ,77
+Cavite ,80
+El Mariachi ,81
+The Mongol King ,84
+Newlyweds ,95
+Signed Sealed Delivered ,87
+The Following             ,43
+A Plague So Pleasant ,76
+Shanghai Calling ,100
+Rabbit Hole ,91

--- a/dsfs/testdata/strict_fail/input.dataset.json
+++ b/dsfs/testdata/strict_fail/input.dataset.json
@@ -1,0 +1,34 @@
+{
+  "commit" : {
+    "qri" : "cm:0",
+    "title" : "initial commit"
+  },
+  "meta": {
+    "title": "example movie data"
+  },
+  "qri": "ds:0",
+  "structure": {
+    "qri": "st:0",
+    "format": "csv",
+    "formatConfig": {
+      "headerRow": true
+    },
+    "strict": true,
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": [
+          {
+            "title": "title",
+            "type": "string"
+          },
+          {
+            "title": "duration",
+            "type": "integer"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/structure.go
+++ b/structure.go
@@ -210,7 +210,7 @@ func (s *Structure) IsEmpty() bool {
 		s.FormatConfig == nil &&
 		s.Length == 0 &&
 		s.Schema == nil &&
-		s.Strict == false
+		!s.Strict
 }
 
 // Assign collapses all properties of a group of structures on to one
@@ -262,7 +262,7 @@ func (s *Structure) Assign(structures ...*Structure) {
 			// s.Schema.Assign(st.Schema)
 			s.Schema = st.Schema
 		}
-		if st.Strict != false {
+		if st.Strict {
 			s.Strict = st.Strict
 		}
 	}

--- a/structure.go
+++ b/structure.go
@@ -62,6 +62,10 @@ type Structure struct {
 	// are defined using the IETF json-schema specification. for more info
 	// on json-schema see: https://json-schema.org
 	Schema map[string]interface{} `json:"schema,omitempty"`
+	// Strict requires schema validation to pass without error. Datasets with
+	// strict: true can have additional functionality and performance speedups
+	// that comes with being able to assume that all data is valid
+	Strict bool `json:"strict,omitempty"`
 }
 
 // NewStructureRef creates an empty struct with it's
@@ -109,6 +113,7 @@ func (s *Structure) Abstract() *Structure {
 		Format:       s.Format,
 		FormatConfig: s.FormatConfig,
 		Encoding:     s.Encoding,
+		Strict:       s.Strict,
 	}
 	if s.Schema != nil {
 		// TODO - Fix meeeeeeee
@@ -171,6 +176,7 @@ func (s Structure) MarshalJSONObject() ([]byte, error) {
 		Length:       s.Length,
 		Qri:          kind,
 		Schema:       s.Schema,
+		Strict:       s.Strict,
 	})
 }
 
@@ -203,7 +209,8 @@ func (s *Structure) IsEmpty() bool {
 		s.Format == "" &&
 		s.FormatConfig == nil &&
 		s.Length == 0 &&
-		s.Schema == nil
+		s.Schema == nil &&
+		s.Strict == false
 }
 
 // Assign collapses all properties of a group of structures on to one
@@ -254,6 +261,9 @@ func (s *Structure) Assign(structures ...*Structure) {
 			// }
 			// s.Schema.Assign(st.Schema)
 			s.Schema = st.Schema
+		}
+		if st.Strict != false {
+			s.Strict = st.Strict
 		}
 	}
 }

--- a/structure_test.go
+++ b/structure_test.go
@@ -82,6 +82,7 @@ func TestStructureIsEmpty(t *testing.T) {
 		{&Structure{FormatConfig: map[string]interface{}{}}},
 		{&Structure{Length: 1}},
 		{&Structure{Schema: map[string]interface{}{}}},
+		{&Structure{Strict: true}},
 	}
 
 	for i, c := range cases {
@@ -102,6 +103,7 @@ func TestStructureAssign(t *testing.T) {
 		Encoding:    "UTF-8",
 		Entries:     3000000000,
 		Format:      "csv",
+		Strict:      true,
 	}
 	got := &Structure{
 		Length: 2000,
@@ -117,6 +119,7 @@ func TestStructureAssign(t *testing.T) {
 		Encoding:    "UTF-8",
 		Entries:     3000000000,
 		Format:      "csv",
+		Strict:      true,
 	})
 
 	if err := CompareStructures(expect, got); err != nil {

--- a/validate/data.go
+++ b/validate/data.go
@@ -14,6 +14,8 @@ import (
 func EntryReader(r dsio.EntryReader) ([]jsonschema.ValError, error) {
 	st := r.Structure()
 
+	// TODO (b5) - do we really need to parse this as JSON? can't we just read and
+	// valudate golang values?
 	buf, err := dsio.NewEntryBuffer(&dataset.Structure{
 		Format: "json",
 		Schema: st.Schema,


### PR DESCRIPTION
builds on #190.

Add a field to the structure component the _requires_ valid data in order to make a change. 

In the future I'd like to investigate adding a more nuanced set of validation logic to the schemas themselves that would allow progressive enhancement of datasets (eg: "this column MUST pass validation"), but even that would be working toward being able to set `strict: true`

In later enhancements we can check for strict: true in packages like `dsio` to facilitate memory allocation speedups. User interfaces can show some sort of check or seal declaring the dataset as "clean data". Finally, we should be able to do cool things when two datasets are strict, thanks to the fact that we know the data won't contain any surprises