### PR TITLE
feat(DropDerived): add methods for dropping derived values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
       GO111MODULE: "on"
+      GOPROXY: "https://proxy.golang.org"
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS

--- a/commit.go
+++ b/commit.go
@@ -17,8 +17,10 @@ type Commit struct {
 	// Message is an optional
 	Message string `json:"message,omitempty"`
 	// Path is the location of this commit, transient
+	// derived
 	Path string `json:"path,omitempty"`
 	// Qri is this commit's qri kind
+	// derived
 	Qri string `json:"qri,omitempty"`
 	// Signature is a base58 encoded privateKey signing of Title
 	Signature string `json:"signature,omitempty"`
@@ -38,6 +40,13 @@ func NewCommitRef(path string) *Commit {
 // dataset is rendered immutable, usually by storing it in a cafs
 func (cm *Commit) DropTransientValues() {
 	cm.Path = ""
+}
+
+// DropDerivedValues removes values that cannot be recorded when the
+// dataset is rendered immutable, usually by storing it in a cafs
+func (cm *Commit) DropDerivedValues() {
+	cm.Path = ""
+	cm.Qri = ""
 }
 
 // IsEmpty checks to see if any fields are filled out other than Path and Qri

--- a/commit_test.go
+++ b/commit_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCommit(t *testing.T) {
@@ -60,6 +62,31 @@ func TestCommitAssign(t *testing.T) {
 	emptyMsg.Assign(expect)
 	if err := CompareCommits(expect, emptyMsg); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestCommitDropTransientValues(t *testing.T) {
+	cm := &Commit{
+		Path: "/ipfs/QmHash",
+	}
+
+	cm.DropTransientValues()
+
+	if !cmp.Equal(cm, &Commit{}) {
+		t.Errorf("expected dropping a commit of only transient values to be empty")
+	}
+}
+
+func TestCommitDropDerivedValues(t *testing.T) {
+	cm := &Commit{
+		Path: "/ipfs/QmHash",
+		Qri:  "oh you know it's qri",
+	}
+
+	cm.DropDerivedValues()
+
+	if !cmp.Equal(cm, &Commit{}) {
+		t.Errorf("expected dropping commit of only derived values to be empty")
 	}
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -74,7 +74,7 @@ type Dataset struct {
 	// Number of versions this dataset has, transient
 	NumVersions int `json:"numVersions,omitempty"`
 	// Qri is a key for both identifying this document type, and versioning the
-	// dataset document definition itself.
+	// dataset document definition itself. derived
 	Qri string `json:"qri"`
 	// Structure of this dataset
 	Structure *Structure `json:"structure,omitempty"`
@@ -135,6 +135,28 @@ func (ds *Dataset) DropTransientValues() {
 	ds.Path = ""
 	ds.ProfileID = ""
 	ds.NumVersions = 0
+}
+
+// DropDerivedValues resets all set-on-save fields to their default values
+func (ds *Dataset) DropDerivedValues() {
+	ds.Qri = ""
+	ds.Path = ""
+
+	if ds.Commit != nil {
+		ds.Commit.DropDerivedValues()
+	}
+	if ds.Meta != nil {
+		ds.Meta.DropDerivedValues()
+	}
+	if ds.Structure != nil {
+		ds.Structure.DropDerivedValues()
+	}
+	if ds.Transform != nil {
+		ds.Transform.DropDerivedValues()
+	}
+	if ds.Viz != nil {
+		ds.Viz.DropDerivedValues()
+	}
 }
 
 var (

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -6,6 +6,9 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestDatasetDropTransientValues(t *testing.T) {
@@ -34,6 +37,61 @@ func TestDatasetDropTransientValues(t *testing.T) {
 	ds.DropTransientValues()
 	if ds.IsEmpty() {
 		t.Errorf("error dataset should not be empty")
+	}
+}
+
+func TestDatasetDropDerivedValues(t *testing.T) {
+	ds := &Dataset{
+		Qri:  "definitely qri",
+		Path: "/ntwk/QmDsHash",
+		Meta: &Meta{
+			Qri:  "foo",
+			Path: "/ntwk/QmHash",
+		},
+		Structure: &Structure{
+			Checksum: "checksum",
+			Depth:    120,
+			ErrCount: 4,
+			Entries:  1234567890,
+			Length:   90210,
+			Path:     "/ipfs/QmHash",
+			Qri:      "oh you know it's qri",
+		},
+		Viz: &Viz{
+			Qri:  "yep, is qri",
+			Path: "/ntwk/QmViz",
+		},
+		Commit: &Commit{
+			Qri:  "qri bird",
+			Path: "/ntwk/QmCommit",
+		},
+		Transform: &Transform{
+			Qri:  "qri qri",
+			Path: "/ntwk/QmTf",
+		},
+	}
+
+	ds.DropDerivedValues()
+
+	exp := &Dataset{
+		Commit:    &Commit{},
+		Meta:      &Meta{},
+		Structure: &Structure{},
+		Viz:       &Viz{},
+		Transform: &Transform{},
+	}
+
+	if !cmp.Equal(ds, exp, cmpopts.IgnoreUnexported(Dataset{}, Meta{}, Viz{}, Transform{})) {
+		t.Errorf("expected dropping a dataset of only derived values to be empty")
+		t.Logf("%#v", ds)
+		// data, _ := json.MarshalIndent(ds, "", "  ")
+		// t.Logf(string(data))
+	}
+	if ds.Path != "" {
+		t.Errorf("expected dataset .Path field to be empty")
+	}
+	if ds.Qri != "" {
+		t.Errorf("expected dataset .Qri field to be empty")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.2.0
 	github.com/ipfs/go-datastore v0.0.5
 	github.com/ipfs/go-log v0.0.1
 	github.com/jinzhu/copier v0.0.0-20180308034124-7e38e58719c3

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0/go.mod h1:qOQCunE
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/meta.go
+++ b/meta.go
@@ -47,8 +47,10 @@ type Meta struct {
 	// raw string
 	License *License `json:"license,omitempty"`
 	// path is the location of meta, transient
+	// derived
 	Path string `json:"path,omitempty"`
 	// Kind is required, must be qri:md:[version]
+	// derived
 	Qri string `json:"qri,omitempty"`
 	// path to dataset readme file, not part of the DCAT spec, but a common
 	// convention in software dev
@@ -65,6 +67,12 @@ type Meta struct {
 // dataset is rendered immutable, usually by storing it in a cafs
 func (md *Meta) DropTransientValues() {
 	md.Path = ""
+}
+
+// DropDerivedValues resets all set-on-save fields to their default values
+func (md *Meta) DropDerivedValues() {
+	md.Path = ""
+	md.Qri = ""
 }
 
 // IsEmpty checks to see if dataset has any fields other than the internal path

--- a/meta_test.go
+++ b/meta_test.go
@@ -6,7 +6,22 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+func TestMetaDropDerivedValues(t *testing.T) {
+	md := &Meta{
+		Path: "/ipfs/QmHash",
+		Qri:  "oh you know it's qri",
+	}
+
+	md.DropDerivedValues()
+
+	if !cmp.Equal(md, &Meta{}, cmp.AllowUnexported(Meta{})) {
+		t.Errorf("expected dropping a commit of only derived values to be empty")
+	}
+}
 
 func TestMetaAssign(t *testing.T) {
 	// TODO - expand test to check all fields

--- a/structure.go
+++ b/structure.go
@@ -30,19 +30,24 @@ type Structure struct {
 	// Checksum is a bas58-encoded multihash checksum of the entire data
 	// file this structure points to. This is different from IPFS
 	// hashes, which are calculated after breaking the file into blocks
+	// derived
 	Checksum string `json:"checksum,omitempty"`
 	// Compression specifies any compression on the source data,
 	// if empty assume no compression
 	Compression string `json:"compression,omitempty"`
-	// Maximum nesting level of composite types in the dataset. eg: depth 1 == [], depth 2 == [[]]
+	// Maximum nesting level of composite types in the dataset.
+	// eg: depth 1 == [], depth 2 == [[]]
+	// derived
 	Depth int `json:"depth,omitempty"`
 	// Encoding specifics character encoding, assume utf-8 if not specified
 	Encoding string `json:"encoding,omitempty"`
 	// ErrCount is the number of errors returned by validating data
 	// against this schema. required
+	// derived
 	ErrCount int `json:"errCount"`
 	// Entries is number of top-level entries in the dataset. With tablular data
 	// this is the same as the number of "rows"
+	// derived
 	Entries int `json:"entries,omitempty"`
 	// Format specifies the format of the raw data MIME type
 	Format string `json:"format"`
@@ -53,10 +58,13 @@ type Structure struct {
 
 	// Length is the length of the data object in bytes.
 	// must always match & be present
+	// derived
 	Length int `json:"length,omitempty"`
 	// location of this structure, transient
+	// derived
 	Path string `json:"path,omitempty"`
 	// Qri should always be KindStructure
+	// derived
 	Qri string `json:"qri"`
 	// Schema contains the schema definition for the underlying data, schemas
 	// are defined using the IETF json-schema specification. for more info
@@ -78,6 +86,17 @@ func NewStructureRef(path string) *Structure {
 // dataset is rendered immutable, usually by storing it in a cafs
 func (s *Structure) DropTransientValues() {
 	s.Path = ""
+}
+
+// DropDerivedValues resets all derived fields to their default values
+func (s *Structure) DropDerivedValues() {
+	s.Checksum = ""
+	s.Depth = 0
+	s.ErrCount = 0
+	s.Entries = 0
+	s.Length = 0
+	s.Path = ""
+	s.Qri = ""
 }
 
 // JSONSchema parses the Schema field into a json-schema

--- a/structure_test.go
+++ b/structure_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/qri-io/dataset/compression"
 )
 
@@ -42,6 +43,24 @@ func TestAbstractColumnName(t *testing.T) {
 	}
 	if AbstractColumnName(30000) != "ariw" {
 		t.Errorf("expected 300 == ariw, got: %s", AbstractColumnName(30000))
+	}
+}
+
+func TestStructureDropDerivedValues(t *testing.T) {
+	st := &Structure{
+		Checksum: "checksum",
+		Depth:    120,
+		ErrCount: 4,
+		Entries:  1234567890,
+		Length:   90210,
+		Path:     "/ipfs/QmHash",
+		Qri:      "oh you know it's qri",
+	}
+
+	st.DropDerivedValues()
+
+	if !cmp.Equal(st, &Structure{}) {
+		t.Errorf("expected dropping a structure of only derived values to be empty")
 	}
 }
 

--- a/transform.go
+++ b/transform.go
@@ -49,6 +49,12 @@ func (q *Transform) DropTransientValues() {
 	q.ScriptBytes = nil
 }
 
+// DropDerivedValues resets all set-on-save fields to their default values
+func (q *Transform) DropDerivedValues() {
+	q.Qri = ""
+	q.Path = ""
+}
+
 // OpenScriptFile generates a byte stream of script data prioritizing creating an
 // in-place file from ScriptBytes when defined, fetching from the
 // passed-in resolver otherwise

--- a/transform_test.go
+++ b/transform_test.go
@@ -4,10 +4,26 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestTransformDropTransientValues(t *testing.T) {
 	t.Log("TODO (b5)")
+}
+
+func TestTransformDropDerivedValues(t *testing.T) {
+	tf := &Transform{
+		Path: "/ipfs/QmHash",
+		Qri:  "oh you know it's qri",
+	}
+
+	tf.DropDerivedValues()
+
+	if !cmp.Equal(tf, &Transform{}, cmpopts.IgnoreUnexported(Transform{})) {
+		t.Errorf("expected dropping a struct only derived values to be empty")
+	}
 }
 
 func TestTransformScript(t *testing.T) {

--- a/viz.go
+++ b/viz.go
@@ -13,9 +13,11 @@ type Viz struct {
 	// Format designates the visualization configuration syntax. currently the
 	// only supported syntax is "html"
 	Format string `json:"format,omitempty"`
-	// path is the location of a viz, transient
+	// Path is the location of a viz, transient
+	// derived
 	Path string `json:"path,omitempty"`
 	// Qri should always be "vc:0"
+	// derived
 	Qri string `json:"qri,omitempty"`
 
 	// script file reader, doesn't serialize
@@ -40,6 +42,12 @@ func NewVizRef(path string) *Viz {
 func (v *Viz) DropTransientValues() {
 	v.Path = ""
 	v.ScriptBytes = nil
+}
+
+// DropDerivedValues resets all set-on-save fields to their default values
+func (v *Viz) DropDerivedValues() {
+	v.Qri = ""
+	v.Path = ""
 }
 
 // OpenScriptFile generates a byte stream of script data prioritizing creating an

--- a/viz_test.go
+++ b/viz_test.go
@@ -5,10 +5,26 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestVizDropTransientValues(t *testing.T) {
 	t.Log("TODO (b5)")
+}
+
+func TestVizDropDerivedValues(t *testing.T) {
+	vz := &Viz{
+		Path: "/ipfs/QmHash",
+		Qri:  "oh you know it's qri",
+	}
+
+	vz.DropDerivedValues()
+
+	if !cmp.Equal(vz, &Viz{}, cmpopts.IgnoreUnexported(Viz{})) {
+		t.Errorf("expected dropping a viz of only derived values to be empt")
+	}
 }
 
 func TestVizScript(t *testing.T) {


### PR DESCRIPTION
we've defined a _derived_ value to be any field that is set by qri at runtime. Dropping derived values is an important step for comparing a saved dataset to an input dataset.