### PR TITLE
feat: tabular package specifically for working with tabular data structure

### DIFF
--- a/dsio/dsio.go
+++ b/dsio/dsio.go
@@ -55,7 +55,7 @@ func NewEntryReader(st *dataset.Structure, r io.Reader) (EntryReader, error) {
 	case dataset.JSONDataFormat:
 		return NewJSONReader(st, r)
 	case dataset.CSVDataFormat:
-		return NewCSVReader(st, r), nil
+		return NewCSVReader(st, r)
 	case dataset.XLSXDataFormat:
 		return NewXLSXReader(st, r)
 	case dataset.UnknownDataFormat:
@@ -77,7 +77,7 @@ func NewEntryWriter(st *dataset.Structure, w io.Writer) (EntryWriter, error) {
 	case dataset.JSONDataFormat:
 		return NewJSONWriter(st, w)
 	case dataset.CSVDataFormat:
-		return NewCSVWriter(st, w), nil
+		return NewCSVWriter(st, w)
 	case dataset.XLSXDataFormat:
 		return NewXLSXWriter(st, w)
 	case dataset.UnknownDataFormat:

--- a/dsio/dsio_test.go
+++ b/dsio/dsio_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/qri-io/dataset"
 )
 
+var basicTableSchema = map[string]interface{}{
+	"type": "array",
+	"items": map[string]interface{}{
+		"type": "array",
+		"items": []interface{}{
+			map[string]interface{}{"title": "column_one", "type": "string"},
+		},
+	},
+}
+
 func TestNewEntryReader(t *testing.T) {
 	cases := []struct {
 		st  *dataset.Structure
@@ -15,7 +25,8 @@ func TestNewEntryReader(t *testing.T) {
 		{&dataset.Structure{}, "structure must have a data format"},
 		{&dataset.Structure{Format: "cbor", Schema: dataset.BaseSchemaArray}, ""},
 		{&dataset.Structure{Format: "json", Schema: dataset.BaseSchemaArray}, ""},
-		{&dataset.Structure{Format: "csv", Schema: dataset.BaseSchemaArray}, ""},
+		{&dataset.Structure{Format: "csv", Schema: basicTableSchema}, ""},
+		// {&dataset.Structure{Format: "xlsx", Schema: basicTableSchema}, ""},
 	}
 
 	for i, c := range cases {
@@ -35,7 +46,8 @@ func TestNewEntryWriter(t *testing.T) {
 		{&dataset.Structure{}, "structure must have a data format"},
 		{&dataset.Structure{Format: "cbor", Schema: dataset.BaseSchemaArray}, ""},
 		{&dataset.Structure{Format: "json", Schema: dataset.BaseSchemaArray}, ""},
-		{&dataset.Structure{Format: "csv", Schema: dataset.BaseSchemaArray}, ""},
+		{&dataset.Structure{Format: "csv", Schema: basicTableSchema}, ""},
+		// {&dataset.Structure{Format: "xlsx", Schema: basicTableSchema}, ""},
 	}
 
 	for i, c := range cases {

--- a/dsio/xlsx.go
+++ b/dsio/xlsx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/360EntSecGroup-Skylar/excelize"
 	"github.com/qri-io/dataset"
+	"github.com/qri-io/dataset/tabular"
 	"github.com/qri-io/dataset/vals"
 )
 
@@ -24,8 +25,15 @@ type XLSXReader struct {
 
 // NewXLSXReader creates a reader from a structure and read source
 func NewXLSXReader(st *dataset.Structure, r io.Reader) (*XLSXReader, error) {
-	// TODO - handle error
-	_, types, _ := terribleHackToGetHeaderRowAndTypes(st)
+	cols, _, err := tabular.ColumnsFromJSONSchema(st.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	types := make([]string, len(cols))
+	for i, c := range cols {
+		types[i] = []string(*c.Type)[0]
+	}
 
 	rdr := &XLSXReader{
 		st:    st,
@@ -144,8 +152,15 @@ type XLSXWriter struct {
 
 // NewXLSXWriter creates a Writer from a structure and write destination
 func NewXLSXWriter(st *dataset.Structure, w io.Writer) (*XLSXWriter, error) {
-	// TODO - capture error
-	_, types, _ := terribleHackToGetHeaderRowAndTypes(st)
+	cols, _, err := tabular.ColumnsFromJSONSchema(st.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	types := make([]string, len(cols))
+	for i, c := range cols {
+		types[i] = []string(*c.Type)[0]
+	}
 
 	wr := &XLSXWriter{
 		st:    st,

--- a/tabular/tabular.go
+++ b/tabular/tabular.go
@@ -1,0 +1,197 @@
+// Package tabular defines functions for working with rectangular datasets.
+// qri positions tabular data as a special shape that comes with additional
+// constraints. This package defines the methods necessary to enforce and
+// interpret those conststraints
+package tabular
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrInvalidTabularSchema is a base type for schemas that don't work as tables
+// all parsing errors in this package can be errors.Is() to this one
+var ErrInvalidTabularSchema = errors.New("invalid tabular schema")
+
+// Columns is an ordered list of column information
+type Columns []Column
+
+// Titles gives just column titles as a slice of strings
+func (cols Columns) Titles() []string {
+	titles := make([]string, len(cols))
+	for i, col := range cols {
+		titles[i] = col.Title
+	}
+	return titles
+}
+
+// ValidMachineTitles confirms column titles are valid for machine-readability
+// using column titles that parse as proper variable names, and unique titles
+// across the column set
+func (cols Columns) ValidMachineTitles() error {
+	re := regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z_$0-9]*$`)
+
+	var problems []string
+	set := map[string]struct{}{}
+
+	for i, col := range cols {
+		t := col.Title
+		if !re.MatchString(t) {
+			problems = append(problems, fmt.Sprintf("col. %d name '%s' is not a valid column name", i, t))
+		}
+		if _, present := set[t]; present {
+			problems = append(problems, fmt.Sprintf("col. %d name '%s' is not unique", i, t))
+		}
+		set[t] = struct{}{}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("%w: column names have problems:\n%s", ErrInvalidTabularSchema, strings.Join(problems, "\n"))
+	}
+	return nil
+}
+
+// Column defines values associated with an index of each row of data
+type Column struct {
+	Title       string                 `json:"title"`
+	Type        *ColType               `json:"type"`
+	Description string                 `json:"description,omitempty"`
+	Validation  map[string]interface{} `json:"validation,omitempty"`
+}
+
+// ColType implements type information for a tablular column. Column Types can
+// be one or more strings enumerating accepted types
+type ColType []string
+
+// MarshalJSON encodes to string in the common case of a single type, an array
+// of strings for a type enumeration
+func (ct ColType) MarshalJSON() ([]byte, error) {
+	switch len(ct) {
+	case 0:
+		return nil, nil
+	case 1:
+		return json.Marshal(ct[0])
+	default:
+		return json.Marshal([]string(ct))
+	}
+}
+
+// UnmarshalJSON decodes string and string array data types
+func (ct *ColType) UnmarshalJSON(p []byte) error {
+	var str string
+	if err := json.Unmarshal(p, &str); err == nil {
+		*ct = ColType{str}
+		return nil
+	}
+
+	var strs []string
+	if err := json.Unmarshal(p, &strs); err == nil {
+		*ct = ColType(strs)
+		return nil
+	}
+
+	return fmt.Errorf("invalid data for ColType")
+}
+
+// ColumnsFromJSONSchema extrats column data from a jsonSchema object, erroring
+// if the provided schema cannot be used to describe a table. a slice of problem
+// strings describes non-breaking issues with the schema that should be
+// addressed like missing column titles or column types
+// the passed in schema must be a decoding of a json schema into default type
+// mappings from the encoding/json package
+func ColumnsFromJSONSchema(sch map[string]interface{}) (Columns, []string, error) {
+	topLevelType, ok := sch["type"].(string)
+	if !ok {
+		msg := "top-level 'type' field is required"
+		return nil, nil, fmt.Errorf("%w: %s", ErrInvalidTabularSchema, msg)
+	}
+
+	switch topLevelType {
+	case "array":
+		return arrayWrapperColumns(sch)
+	case "object":
+		return objectWrapperColumns(sch)
+	default:
+		msg := fmt.Sprintf("'%s' is not a valid type to describe the top level of a tablular schema", topLevelType)
+		return nil, nil, fmt.Errorf("%w: %s", ErrInvalidTabularSchema, msg)
+	}
+}
+
+func arrayWrapperColumns(sch map[string]interface{}) (Columns, []string, error) {
+	var problems []string
+
+	itemObj, ok := sch["items"].(map[string]interface{})
+	if !ok {
+		msg := "top level 'items' property must be an object"
+		return nil, nil, fmt.Errorf("%w: %s", ErrInvalidTabularSchema, msg)
+	}
+
+	itemArr, ok := itemObj["items"].([]interface{})
+	if !ok {
+		msg := "items.items must be an array"
+		return nil, nil, fmt.Errorf("%w: %s", ErrInvalidTabularSchema, msg)
+	}
+
+	cols := make([]Column, len(itemArr))
+	for i, f := range itemArr {
+		// set defaults that
+		cols[i].Title = fmt.Sprintf("col_%d", i)
+		cols[i].Type = &ColType{"string"}
+
+		colSchema, ok := f.(map[string]interface{})
+		if !ok {
+			problems = append(problems, fmt.Sprintf("col. %d schema should be an object", i))
+			continue
+		}
+
+		setTitle, setType := false, false
+		for key, val := range colSchema {
+			switch key {
+			case "title":
+				if title, ok := val.(string); ok {
+					setTitle = true
+					cols[i].Title = title
+				}
+			case "type":
+				setType = true
+				switch x := val.(type) {
+				case string:
+					cols[i].Type = &ColType{x}
+				case []interface{}:
+					types := ColType{}
+					for _, v := range x {
+						if t, ok := v.(string); ok {
+							types = append(types, t)
+						}
+					}
+					cols[i].Type = &types
+				}
+			case "description":
+				if d, ok := val.(string); ok {
+					cols[i].Description = d
+				}
+			default:
+				if cols[i].Validation == nil {
+					cols[i].Validation = map[string]interface{}{}
+				}
+				cols[i].Validation[key] = val
+			}
+		}
+
+		if !setTitle {
+			problems = append(problems, fmt.Sprintf("col. %d title is not set", i))
+		}
+		if !setType {
+			problems = append(problems, fmt.Sprintf("col, %d type is not set, defaulting to string", i))
+		}
+	}
+
+	return cols, problems, nil
+}
+
+func objectWrapperColumns(sch map[string]interface{}) (Columns, []string, error) {
+	return nil, nil, fmt.Errorf("unfinished")
+}

--- a/tabular/tabular.go
+++ b/tabular/tabular.go
@@ -1,7 +1,7 @@
 // Package tabular defines functions for working with rectangular datasets.
 // qri positions tabular data as a special shape that comes with additional
 // constraints. This package defines the methods necessary to enforce and
-// interpret those conststraints
+// interpret those constraints
 package tabular
 
 import (
@@ -28,18 +28,19 @@ func (cols Columns) Titles() []string {
 	return titles
 }
 
+var validMachineTitle = regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z_$0-9]*$`)
+
 // ValidMachineTitles confirms column titles are valid for machine-readability
 // using column titles that parse as proper variable names, and unique titles
 // across the column set
 func (cols Columns) ValidMachineTitles() error {
-	re := regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z_$0-9]*$`)
 
 	var problems []string
 	set := map[string]struct{}{}
 
 	for i, col := range cols {
 		t := col.Title
-		if !re.MatchString(t) {
+		if !validMachineTitle.MatchString(t) {
 			problems = append(problems, fmt.Sprintf("col. %d name '%s' is not a valid column name", i, t))
 		}
 		if _, present := set[t]; present {
@@ -62,7 +63,7 @@ type Column struct {
 	Validation  map[string]interface{} `json:"validation,omitempty"`
 }
 
-// ColType implements type information for a tablular column. Column Types can
+// ColType implements type information for a tabular column. Column Types can
 // be one or more strings enumerating accepted types
 type ColType []string
 
@@ -96,7 +97,7 @@ func (ct *ColType) UnmarshalJSON(p []byte) error {
 	return fmt.Errorf("invalid data for ColType")
 }
 
-// ColumnsFromJSONSchema extrats column data from a jsonSchema object, erroring
+// ColumnsFromJSONSchema extracts column data from a jsonSchema object, erroring
 // if the provided schema cannot be used to describe a table. a slice of problem
 // strings describes non-breaking issues with the schema that should be
 // addressed like missing column titles or column types
@@ -137,7 +138,6 @@ func arrayWrapperColumns(sch map[string]interface{}) (Columns, []string, error) 
 
 	cols := make([]Column, len(itemArr))
 	for i, f := range itemArr {
-		// set defaults that
 		cols[i].Title = fmt.Sprintf("col_%d", i)
 		cols[i].Type = &ColType{"string"}
 

--- a/tabular/tabular_test.go
+++ b/tabular/tabular_test.go
@@ -81,6 +81,7 @@ func TestColumnsFromJSONSchema(t *testing.T) {
 		{`{ "type": "string" }`, "invalid tabular schema: 'string' is not a valid type to describe the top level of a tablular schema"},
 		{`{ "type": "array" }`, "invalid tabular schema: top level 'items' property must be an object"},
 		{`{ "type": "array", "items": { "type" : "string" }}`, "invalid tabular schema: items.items must be an array"},
+		{`{ "type": "array", "items": { "type" : "array", "items": { "type": "array"}}}`, "invalid tabular schema: items.items must be an array"},
 	}
 	for _, c := range bad {
 		t.Run(fmt.Sprintf("bad_case_%s", c.err), func(t *testing.T) {
@@ -148,7 +149,7 @@ func TestColumnsJSON(t *testing.T) {
 	if err != nil {
 		t.Errorf("marshal error: %s", err)
 	}
-	
+
 	if diff := cmp.Diff(val, string(data)); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}

--- a/tabular/tabular_test.go
+++ b/tabular/tabular_test.go
@@ -1,0 +1,218 @@
+package tabular
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestColumnsFromJSONSchema(t *testing.T) {
+	good := []struct {
+		description string
+		input       string
+		expect      Columns
+	}{
+		{"one column array wrapper", `{
+			"type" : "array",
+			"items": {
+				"type": "array",
+				"items": [
+					{ "title" : "column_1", "type": "string", "description":"the first column" }
+				]
+			}
+		}`, Columns{
+			{Title: "column_1", Description: "the first column", Type: &ColType{"string"}},
+		}},
+		{"one column array wrapper with validation", `{
+			"type" : "array",
+			"items": {
+				"type": "array",
+				"items": [
+					{ "title" : "rating", "type": ["number", "null"], "description":"0-5 rating", "max": 5, "min": 0 }
+				]
+			}
+		}`, Columns{
+			{Title: "rating", Description: "0-5 rating", Type: &ColType{"number", "null"}, Validation: map[string]interface{}{"max": float64(5), "min": float64(0)}},
+		}},
+		// {"one column object wrapper", `{
+		// 	"type": "object",
+		// 	"properties": {
+		// 		"column_1": {
+		// 			"type": "array",
+		// 			"title": "column_1",
+		// 			"description": "the first column",
+		// 			"items": { "type": "string" }
+		// 		}
+		// 	}
+		// }`, []Column{
+		// 	{Title: "column_1", Description: "the first column", Type: "string"},
+		// }},
+	}
+
+	for _, c := range good {
+		t.Run(c.description, func(t *testing.T) {
+			input := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(c.input), &input); err != nil {
+				t.Fatal(err)
+			}
+
+			got, problems, err := ColumnsFromJSONSchema(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(problems) != 0 {
+				t.Errorf("unexpected problems: %s", problems)
+			}
+
+			if diff := cmp.Diff(c.expect, got); diff != "" {
+				t.Errorf("result mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	bad := []struct {
+		input string
+		err   string
+	}{
+		{`{}`, "invalid tabular schema: top-level 'type' field is required"},
+		{`{ "type": "string" }`, "invalid tabular schema: 'string' is not a valid type to describe the top level of a tablular schema"},
+		{`{ "type": "array" }`, "invalid tabular schema: top level 'items' property must be an object"},
+		{`{ "type": "array", "items": { "type" : "string" }}`, "invalid tabular schema: items.items must be an array"},
+	}
+	for _, c := range bad {
+		t.Run(fmt.Sprintf("bad_case_%s", c.err), func(t *testing.T) {
+			input := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(c.input), &input); err != nil {
+				t.Fatal(err)
+			}
+
+			_, _, err := ColumnsFromJSONSchema(input)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if diff := cmp.Diff(c.err, err.Error()); diff != "" {
+				t.Errorf("result mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	problems := []struct {
+		description string
+		input       string
+		problems    []string
+	}{
+		{"false column",
+			`{ "type": "array", "items": { "type" : "string", "items": [false] }}`,
+			[]string{"col. 0 schema should be an object"},
+		},
+		{"missing title",
+			`{ "type": "array", "items": { "type" : "string", "items": [{"type": "string"}] }}`,
+			[]string{"col. 0 title is not set"},
+		},
+		{"missing type",
+			`{ "type": "array", "items": { "type" : "string", "items": [{"title": "a_column"}] }}`,
+			[]string{"col, 0 type is not set, defaulting to string"},
+		},
+	}
+	for _, c := range problems {
+		t.Run(fmt.Sprintf("problem_%s", c.description), func(t *testing.T) {
+			input := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(c.input), &input); err != nil {
+				t.Fatal(err)
+			}
+
+			_, problems, err := ColumnsFromJSONSchema(input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(c.problems, problems); diff != "" {
+				t.Errorf("result mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestColumnsJSON(t *testing.T) {
+	val := `[{"title":"foo","type":["string","number"]},{"title":"bar","type":"string"}]`
+	cols := &Columns{}
+	if err := json.Unmarshal([]byte(val), cols); err != nil {
+		t.Errorf("unmarshal error: %s", err)
+	}
+
+	data, err := json.Marshal(cols)
+	if err != nil {
+		t.Errorf("marshal error: %s", err)
+	}
+	
+	if diff := cmp.Diff(val, string(data)); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestColumnsTitles(t *testing.T) {
+	cols := Columns{
+		Column{Title: "foo"},
+		Column{Title: ""},
+		Column{Title: "🔥"},
+	}
+
+	got := cols.Titles()
+	expect := []string{"foo", "", "🔥"}
+	if diff := cmp.Diff(expect, got); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidMachineTitles(t *testing.T) {
+	good := []struct {
+		description string
+		cols        Columns
+	}{
+		{"single title",
+			Columns{
+				Column{Title: "foo"},
+			},
+		},
+	}
+	for _, c := range good {
+		t.Run(c.description, func(t *testing.T) {
+			if err := c.cols.ValidMachineTitles(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
+	bad := []struct {
+		err  string
+		cols Columns
+	}{
+		{"invalid tabular schema: column names have problems:\ncol. 0 name '???' is not a valid column name",
+			Columns{
+				Column{Title: "???"},
+			},
+		},
+		{"invalid tabular schema: column names have problems:\ncol. 1 name 'a' is not unique",
+			Columns{
+				Column{Title: "a"},
+				Column{Title: "a"},
+			},
+		},
+	}
+
+	for _, c := range bad {
+		t.Run(c.err, func(t *testing.T) {
+			err := c.cols.ValidMachineTitles()
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+			if diff := cmp.Diff(c.err, err.Error()); diff != "" {
+				t.Errorf("error mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This one's been a long time coming. we use JSON Schema to describe the structure of a dataset body, which gives us lots of flexibility for defining shemas. For tabular data formats this if often _too_ much flexibility. Qri does as much work as possible to get schemas into a tabular shape by default, but we don't have much in the way of feedback when tabular structures get messed up or corrupted, or when we'd like to use flexible formats like JSON in a tabular context.

So, let's define a package `tabular` specifically for working with tabular data. I can see this package growing over time to include things more than just structure validation.