### PR TITLE
refactor(Transform): add `Step` field to cover step-based execution

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -49,6 +49,8 @@ type Transform struct {
 	// produced the result
 	// Deprecated - use steps.Syntax with a version suffix instead
 	SyntaxVersion string `json:"syntaxVersion,omitempty"`
+	// map of syntaxes used in this transform to their version identifier.
+	Syntaxes map[string]string `json:"syntaxes,omitempty"`
 }
 
 // DropTransientValues removes values that cannot be recorded when the
@@ -165,7 +167,8 @@ func (q *Transform) IsEmpty() bool {
 		q.Secrets == nil &&
 		q.Steps == nil &&
 		q.Syntax == "" &&
-		q.SyntaxVersion == ""
+		q.SyntaxVersion == "" &&
+		q.Syntaxes == nil
 }
 
 // ShallowCompare is an equality check that ignores Path values
@@ -188,7 +191,8 @@ func (q *Transform) ShallowCompare(b *Transform) bool {
 		reflect.DeepEqual(q.Config, b.Config) &&
 		reflect.DeepEqual(q.Secrets, b.Secrets) &&
 		reflect.DeepEqual(q.Steps, b.Steps) &&
-		reflect.DeepEqual(q.Resources, b.Resources)
+		reflect.DeepEqual(q.Resources, b.Resources) &&
+		reflect.DeepEqual(q.Syntaxes, b.Syntaxes)
 }
 
 // Assign collapses all properties of a group of queries onto one.
@@ -252,6 +256,9 @@ func (q *Transform) Assign(qs ...*Transform) {
 		if q2.SyntaxVersion != "" {
 			q.SyntaxVersion = q2.SyntaxVersion
 		}
+		if q2.Syntaxes != nil {
+			q.Syntaxes = q2.Syntaxes
+		}
 	}
 }
 
@@ -285,6 +292,7 @@ func (q Transform) MarshalJSONObject() ([]byte, error) {
 		Steps:         q.Steps,
 		Syntax:        q.Syntax,
 		SyntaxVersion: q.SyntaxVersion,
+		Syntaxes:      q.Syntaxes,
 	})
 }
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -44,6 +44,7 @@ func TestTransformAssign(t *testing.T) {
 		Path:          "path",
 		Syntax:        "a",
 		SyntaxVersion: "b",
+		Syntaxes:      map[string]string{"c": "d"},
 		Steps: []*TransformStep{
 			{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"},
 		},
@@ -57,6 +58,7 @@ func TestTransformAssign(t *testing.T) {
 	got := &Transform{
 		Syntax:        "no",
 		SyntaxVersion: "change",
+		Syntaxes:      map[string]string{"change": "change"},
 		Config: map[string]interface{}{
 			"foo": "baz",
 		},
@@ -76,6 +78,7 @@ func TestTransformAssign(t *testing.T) {
 			"a": &TransformResource{Path: "/path/to/a"},
 		},
 	}, &Transform{
+		Syntaxes: map[string]string{"c": "d"},
 		Steps: []*TransformStep{
 			{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"},
 		},
@@ -112,6 +115,7 @@ func TestTransformShallowCompare(t *testing.T) {
 		{&Transform{Syntax: "a"}, &Transform{Syntax: "b"}, false},
 		{&Transform{ScriptBytes: []byte("a")}, &Transform{ScriptBytes: []byte("b")}, false},
 		{&Transform{ScriptPath: "a"}, &Transform{ScriptPath: "b"}, false},
+		{&Transform{Syntaxes: map[string]string{"c": "d"}}, &Transform{Syntaxes: map[string]string{"c": "e"}}, false},
 
 		{
 			&Transform{Qri: "a", Syntax: "b", SyntaxVersion: "c", ScriptBytes: []byte("d"), ScriptPath: "e", Secrets: map[string]string{"f": "f"}, Config: map[string]interface{}{"g": "g"}, Resources: map[string]*TransformResource{"h": nil}},
@@ -183,6 +187,7 @@ func TestTransformMarshalJSONObject(t *testing.T) {
 	}{
 		{&Transform{}, `{"qri":"tf:0"}`, nil},
 		{&Transform{Syntax: "sql", ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntax":"sql"}`, nil},
+		{&Transform{Syntaxes: map[string]string{"sql": "1"}, ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntaxes":{"sql":"1"}}`, nil},
 		{&Transform{Syntax: "starlark", Steps: []*TransformStep{
 			{Syntax: "starlark", Category: "download", Name: "download", Script: `# get the popular baby names dataset as a csv
 		def download(ctx):
@@ -230,6 +235,7 @@ func TestTransformMarshalJSON(t *testing.T) {
 	}{
 		{&Transform{}, `{"qri":"tf:0"}`, nil},
 		{&Transform{Syntax: "sql", ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntax":"sql"}`, nil},
+		{&Transform{Syntaxes: map[string]string{"sql": "1"}, ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntaxes":{"sql":"1"}}`, nil},
 		{&Transform{Syntax: "starlark", Steps: []*TransformStep{
 			{Syntax: "starlark", Category: "download", Name: "download", Script: `# get the popular baby names dataset as a csv
 		def download(ctx):
@@ -272,6 +278,7 @@ func TestTransformIsEmpty(t *testing.T) {
 		{&Transform{}, true},
 		{&Transform{Syntax: "foo"}, false},
 		{&Transform{SyntaxVersion: "0"}, false},
+		{&Transform{Syntaxes: map[string]string{}}, false},
 		{&Transform{ScriptPath: "foo"}, false},
 		{&Transform{Config: nil}, true},
 		{&Transform{Config: map[string]interface{}{}}, false},

--- a/transform_test.go
+++ b/transform_test.go
@@ -43,7 +43,10 @@ func TestTransformAssign(t *testing.T) {
 	expect := &Transform{
 		Path:          "path",
 		Syntax:        "a",
-		SyntaxVersion: "change",
+		SyntaxVersion: "b",
+		Steps: []*TransformStep{
+			{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"},
+		},
 		Config: map[string]interface{}{
 			"foo": "bar",
 		},
@@ -53,7 +56,7 @@ func TestTransformAssign(t *testing.T) {
 	}
 	got := &Transform{
 		Syntax:        "no",
-		SyntaxVersion: "b",
+		SyntaxVersion: "change",
 		Config: map[string]interface{}{
 			"foo": "baz",
 		},
@@ -62,7 +65,7 @@ func TestTransformAssign(t *testing.T) {
 
 	got.Assign(&Transform{
 		Syntax:        "a",
-		SyntaxVersion: "change",
+		SyntaxVersion: "b",
 		Config: map[string]interface{}{
 			"foo": "bar",
 		},
@@ -71,6 +74,10 @@ func TestTransformAssign(t *testing.T) {
 		Path: "path",
 		Resources: map[string]*TransformResource{
 			"a": &TransformResource{Path: "/path/to/a"},
+		},
+	}, &Transform{
+		Steps: []*TransformStep{
+			{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"},
 		},
 	})
 
@@ -109,6 +116,12 @@ func TestTransformShallowCompare(t *testing.T) {
 		{
 			&Transform{Qri: "a", Syntax: "b", SyntaxVersion: "c", ScriptBytes: []byte("d"), ScriptPath: "e", Secrets: map[string]string{"f": "f"}, Config: map[string]interface{}{"g": "g"}, Resources: map[string]*TransformResource{"h": nil}},
 			&Transform{Qri: "a", Syntax: "b", SyntaxVersion: "c", ScriptBytes: []byte("d"), ScriptPath: "e", Secrets: map[string]string{"f": "f"}, Config: map[string]interface{}{"g": "g"}, Resources: map[string]*TransformResource{"h": nil}},
+			true,
+		},
+
+		{
+			&Transform{Qri: "a", Syntax: "b", SyntaxVersion: "c", Secrets: map[string]string{"f": "f"}, Config: map[string]interface{}{"g": "g"}, Steps: []*TransformStep{{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"}}, Resources: map[string]*TransformResource{"h": nil}},
+			&Transform{Qri: "a", Syntax: "b", SyntaxVersion: "c", Secrets: map[string]string{"f": "f"}, Config: map[string]interface{}{"g": "g"}, Steps: []*TransformStep{{Name: "h", Path: "i", Syntax: "j", Category: "k", Script: "l"}}, Resources: map[string]*TransformResource{"h": nil}},
 			true,
 		},
 	}
@@ -170,6 +183,20 @@ func TestTransformMarshalJSONObject(t *testing.T) {
 	}{
 		{&Transform{}, `{"qri":"tf:0"}`, nil},
 		{&Transform{Syntax: "sql", ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntax":"sql"}`, nil},
+		{&Transform{Syntax: "starlark", Steps: []*TransformStep{
+			{Syntax: "starlark", Category: "download", Name: "download", Script: `# get the popular baby names dataset as a csv
+		def download(ctx):
+			csvDownloadUrl = "https://data.cityofnewyork.us/api/views/25th-nujf/rows.csv?accessType=DOWNLOAD"
+			return http.get(csvDownloadUrl).body()`,
+			},
+			{Name: "transform", Syntax: "starlark", Category: "transform", Script: `# set the body
+def transform(ds, ctx):
+	# ctx.download is whatever download() returned
+	csv = ctx.download
+	# set the dataset body
+	ds.set_body(csv, parse_as='csv')`,
+			},
+		}}, `{"qri":"tf:0","steps":[{"name":"download","syntax":"starlark","category":"download","script":"# get the popular baby names dataset as a csv\n\t\tdef download(ctx):\n\t\t\tcsvDownloadUrl = \"https://data.cityofnewyork.us/api/views/25th-nujf/rows.csv?accessType=DOWNLOAD\"\n\t\t\treturn http.get(csvDownloadUrl).body()"},{"name":"transform","syntax":"starlark","category":"transform","script":"# set the body\ndef transform(ds, ctx):\n\t# ctx.download is whatever download() returned\n\tcsv = ctx.download\n\t# set the dataset body\n\tds.set_body(csv, parse_as='csv')"}],"syntax":"starlark"}`, nil},
 	}
 
 	for i, c := range cases {
@@ -203,6 +230,20 @@ func TestTransformMarshalJSON(t *testing.T) {
 	}{
 		{&Transform{}, `{"qri":"tf:0"}`, nil},
 		{&Transform{Syntax: "sql", ScriptPath: "foo.star"}, `{"qri":"tf:0","scriptPath":"foo.star","syntax":"sql"}`, nil},
+		{&Transform{Syntax: "starlark", Steps: []*TransformStep{
+			{Syntax: "starlark", Category: "download", Name: "download", Script: `# get the popular baby names dataset as a csv
+		def download(ctx):
+			csvDownloadUrl = "https://data.cityofnewyork.us/api/views/25th-nujf/rows.csv?accessType=DOWNLOAD"
+			return http.get(csvDownloadUrl).body()`,
+			},
+			{Name: "transform", Syntax: "starlark", Category: "transform", Script: `# set the body
+def transform(ds, ctx):
+	# ctx.download is whatever download() returned
+	csv = ctx.download
+	# set the dataset body
+	ds.set_body(csv, parse_as='csv')`,
+			},
+		}}, `{"qri":"tf:0","steps":[{"name":"download","syntax":"starlark","type":"download","value":"# get the popular baby names dataset as a csv\n\t\tdef download(ctx):\n\t\t\tcsvDownloadUrl = \"https://data.cityofnewyork.us/api/views/25th-nujf/rows.csv?accessType=DOWNLOAD\"\n\t\t\treturn http.get(csvDownloadUrl).body()"},{"name":"transform","syntax":"starlark","type":"transform","value":"# set the body\ndef transform(ds, ctx):\n\t# ctx.download is whatever download() returned\n\tcsv = ctx.download\n\t# set the dataset body\n\tds.set_body(csv, parse_as='csv')"}],"syntax":"starlark"}`, nil},
 	}
 
 	for i, c := range cases {
@@ -236,6 +277,7 @@ func TestTransformIsEmpty(t *testing.T) {
 		{&Transform{Config: map[string]interface{}{}}, false},
 		{&Transform{Resources: nil}, true},
 		{&Transform{Resources: map[string]*TransformResource{}}, false},
+		{&Transform{Steps: []*TransformStep{}}, false},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
closes #246 

Adds `Steps` field to `Transform` struct and adds `TransformSteps` struct.
Adjusts `transform.MarshalJSONObject`, `transform.Assign`, `transform.ShallowCompare`, & `transform.IsEmpty`.
Also adjusts each associated test to ensure the `Steps` field is being handled.

Also, changes `transform.SyntaxVersion` from `string` to `map[string]string` type, as per [this comment](https://github.com/qri-io/dataset/pull/247#issuecomment-762573306) by b5 below:

> Steps add the possibility of multiple syntaxes being mixed in the same transform, so we need to manage a map of "execution syntaxes" to their versions. The one solution would be to add a SyntaxVersions field of type map[string]string to the Transform struct, where each key is a unique syntax used in at least one step, and the value is the version of that syntax used.

Ups coverage of the `dataset` tests by 0.04%