### PR TITLE
fix(transform): Assign() overwrites Steps field

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -243,12 +243,7 @@ func (q *Transform) Assign(qs ...*Transform) {
 			}
 		}
 		if q2.Steps != nil {
-			if q.Steps == nil {
-				q.Steps = []*TransformStep{}
-			}
-			for _, val := range q2.Steps {
-				q.Steps = append(q.Steps, val)
-			}
+			q.Steps = q2.Steps
 		}
 		if q2.Syntax != "" {
 			q.Syntax = q2.Syntax

--- a/transform_test.go
+++ b/transform_test.go
@@ -52,7 +52,7 @@ func TestTransformAssign(t *testing.T) {
 			"foo": "bar",
 		},
 		Resources: map[string]*TransformResource{
-			"a": &TransformResource{Path: "/path/to/a"},
+			"a": {Path: "/path/to/a"},
 		},
 	}
 	got := &Transform{
@@ -75,7 +75,7 @@ func TestTransformAssign(t *testing.T) {
 	}, &Transform{
 		Path: "path",
 		Resources: map[string]*TransformResource{
-			"a": &TransformResource{Path: "/path/to/a"},
+			"a": {Path: "/path/to/a"},
 		},
 	}, &Transform{
 		Syntaxes: map[string]string{"c": "d"},
@@ -96,6 +96,31 @@ func TestTransformAssign(t *testing.T) {
 	emptyTf := &Transform{}
 	emptyTf.Assign(expect)
 	if diff := compareTransforms(expect, emptyTf); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+
+	expect = &Transform{
+		Steps: []*TransformStep{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+	}
+
+	shouldReplaceSteps := &Transform{
+		Steps: []*TransformStep{
+			{Name: "f"},
+		},
+	}
+	shouldReplaceSteps.Assign(&Transform{
+		Steps: []*TransformStep{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+	})
+
+	if diff := compareTransforms(expect, shouldReplaceSteps); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
instead of concatenating arrays. This was creating a situation in qri where scripts were doubling their steps slice on each call to `preview.Create` (which uses Assign). My bad!