### PR TITLE
fix(preview): rename CreatePreview -> Preview, don't consume input dataset files

### DIFF
--- a/preview/preview_test.go
+++ b/preview/preview_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/qri-io/dataset/dstest"
 )
 
-func TestCreatePreview(t *testing.T) {
+func TestCreate(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := CreatePreview(ctx, &dataset.Dataset{})
+	_, err := Create(ctx, &dataset.Dataset{})
 
 	if err == nil {
 		t.Fatal(fmt.Errorf("expected empty dataset to error"))
@@ -25,7 +25,7 @@ func TestCreatePreview(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := CreatePreview(ctx, tc.Input)
+	got, err := Create(ctx, tc.Input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,6 +45,14 @@ func TestCreatePreview(t *testing.T) {
 	if len(body) != 100 {
 		t.Errorf("error: body length mismatch, expected 100 got %d", len(body))
 	}
+	if got.BodyFile() == nil {
+		t.Errorf("expected creating a preview to leave existing BodyFile intact, is missing")
+		// TODO (b5) - confirm body file contents are unmodified
+	}
+	if got.Readme.ScriptFile() == nil {
+		t.Errorf("expected creating a preview to leave existing Readme.ScriptFile intact, is missing")
+		// TODO (b5) - confirm actual readme scriptfile is unmodified
+	}
 
 	// TODO (b5) - required adjustments for accurate comparison due to JSON serialization
 	// issues. either solve the serialization issues or add options to dstest.CompareDatasets
@@ -60,7 +68,7 @@ func TestCreatePreview(t *testing.T) {
 	// make sure you can create a preview of a dataset without a body file
 	tc.Input.SetBodyFile(nil)
 
-	got, err = CreatePreview(ctx, tc.Input)
+	got, err = Create(ctx, tc.Input)
 	if err != nil {
 		t.Fatalf("unexpected error creating a preview of a dataset without a body: %s", err)
 	}


### PR DESCRIPTION
This makes preview creation a far less destructive process, allowing continued use of the input dataset parameter after Preview creation