### PR TITLE
fix(dsio): don't fail on escaped forward slashes

### DIFF
--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -13,6 +13,16 @@ import (
 )
 
 func TestJSONReader(t *testing.T) {
+	arrSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaArray,
+	}
+
+	objSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaObject,
+	}
+
 	cases := []struct {
 		name      string
 		structure *dataset.Structure
@@ -21,38 +31,14 @@ func TestJSONReader(t *testing.T) {
 	}{
 		{"city", &dataset.Structure{}, 0, "schema required for JSON reader"},
 		{"city", &dataset.Structure{Schema: map[string]interface{}{"type": "number"}}, 0, "invalid schema. root must be either an array or object type"},
-		{"city", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 6, ""},
-		{"sitemap_object", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 7, ""},
-		{"links_object", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 20, ""},
-		{"links_array", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 20, ""},
-		{"array", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 10, ""},
-		{"object", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 10, ""},
-		{"craigslist", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 1200, ""},
-		{"sitemap", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, ""},
+		{"city", arrSt, 6, ""},
+		{"sitemap_object", objSt, 7, ""},
+		{"links_object", objSt, 20, ""},
+		{"links_array", arrSt, 20, ""},
+		{"array", arrSt, 10, ""},
+		{"object", objSt, 10, ""},
+		{"craigslist", arrSt, 1200, ""},
+		{"sitemap", objSt, 1, ""},
 	}
 
 	for i, c := range cases {
@@ -195,35 +181,22 @@ func TestJSONReaderSmallerBufferForHugeToken(t *testing.T) {
 }
 
 func TestJSONSizeReader(t *testing.T) {
+	arrSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaArray,
+	}
+
 	cases := []struct {
 		structure *dataset.Structure
 		size      int
 		data      string
 	}{
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 16, `[["a","b","cdef"]]`},
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 16, `[[12345,67890,12345,67890]]`},
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 18, `[{"a":"b","c":"d","e":"f"}]`},
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 16, `[[  "a"  ,  "b"  ,  "c"  ,  "d"  ]]`},
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 16, `[[false, false, false , false]]`},
-		{&dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 16, `[[true, true, true, true]]`},
+		{arrSt, 16, `[["a","b","cdef"]]`},
+		{arrSt, 16, `[[12345,67890,12345,67890]]`},
+		{arrSt, 18, `[{"a":"b","c":"d","e":"f"}]`},
+		{arrSt, 16, `[[  "a"  ,  "b"  ,  "c"  ,  "d"  ]]`},
+		{arrSt, 16, `[[false, false, false , false]]`},
+		{arrSt, 16, `[[true, true, true, true]]`},
 	}
 
 	for i, c := range cases {
@@ -249,76 +222,38 @@ func TestJSONSizeReader(t *testing.T) {
 }
 
 func TestJSONReaderErrors(t *testing.T) {
+	objSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaObject,
+	}
+
+	arrSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaArray,
+	}
+
 	cases := []struct {
 		text      string
 		structure *dataset.Structure
 		count     int
 		err       string
 	}{
-		{"{\"a\":1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, ""},
-		{"{\"a\"\"b\":1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 0, "Expected: ':' to separate key and value"},
-		{"{:\"a\"1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 0, "Expected: string"},
-		{"{\"abc:def\"1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 0, "Expected: ':' to separate key and value"},
-		{"{\"a\"\x01:\x02\"b\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 0, "Expected: ':' to separate key and value"},
-		{"{\"abc\",1,,,,,\"def\",2,,\"ghi\",3,,,\"jkl\"4:}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 0, "Expected: ':' to separate key and value"},
-		{"{\"abc\":{\"inner\":1}}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, ""},
-		{"{\"abc\":[1,2,3]}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, ""},
-		{"{\"abc\":{\"inner\":[1,2,3]}}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, ""},
-		{"{\"abc\":1,", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, "Expected: string"},
-		{"{\"abc\":1", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1, "Expected: separator ','"},
-		{"[\"abc\",1]", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 2, ""},
-		{"[]", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 0, ""},
-		{"[{}]", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 1, ""},
-		{"[\"abc\",1", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 2, "Expected: separator ','"},
-		{"[\"abc\",1,", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaArray,
-		}, 3, "Expected: separator ','"},
+		{`{"a":1}`, objSt, 1, ""},
+		{`{"a""b":1}`, objSt, 0, "Expected: ':' to separate key and value"},
+		{`{:"a"1}`, objSt, 0, "Expected: string"},
+		{`{"abc:def"1}`, objSt, 0, "Expected: ':' to separate key and value"},
+		{"{\"a\"\x01:\x02\"b\"}", objSt, 0, "Expected: ':' to separate key and value"},
+		{`{"abc",1,,,,,"def",2,,"ghi",3,,,"jkl"4:}`, objSt, 0, "Expected: ':' to separate key and value"},
+		{`{"abc":{"inner":1}}`, objSt, 1, ""},
+		{`{"abc":[1,2,3]}`, objSt, 1, ""},
+		{`{"abc":{"inner":[1,2,3]}}`, objSt, 1, ""},
+		{`{"abc":1,`, objSt, 1, "Expected: string"},
+		{`{"abc":1`, objSt, 1, "Expected: separator ','"},
+		{`["abc",1]`, arrSt, 2, ""},
+		{`[]`, arrSt, 0, ""},
+		{`[{}]`, arrSt, 1, ""},
+		{`["abc",1`, arrSt, 2, "Expected: separator ','"},
+		{`["abc",1,`, arrSt, 3, "Expected: separator ','"},
 	}
 
 	for i, c := range cases {

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -100,59 +100,29 @@ func TestJSONReader(t *testing.T) {
 }
 
 func TestJSONReaderBasicParsing(t *testing.T) {
+	objSt := &dataset.Structure{
+		Format: "json",
+		Schema: dataset.BaseSchemaObject,
+	}
+
 	cases := []struct {
 		text      string
 		structure *dataset.Structure
 		expect    interface{}
 	}{
-		{"{\"a\":1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1},
-		{"{\"a\": 1}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 1},
-		{"{\"a\":\"abc\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, "abc"},
-		{"{\"a\":4.56}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, 4.56},
-		{"{\"a\":\"\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, ""},
-		{"{\"a\":null}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, nil},
-		{"{\"a\":true}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, true},
-		{"{\"a\":false}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, false},
-		{"{\"a\":\"\xe7\x8a\xac\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, "\xe7\x8a\xac"},
-		{"{\"a\":\"say \\\"dog\\\"\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, "say \"dog\""},
-		{"{\"a\":\"say \\\"\\u72ac\\\"\"}", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, "say \"\xe7\x8a\xac\""},
-		{"{\n  \"a\" : \"b\" }", &dataset.Structure{
-			Format: "json",
-			Schema: dataset.BaseSchemaObject,
-		}, "b"},
+		{`{"a":1}`, objSt, 1},
+		{`{"a": 1}`, objSt, 1},
+		{`{"a":"abc"}`, objSt, "abc"},
+		{`{"a":4.56}`, objSt, 4.56},
+		{`{"a":""}`, objSt, ""},
+		{`{"a":null}`, objSt, nil},
+		{`{"a":true}`, objSt, true},
+		{`{"a":false}`, objSt, false},
+		{"{\"a\":\"\xe7\x8a\xac\"}", objSt, "\xe7\x8a\xac"},
+		{"{\"a\":\"say \\\"dog\\\"\"}", objSt, "say \"dog\""},
+		{"{\"a\":\"say \\\"\\u72ac\\\"\"}", objSt, "say \"\xe7\x8a\xac\""},
+		{"{\n  \"a\" : \"b\" }", objSt, "b"},
+		{`{"a": "\/"}`, objSt, "/"},
 	}
 
 	for i, c := range cases {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,16 @@ module github.com/qri-io/dataset
 
 go 1.12
 
+// override with corret timestamps for circleci: https://github.com/qri-io/qri/pull/865/files
+replace github.com/go-critic/go-critic v0.0.0-20181204210945-c3db6069acc5 => github.com/go-critic/go-critic v0.0.0-20190422201921-c3db6069acc5
+replace github.com/go-critic/go-critic v0.0.0-20181204210945-ee9bf5809ead => github.com/go-critic/go-critic v0.0.0-20190210220443-ee9bf5809ead
+replace github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
+replace github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196 => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
+replace github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
+replace github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547 => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
+replace github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
+replace mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34 => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
+
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
ran into this issue from funky output of a QGIS conversion. Turns out escaping forward slashes are _allowed_, but not required in JSON.

I've made a note in code on how this solution can be improved, but I think this'll work just fine for a long while