### PR TITLE
fix(`dataset.BodyFile`): if no dataset exists, return nil

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -339,6 +339,9 @@ func (ds *Dataset) SetBodyFile(file qfs.File) {
 // BodyFile exposes bodyFile if one is set. Callers that use the file in any
 // way (eg. by calling Read) should consume the entire file and call Close
 func (ds *Dataset) BodyFile() qfs.File {
+	if ds == nil {
+		return nil
+	}
 	return ds.bodyFile
 }
 


### PR DESCRIPTION
Might make sense to expand this beyond just `dataset.BodyFile()`.

This was causing a bug in `startf`, where if this was there was no previous version of a dataset, `ds.get_body` would segfault. It was relying on `dataset.BodyFile()`, which, if there was no dataset, would segfault b/c of a nil pointer dereference.

Again, might be beneficial to expand this for all the `dataset` methods.