### PR TITLE
feat(FeildsEqual,PathMap): add utility methods for comparing datasets

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -115,6 +115,53 @@ func NewDatasetRef(path string) *Dataset {
 	return &Dataset{Path: path}
 }
 
+// PathMap converts all path references in a dataset into a map keyed by
+// component name. Keys are only present in the map if the component exists
+// on the dataset. Present components that do not have a path are represented
+// by the empty string
+// any components specified in ignore are omitted from the map
+func (ds *Dataset) PathMap(ignore ...string) map[string]string {
+	igMap := map[string]bool{}
+	for _, ignore := range ignore {
+		igMap[ignore] = true
+	}
+
+	componentPaths := map[string]string{}
+
+	if ds == nil {
+		return componentPaths
+	}
+
+	if ds.BodyPath != "" && !igMap["body"] {
+		componentPaths["body"] = ds.BodyPath
+	}
+	if ds.Commit != nil && !igMap["commit"] {
+		componentPaths["commit"] = ds.Commit.Path
+	}
+	if ds.Meta != nil && !igMap["meta"] {
+		componentPaths["meta"] = ds.Meta.Path
+	}
+	if ds.Path != "" && !igMap["dataset"] {
+		componentPaths["dataset"] = ds.Path
+	}
+	if ds.Readme != nil && !igMap["readme"] {
+		componentPaths["readme"] = ds.Readme.Path
+	}
+	if ds.Structure != nil && !igMap["structure"] {
+		componentPaths["structure"] = ds.Structure.Path
+	}
+	if ds.Transform != nil && !igMap["transform"] {
+		componentPaths["transform"] = ds.Transform.Path
+	}
+	if ds.Viz != nil && !igMap["viz"] {
+		componentPaths["viz"] = ds.Viz.Path
+	}
+	if ds.Stats != nil && !igMap["stats"] {
+		componentPaths["stats"] = ds.Stats.Path
+	}
+	return componentPaths
+}
+
 // SigningBytes produces a set of bytes for signing to establish authorship of a
 // dataset. The signing bytes is a newline-delimited, alpha-sorted list of
 // components within the dataset, where each component is identified by a two

--- a/readme.go
+++ b/readme.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -50,6 +51,25 @@ func (r *Readme) DropTransientValues() {
 func (r *Readme) DropDerivedValues() {
 	r.Qri = ""
 	r.Path = ""
+}
+
+// ShallowCompare is an equality check that ignores Path values
+// Intended for comparing components across different persistence states,
+// ShallowCompare returns true if all exported fields in the component have the
+// same value (with the exception of Path). ShallowCompare does not consider
+// scriptFile or renderedFile
+func (r *Readme) ShallowCompare(b *Readme) bool {
+	if r == nil && b == nil {
+		return true
+	} else if r == nil && b != nil || r != nil && b == nil {
+		return false
+	}
+
+	return r.Format == b.Format &&
+		r.Qri == b.Qri &&
+		r.ScriptPath == b.ScriptPath &&
+		r.RenderedPath == b.RenderedPath &&
+		bytes.Equal(r.ScriptBytes, b.ScriptBytes)
 }
 
 // InlineScriptFile opens the script file, reads its contents, and assigns it to scriptBytes.

--- a/readme_test.go
+++ b/readme_test.go
@@ -1,0 +1,292 @@
+package dataset
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func compareReadmes(a, b *Readme) string {
+	return cmp.Diff(a, b, cmpopts.IgnoreUnexported(Readme{}))
+}
+
+func TestReadmeDropTransientValues(t *testing.T) {
+	t.Log("TODO (b5)")
+}
+
+func TestReadmeDropDerivedValues(t *testing.T) {
+	rm := &Readme{
+		Path: "/ipfs/QmHash",
+		Qri:  "oh you know it's qri",
+	}
+
+	rm.DropDerivedValues()
+
+	if diff := compareReadmes(rm, &Readme{}); diff != "" {
+		t.Errorf("expected dropping a readme of only derived values to be empty. diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestReadmeScript(t *testing.T) {
+	t.Log("TODO (b5)")
+}
+
+func TestReadmeOpenScriptFile(t *testing.T) {
+	t.Log("TODO (b5)")
+}
+
+var readme1 = &Readme{
+	Format:       "foo",
+	Qri:          KindReadme.String(),
+	ScriptPath:   "one",
+	RenderedPath: "one",
+}
+
+var readme2 = &Readme{
+	Format:     "bar",
+	Qri:        KindReadme.String(),
+	ScriptPath: "two",
+}
+
+var readme3 = &Readme{
+	Format:     "bar",
+	Qri:        KindReadme.String(),
+	ScriptPath: "three",
+}
+
+func TestReadmeAssign(t *testing.T) {
+	cases := []struct {
+		got    *Readme
+		assign *Readme
+		expect *Readme
+	}{
+		{nil, nil, nil},
+		{&Readme{}, readme1, readme1},
+		{&Readme{
+			Format:     "bar",
+			Qri:        KindReadme.String(),
+			ScriptPath: "replace me",
+		},
+			readme2, readme2},
+		{&Readme{
+			Path:       "foo",
+			Format:     "foo",
+			Qri:        KindReadme.String(),
+			ScriptPath: "bat",
+		},
+			&Readme{Path: "bar", Format: "bar", RenderedPath: "rendered"},
+			&Readme{
+				Path:         "bar",
+				Format:       "bar",
+				Qri:          KindReadme.String(),
+				ScriptPath:   "bat",
+				RenderedPath: "rendered",
+			}},
+	}
+	for i, c := range cases {
+		c.got.Assign(c.assign)
+		if diff := compareReadmes(c.expect, c.got); diff != "" {
+			t.Errorf("case %d result mismatch. (-want +got):\n%s", i, diff)
+		}
+	}
+
+}
+
+func TestReadmeIsEmpty(t *testing.T) {
+	cases := []struct {
+		vc       *Readme
+		expected bool
+	}{
+		{&Readme{Qri: KindReadme.String()}, true},
+		{&Readme{ScriptPath: "foo"}, false},
+		{&Readme{RenderedPath: "foo"}, false},
+		{&Readme{}, true},
+		{&Readme{Path: "foo"}, true},
+	}
+
+	for i, c := range cases {
+		if c.vc.IsEmpty() != c.expected {
+			t.Errorf("case %d improperly reported visconfig as empty == %v", i, c.expected)
+			continue
+		}
+	}
+}
+
+func TestReadmeShallowCompare(t *testing.T) {
+	cases := []struct {
+		a, b   *Readme
+		expect bool
+	}{
+		{nil, nil, true},
+		{nil, &Readme{}, false},
+		{&Readme{}, nil, false},
+
+		{&Readme{Path: "a"}, &Readme{Path: "NOT_A"}, true},
+
+		{&Readme{Qri: "a"}, &Readme{Qri: "b"}, false},
+		{&Readme{Format: "a"}, &Readme{Format: "b"}, false},
+		{&Readme{ScriptBytes: []byte("a")}, &Readme{ScriptBytes: []byte("b")}, false},
+		{&Readme{ScriptPath: "a"}, &Readme{ScriptPath: "b"}, false},
+		{&Readme{RenderedPath: "a"}, &Readme{RenderedPath: "b"}, false},
+
+		{
+			&Readme{Qri: "a", Format: "a", ScriptBytes: []byte("a"), ScriptPath: "a", RenderedPath: "a"},
+			&Readme{Qri: "a", Format: "a", ScriptBytes: []byte("a"), ScriptPath: "a", RenderedPath: "a"},
+			true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			got := c.a.ShallowCompare(c.b)
+			if c.expect != got {
+				t.Errorf("wanted %t, got %t", c.expect, got)
+			}
+		})
+	}
+}
+
+func TestReadmeUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		FileName string
+		result   *Readme
+		err      string
+	}{
+		{"testdata/readmes/invalidJSON.json", nil, `invalid character 'I' looking for beginning of value`},
+		{"testdata/readmes/readmeconfig1.json", readme1, ""},
+		{"testdata/readmes/readmeconfig2.json", readme2, ""},
+		{"testdata/readmes/readmeconfig3.json", readme3, ""},
+	}
+
+	for i, c := range cases {
+		data, err := ioutil.ReadFile(c.FileName)
+		if err != nil {
+			t.Errorf("case %d couldn't read file: %s", i, err.Error())
+		}
+
+		vc := &Readme{}
+		err = json.Unmarshal(data, vc)
+		if err != nil {
+			if err.Error() != c.err {
+				t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+				continue
+			} else {
+				continue
+			}
+		}
+
+		if diff := compareReadmes(vc, c.result); diff != "" {
+			t.Errorf("case %d resource comparison error (-want +got):\n%s", i, diff)
+			continue
+		}
+	}
+
+	vc := &Readme{}
+	path := "/path/to/visconfig"
+	if err := json.Unmarshal([]byte(`"`+path+`"`), vc); err != nil {
+		t.Errorf("unmarshal string path error: %s", err.Error())
+		return
+	}
+
+	if vc.Path != path {
+		t.Errorf("unmarshal didn't set proper path: %s != %s", path, vc.Path)
+		return
+	}
+}
+
+func TestReadmeMarshalJSON(t *testing.T) {
+	cases := []struct {
+		in  *Readme
+		out []byte
+		err string
+	}{
+		{&Readme{}, []byte(`{"qri":"rm:0"}`), ""},
+		{&Readme{Qri: KindReadme.String()}, []byte(`{"qri":"rm:0"}`), ""},
+		{&Readme{Format: "foo", Qri: KindReadme.String()}, []byte(`{"format":"foo","qri":"rm:0"}`), ""},
+		{readme1, []byte(`{"format":"foo","qri":"rm:0","renderedPath":"one","scriptPath":"one"}`), ""},
+		{&Readme{Path: "/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"}, []byte(`"/map/QmXo5LE3WVfKZKzTrrgtUUX3nMK4VREKTAoBu5WAGECz4U"`), ""},
+		{&Readme{Path: "/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"}, []byte(`"/map/QmUaMozKVkjPf7CVf3Zd8Cy5Ex1i9oUdhYhU8uTJph5iFD"`), ""},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSON()
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if string(c.out) != string(got) {
+			t.Errorf("case %d, %s != %s", i, string(c.out), string(got))
+			continue
+		}
+	}
+
+	vcbytes, err := json.Marshal(&Readme{Path: "/path/to/Readme"})
+	if err != nil {
+		t.Errorf("unexpected string marshal error: %s", err.Error())
+		return
+	}
+
+	if !bytes.Equal(vcbytes, []byte("\"/path/to/Readme\"")) {
+		t.Errorf("marshal strbyte interface byte mismatch: %s != %s", string(vcbytes), "\"/path/to/Readme\"")
+	}
+}
+
+func TestReadmeMarshalJSONObject(t *testing.T) {
+	cases := []struct {
+		in  *Readme
+		out []byte
+		err string
+	}{
+		{&Readme{}, []byte(`{"qri":"rm:0"}`), ""},
+		{&Readme{Qri: KindReadme.String()}, []byte(`{"qri":"rm:0"}`), ""},
+		{&Readme{Format: "foo", Qri: KindReadme.String()}, []byte(`{"format":"foo","qri":"rm:0"}`), ""},
+		{readme1, []byte(`{"format":"foo","qri":"rm:0","visualizations":{"colors":{"background":"#000000","bars":"#ffffff"},"type":"bar"}}`), ""},
+	}
+
+	for i, c := range cases {
+		got, err := c.in.MarshalJSON()
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		check := &map[string]interface{}{}
+		err = json.Unmarshal(got, check)
+		if err != nil {
+			t.Errorf("case %d error: failed to unmarshal to object: %s", i, err.Error())
+			continue
+		}
+
+	}
+}
+
+func TestUnmarshalReadme(t *testing.T) {
+	vc := Readme{Qri: KindReadme.String(), Format: "foo"}
+	cases := []struct {
+		value interface{}
+		out   *Readme
+		err   string
+	}{
+		{vc, &vc, ""},
+		{&vc, &vc, ""},
+		{[]byte("{\"qri\":\"rm:0\"}"), &Readme{Qri: KindReadme.String()}, ""},
+		{5, nil, "couldn't parse Readme, value is invalid type"},
+	}
+
+	for i, c := range cases {
+		got, err := UnmarshalReadme(c.value)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+		if diff := compareReadmes(c.out, got); diff != "" {
+			t.Errorf("case %d Readme mismatch (-want +got):\n%s", i, diff)
+			continue
+		}
+	}
+}

--- a/testdata/readmes/invalidJSON.json
+++ b/testdata/readmes/invalidJSON.json
@@ -1,0 +1,1 @@
+Invalid Json

--- a/testdata/readmes/readmeconfig1.json
+++ b/testdata/readmes/readmeconfig1.json
@@ -1,0 +1,6 @@
+{
+  "format": "foo",
+  "qri": "rm:0",
+  "scriptPath": "one",
+  "renderedPath": "one"
+}

--- a/testdata/readmes/readmeconfig2.json
+++ b/testdata/readmes/readmeconfig2.json
@@ -1,0 +1,5 @@
+{
+  "format": "bar",
+  "qri": "rm:0",
+  "scriptPath": "two"
+}

--- a/testdata/readmes/readmeconfig3.json
+++ b/testdata/readmes/readmeconfig3.json
@@ -1,0 +1,5 @@
+{
+  "format": "bar",
+  "qri": "rm:0",
+  "scriptPath": "three"
+}

--- a/transform.go
+++ b/transform.go
@@ -1,10 +1,12 @@
 package dataset
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 
 	"github.com/qri-io/qfs"
 )
@@ -157,6 +159,28 @@ func (q *Transform) IsEmpty() bool {
 		q.Secrets == nil &&
 		q.Syntax == "" &&
 		q.SyntaxVersion == ""
+}
+
+// ShallowCompare is an equality check that ignores Path values
+// Intended for comparing transform components across different persistence states,
+// ShallowCompare returns true if all exported fields in the component have the
+// same value (with the exception of Path). ShallowCompare does not consider
+// scriptFile or renderedFile
+func (q *Transform) ShallowCompare(b *Transform) bool {
+	if q == nil && b == nil {
+		return true
+	} else if q == nil && b != nil || q != nil && b == nil {
+		return false
+	}
+
+	return q.Syntax == b.Syntax &&
+		q.SyntaxVersion == b.SyntaxVersion &&
+		q.Qri == b.Qri &&
+		q.ScriptPath == b.ScriptPath &&
+		bytes.Equal(q.ScriptBytes, b.ScriptBytes) &&
+		reflect.DeepEqual(q.Config, b.Config) &&
+		reflect.DeepEqual(q.Secrets, b.Secrets) &&
+		reflect.DeepEqual(q.Resources, b.Resources)
 }
 
 // Assign collapses all properties of a group of queries onto one.

--- a/viz.go
+++ b/viz.go
@@ -1,6 +1,7 @@
 package dataset
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -49,6 +50,25 @@ func (v *Viz) DropTransientValues() {
 func (v *Viz) DropDerivedValues() {
 	v.Qri = ""
 	v.Path = ""
+}
+
+// ShallowCompare is an equality check that ignores Path values
+// Intended for comparing viz components across different persistence states,
+// ShallowCompare returns true if all exported fields in the component have the
+// same value (with the exception of Path). ShallowCompare does not consider
+// scriptFile or renderedFile
+func (v *Viz) ShallowCompare(b *Viz) bool {
+	if v == nil && b == nil {
+		return true
+	} else if v == nil && b != nil || v != nil && b == nil {
+		return false
+	}
+
+	return v.Format == b.Format &&
+		v.Qri == b.Qri &&
+		v.ScriptPath == b.ScriptPath &&
+		v.RenderedPath == b.RenderedPath &&
+		bytes.Equal(v.ScriptBytes, b.ScriptBytes)
 }
 
 // OpenScriptFile generates a byte stream of script data prioritizing creating an

--- a/viz_test.go
+++ b/viz_test.go
@@ -3,6 +3,7 @@ package dataset
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -119,6 +120,40 @@ func TestVizIsEmpty(t *testing.T) {
 			t.Errorf("case %d improperly reported visconfig as empty == %v", i, c.expected)
 			continue
 		}
+	}
+}
+
+func TestVizShallowCompare(t *testing.T) {
+	cases := []struct {
+		a, b   *Viz
+		expect bool
+	}{
+		{nil, nil, true},
+		{nil, &Viz{}, false},
+		{&Viz{}, nil, false},
+
+		{&Viz{Path: "a"}, &Viz{Path: "NOT_A"}, true},
+
+		{&Viz{Qri: "a"}, &Viz{Qri: "b"}, false},
+		{&Viz{Format: "a"}, &Viz{Format: "b"}, false},
+		{&Viz{ScriptBytes: []byte("a")}, &Viz{ScriptBytes: []byte("b")}, false},
+		{&Viz{ScriptPath: "a"}, &Viz{ScriptPath: "b"}, false},
+		{&Viz{RenderedPath: "a"}, &Viz{RenderedPath: "b"}, false},
+
+		{
+			&Viz{Qri: "a", Format: "a", ScriptBytes: []byte("a"), ScriptPath: "a", RenderedPath: "a"},
+			&Viz{Qri: "a", Format: "a", ScriptBytes: []byte("a"), ScriptPath: "a", RenderedPath: "a"},
+			true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			got := c.a.ShallowCompare(c.b)
+			if c.expect != got {
+				t.Errorf("wanted %t, got %t", c.expect, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
I think we should start shifting the "dynamic" methods for working with datasets down into the dataset package itself. Most of this is defined in [`github.com/qri-io/qri/base/component`](https://github.com/qri-io/qri/blob/master/base/component/component.go).

We should start selectively pulling the the utilitarian methods that express datasets & components using dynamic types & interfaces down into the dataset package, but adding _lots_ of tests in the process. This PR is a start to that, adding a `PathMap` method to dataset, and "runtime comparison" method to components that are inlined at save time.

### FieldsEqual methods
I'm not sure how to name this, but here's the general problem this method solves: 

you have two components that are in different states of persistence that need to be checked for equality. For example one "viz" component is saved to `/ipfs/`, and the other "viz" is not yet saved, or one "viz" component is saved to `/s3/` and the other is saved to `/ipfs/`. `FieldsEqual` checks if they're the same.

Basically this means "check everything but the component `Path` field and open script files. It comes with the caveat that fields that reference _other_ paths like `ScriptPath` are checked for equality (because two components that reference different script files are different.