### PR TITLE
feat(dataset): add ID field to dataset.Dataset

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -58,6 +58,8 @@ type Dataset struct {
 	// Commit contains author & change message information that describes this
 	// version of a dataset
 	Commit *Commit `json:"commit,omitempty"`
+	// ID is an identifier string for this dataset.
+	ID string `json:"id,omitempty"`
 	// Meta contains all human-readable meta about this dataset intended to aid
 	// in discovery and organization of this document
 	Meta *Meta `json:"meta,omitempty"`
@@ -97,6 +99,7 @@ func (ds *Dataset) IsEmpty() bool {
 		ds.BodyBytes == nil &&
 		ds.BodyPath == "" &&
 		ds.Commit == nil &&
+		ds.ID == "" &&
 		ds.Meta == nil &&
 		ds.Name == "" &&
 		ds.Peername == "" &&
@@ -181,6 +184,9 @@ func (ds *Dataset) PathMap(ignore ...string) map[string]string {
 func (ds *Dataset) SigningBytes() []byte {
 	var sigComponents []string
 
+	if ds.ID != "" {
+		sigComponents = append(sigComponents, fmt.Sprintf("id:%s", ds.ID))
+	}
 	if ds.BodyPath != "" {
 		sigComponents = append(sigComponents, ComponentTypePrefix(KindBody, ds.BodyPath))
 	}
@@ -362,6 +368,9 @@ func (ds *Dataset) Assign(datasets ...*Dataset) {
 			ds.Commit = d.Commit
 		} else if ds.Commit != nil {
 			ds.Commit.Assign(d.Commit)
+		}
+		if ds.ID == "" && d.ID != "" {
+			ds.ID = d.ID
 		}
 		if ds.Meta == nil && d.Meta != nil {
 			ds.Meta = d.Meta

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -98,6 +98,7 @@ func TestDatasetAssign(t *testing.T) {
 	cases := []struct {
 		in *Dataset
 	}{
+		{&Dataset{ID: "id"}},
 		{&Dataset{Path: "/a"}},
 		{&Dataset{Structure: &Structure{Format: "csv"}}},
 		{&Dataset{Transform: &Transform{ScriptPath: "some_transform_script.star"}}},
@@ -173,6 +174,7 @@ func TestDatasetSignableBytes(t *testing.T) {
 
 func TestSigningBytes(t *testing.T) {
 	ds := &Dataset{
+		ID:        "identifier",
 		Commit:    &Commit{Timestamp: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC)},
 		BodyPath:  "body",
 		Meta:      &Meta{Path: "meta"},
@@ -185,14 +187,16 @@ func TestSigningBytes(t *testing.T) {
 
 	got := ds.SigningBytes()
 
-	expect := `bd:body
+	expect := `
+id:identifier
+bd:body
 cm:2001-01-01T01:01:01Z
 md:meta
 rm:readme
 st:structure
 tf:transform
 sa:stats
-vz:viz`
+vz:viz`[1:]
 
 	if diff := cmp.Diff(expect, string(got)); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
In qri-io/qri land we talk about a cascade of values from refstring to dataset, where each structure is a superset of the structure before it:

  * reference string: "b5/population@/ipfs/hash"
  * dsref.Ref: { "username": "b5", "name": "population", "path": "/ipfs/hash" }
  * dsref.VersionInfo: { "username": "b5", "name": "population", "path": "/ipfs/hash", "commitTitle": "added..." }
  * dataset.Dataset: { /* complete dataset */ }

This lets us expand-to-suit depending on the needs of the operation. It also means that any field that can be represented in a smaller structure must be present in all others.

In a separate conversation we've been on a push to use _stable identifiers for dataset histories_, which have to be worked into _all_ of these structures to be effective. This commit adds an ID field to the dataset structure itself to
advance that goal. the ID field is added directly to the dataset struct, should be persisted to disk, and is added to the `SignableBytes` method to add cryptographic integrity to it's value.

There is already an "ID" field on a dataset within the Meta component. We can't use it for this purpose and keep the `Meta` component optional, so I've chosen to add it to the dataset itself. I generally think of `Meta.ID` as being a refernce to an _external_ identifier.

BREAKING CHANGE:
older versions of qri that attempt to verify the signature of datasets with a
non-empty ID string field will error.