### PR TITLE
feat: detect tabular schema from go types

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -67,3 +67,58 @@ func ExtensionDataFormat(path string) (format dataset.DataFormat, err error) {
 		return dataset.UnknownDataFormat, fmt.Errorf("unsupported file type: '%s'", ext)
 	}
 }
+
+// ErrInvalidTabularData indicates non-tabular data in a context that expects
+// tabular input
+var ErrInvalidTabularData = errors.New("invalid tabular data")
+
+// TabularSchemaFromTabularData infers a basic tabular JSON schema from go types
+// it only works in the narrow case where the source data is known to be tabular
+// but lacks a schema to describe it
+// given the lack of metadata, these schema should be used primarily for
+// machine purposes
+func TabularSchemaFromTabularData(source interface{}) (map[string]interface{}, error) {
+	schema := map[string]interface{}{}
+	switch data := source.(type) {
+	case []interface{}:
+		schema["type"] = "array"
+		items := map[string]interface{}{}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("%w: missing row data", ErrInvalidTabularData)
+		}
+
+		switch ent := data[0].(type) {
+		case []interface{}:
+			items["type"] = "array"
+			cols := make([]interface{}, len(ent))
+			for i, v := range ent {
+				cols[i] = map[string]interface{}{
+					"title": fmt.Sprintf("col_%d", i),
+					"type":  goDataType(v),
+				}
+			}
+			items["items"] = cols
+		default:
+			return nil, fmt.Errorf("%w: array schemas must use an inner array for rows", ErrInvalidTabularData)
+		}
+		schema["items"] = items
+	case map[string]interface{}:
+		return nil, fmt.Errorf("%w: cannot interpret object-based tabular schemas", ErrInvalidTabularData)
+	}
+
+	return schema, nil
+}
+
+func goDataType(v interface{}) string {
+	switch v.(type) {
+	case int64, int, uint, float64:
+		return "number"
+	case bool:
+		return "boolean"
+	case nil:
+		return "null"
+	default:
+		// assume a string type
+		return "string"
+	}
+}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -111,7 +111,7 @@ func TabularSchemaFromTabularData(source interface{}) (map[string]interface{}, e
 
 func goDataType(v interface{}) string {
 	switch v.(type) {
-	case int64, int, uint, float64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
 		return "number"
 	case bool:
 		return "boolean"

--- a/structure.go
+++ b/structure.go
@@ -124,6 +124,12 @@ func (s *Structure) DataFormat() DataFormat {
 	return df
 }
 
+// RequiresTabularSchema returns true if the structure's specified data format
+// requires a JSON schema that describes a rectangular data shape
+func (s *Structure) RequiresTabularSchema() bool {
+	return s.Format == CSVDataFormat.String() || s.Format == XLSXDataFormat.String()
+}
+
 // Abstract returns this structure instance in it's "Abstract" form
 // stripping all nonessential values &
 // renaming all schema field names to standard variable names

--- a/structure_test.go
+++ b/structure_test.go
@@ -73,6 +73,22 @@ func TestStructureDataFormat(t *testing.T) {
 	t.Skip("TODO (b5)")
 }
 
+func TestStructureRequiresTabularSchema(t *testing.T) {
+	tabularFormats := map[string]struct{}{
+		CSVDataFormat.String():  struct{}{},
+		XLSXDataFormat.String(): struct{}{},
+	}
+
+	for _, f := range SupportedDataFormats() {
+		st := &Structure{Format: f.String()}
+		_, required := tabularFormats[f.String()]
+		got := st.RequiresTabularSchema()
+		if got != required {
+			t.Errorf("format %s must return '%t', got '%t'", f, required, got)
+		}
+	}
+}
+
 func TestStructureAbstract(t *testing.T) {
 	cases := []struct {
 		in, out *Structure

--- a/tabular/tabular_test.go
+++ b/tabular/tabular_test.go
@@ -2,6 +2,7 @@ package tabular
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -94,7 +95,9 @@ func TestColumnsFromJSONSchema(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-
+			if !errors.Is(err, ErrInvalidTabularSchema) {
+				t.Errorf("err must be an instance of ErrInvalidTabularSchema")
+			}
 			if diff := cmp.Diff(c.err, err.Error()); diff != "" {
 				t.Errorf("result mismatch. (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
#222 uncovered a number of issues in the qri-io/qri codebase, including one case within `fsi.Init` where a CSV writer was relying on not having a tabular schema where one is needed.

fsi.Init is special, because the data being written to disk is coming from a pure go source, and we now need a schema to allocate a `dsio.CSVWriter`. This PR adds a function to infer a "machine only" schema for such a context, and a new method on dataset.Structure to help determine when this is needed.