### PR TITLE
feat(SigningBytes): new SigningBytes includes all components

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -177,6 +177,32 @@ func TestDatasetSignableBytes(t *testing.T) {
 	}
 }
 
+func TestSigningBytes(t *testing.T) {
+	ds := &Dataset{
+		Commit:    &Commit{Timestamp: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC)},
+		BodyPath:  "body",
+		Meta:      &Meta{Path: "meta"},
+		Readme:    &Readme{Path: "readme"},
+		Structure: &Structure{Path: "structure"},
+		Transform: &Transform{Path: "transform"},
+		Viz:       &Viz{Path: "viz"},
+	}
+
+	got := ds.SigningBytes()
+
+	expect := `bd:body
+cm:2001-01-01T01:01:01Z
+md:meta
+rm:readme
+st:structure
+tf:transform
+vz:viz`
+
+	if diff := cmp.Diff(expect, string(got)); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestDatasetMarshalJSON(t *testing.T) {
 	cases := []struct {
 		in  *Dataset

--- a/kind.go
+++ b/kind.go
@@ -11,17 +11,19 @@ const CurrentSpecVersion = "0"
 const (
 	// KindDataset is the current kind for datasets
 	KindDataset = Kind("ds:" + CurrentSpecVersion)
-	// KindMeta is the current kind for metadata
+	// KindBody is the current kind for body components
+	KindBody = Kind("bd:" + CurrentSpecVersion)
+	// KindMeta is the current kind for metadata components
 	KindMeta = Kind("md:" + CurrentSpecVersion)
-	// KindStructure is the current kind for dataset structures
+	// KindStructure is the current kind for structure components
 	KindStructure = Kind("st:" + CurrentSpecVersion)
-	// KindTransform is the current kind for dataset transforms
+	// KindTransform is the current kind for transform components
 	KindTransform = Kind("tf:" + CurrentSpecVersion)
-	// KindCommit is the current kind for dataset commit
+	// KindCommit is the current kind for commit components
 	KindCommit = Kind("cm:" + CurrentSpecVersion)
-	// KindViz is the current kind for dataset viz
+	// KindViz is the current kind for viz components
 	KindViz = Kind("vz:" + CurrentSpecVersion)
-	// KindReadme is the current kind for dataset readme
+	// KindReadme is the current kind for readme components
 	KindReadme = Kind("rm:" + CurrentSpecVersion)
 )
 
@@ -65,4 +67,11 @@ func (k *Kind) UnmarshalJSON(data []byte) error {
 	}
 	*k = Kind(_k)
 	return k.Valid()
+}
+
+// ComponentTypePrefix prefixes a string with a two letter component type
+// identifier & a colon. Example:
+// ComponentTypePrefix(KindDataset, "hello") == "ds:hello"
+func ComponentTypePrefix(k Kind, str string) string {
+	return fmt.Sprintf("%s:%s", k.Type(), str)
 }


### PR DESCRIPTION
The already-existing SignableBytes method produces a string that gets signed with each commit. In general form it's `commit.Timestamp` and `structure.Checksum` joined by a newline. The output of SignableBytes looks like
this:

```
2001-01-01T06:01:01Z
QmaqzQkPWZW9AY5BbkVqB4cup8tTs5w9tDyLwonpLWD7Dj
```

Two big problems with this approach:

* Calculating a checksum requires loading the contents of the entire byte slice
  into memery. It's neither practical nor feasible to calculate checksums of
  very large body files
* We're only signing a checksum for the _body_, making it possible to construct
  a version that alters data outside the body without invalidating the signature

Solve both problems by introducing a new method SigningBytes and mark `SignableBytes` as deprecated. `SigningBytes` returns a newline-delimited, alpha-sorted list of components within the dataset, where each component is identified by a two letter prefix and a colon ':' character followed by a value. In practice that looks like this:

```
bd:/ipfs/QmZhMjRvEhGtpPsob7mgQWUuj3CmRGoQ7tnc7W49GD4nEW
cm:2001-01-01T01:01:01Z
md:/ipfs/QmZo2NRJ4cVsGzeUpk2j2ZxsY6LWgpafn5ujesAsx9eyH
st:/ipfs/QmNRRfKnXcifBntmKbNG4sZegL2aNJaCmJKdnTzjBfQZ4s
tf:/ipfs/QmV9BWgxuBgpb8ZQQvaxpqu6G8ZSNMD82jy58jSkQG7pT1
vz:/ipfs/QmewyWbzbPp5SEDw885YNZ1hAhnbe3YLR6RcKVdEnK14NE
```

For most components the value is the path. When stored on IPFS path is hash-of-contents, making this a strong claim about the contents of the entire dataset. We'll calculate this value _very_ late in the saving process, after every other component has been written, but before `dataset.json` has been saved

Commit is special b/c the signature field is set within the commit component itself, so it's hash cannot be calculated at signing time. Besides, adding a timestamp anchors the statement in time.

Worth noting: the readme (rm) component is missing in this example for a real-world reason: we inline the readme component into the dataset document itself when saving, and so we don't calculate a path, which would result in this field being empty & _not being signed_. We can fix this by either dropping the inlining process, or calculating a path & not including the blocks within the persisted DAG.

Here's an example of the dataset document in question:
```
$ ipfs cat /ipfs/QmWHkqzzhiS9HH2fkG1nX7JQRQfpYQDMprWnuxELubcouP/dataset.json | jq
{
  "bodyPath": "/ipfs/QmZhMjRvEhGtpPsob7mgQWUuj3CmRGoQ7tnc7W49GD4nEW",
  "commit": "/ipfs/Qma9rKrHF4BfyTFTefhMpDK21BREHu8P5fpucNo3STJaFs",
  "meta": "/ipfs/QmZo2NRJ4cVsGzeUpk2j2ZxsY6LWgpafn5ujesAsx9eyH1",
  "peername": "b5",
  "readme": {
    "qri": "rm:0",
    "scriptPath": "/ipfs/QmUeXaY15cSMLY6zcrBuxWAPvXo3cQoF393sHtpy6sLgUS"
  },
  "qri": "ds:0",
  "structure": "/ipfs/QmNRRfKnXcifBntmKbNG4sZegL2aNJaCmJKdnTzjBfQZ4s",
  "transform": "/ipfs/QmV9BWgxuBgpb8ZQQvaxpqu6G8ZSNMD82jy58jSkQG7pT1",
  "viz": "/ipfs/QmewyWbzbPp5SEDw885YNZ1hAhnbe3YLR6RcKVdEnK14NE"
}
```