### PR TITLE
feat(detect.Structure): move struture detection function down from qri

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -276,6 +276,8 @@ func (ds *Dataset) DropDerivedValues() {
 }
 
 var (
+	// ErrNoBody occurs when a dataset has no body component, but one is expected
+	ErrNoBody = fmt.Errorf("dataset has no body component")
 	// ErrInlineBody is the error for attempting to generate a body file when
 	// body data is stored as native go types
 	ErrInlineBody = fmt.Errorf("dataset body is inlined")

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -15,6 +15,11 @@ import (
 
 func TestStructure(t *testing.T) {
 	ds := &dataset.Dataset{}
+	if err := Structure(ds); !errors.Is(err, dataset.ErrNoBody) {
+		t.Errorf("expected dataset without an open body file to return dataset.ErrNoBody, got: %v", err)
+	}
+
+	ds = &dataset.Dataset{}
 	ds.SetBodyFile(qfs.NewMemfileBytes("animals.csv",
 		[]byte("Animal,Sound,Weight\ncat,meow,1.4\ndog,bark,3.7\n")))
 
@@ -97,6 +102,15 @@ func TestStructure(t *testing.T) {
 	if ds.Structure.FormatConfig != nil {
 		t.Errorf("format config should not be set when inferred format & input format don't match")
 	}
+	if diff := cmp.Diff(expect, ds.Structure); diff != "" {
+		t.Errorf("mismatched resulting structure (-want +got):\n%s", diff)
+	}
+
+	// fully hydrated structure should hit the fast path, change nothing
+	if err := Structure(ds); err != nil {
+		t.Error(err)
+	}
+
 	if diff := cmp.Diff(expect, ds.Structure); diff != "" {
 		t.Errorf("mismatched resulting structure (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
and add a bunch of tests / fixes. There are a few spots in the qri codebase that will be much cleaner with this abstraction, and having it in dataset with these tests will help make behaviour more consistent.

The tests I've added make a few more assurances that detect.Structure is idempotent