### PR TITLE
fix(compression): coerce various format strings while parsing

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -10,14 +10,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// Format represents a type of byte compression
-type Format string
-
-// String implements the stringer interface
-func (s Format) String() string {
-	return string(s)
-}
-
 const (
 	// FmtNone is a sentinel for no compression
 	FmtNone Format = ""
@@ -26,6 +18,14 @@ const (
 	// FmtGZip GNU zip compression https://www.gnu.org/software/gzip/
 	FmtGZip Format = "gzip"
 )
+
+// Format represents a type of byte compression
+type Format string
+
+// String implements the stringer interface
+func (s Format) String() string {
+	return string(s)
+}
 
 // SupportedFormats indexes supported formats in a map for lookups
 var SupportedFormats = map[Format]struct{}{
@@ -36,10 +36,21 @@ var SupportedFormats = map[Format]struct{}{
 // ParseFormat interprets a string into a supported compression format
 // errors when provided the empty string ("no compression" format)
 func ParseFormat(s string) (f Format, err error) {
-	f = Format(s)
+	f, ok := map[string]Format{
+		"gzip": FmtGZip,
+		"gz":   FmtGZip,
+		"zst":  FmtZStandard,
+		"zstd": FmtZStandard, // not a common file ending, but "zstd" is the shorthand name for the library
+	}[s]
+
+	if !ok {
+		return f, fmt.Errorf("invalid compression format %q", s)
+	}
+
 	if _, ok := SupportedFormats[f]; !ok {
 		return FmtNone, fmt.Errorf("unsupported compression format: %q", s)
 	}
+
 	return f, nil
 }
 

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -7,6 +7,31 @@ import (
 	"testing"
 )
 
+func TestParseFormat(t *testing.T) {
+	good := []string{
+		"gz", "gzip", "zstd",
+	}
+
+	for _, s := range good {
+		f, err := ParseFormat(s)
+		if err != nil {
+			t.Errorf("unexpected error for format %q: %s", s, err)
+		}
+		if _, ok := SupportedFormats[f]; !ok {
+			t.Errorf("expected %q to be a supported format", s)
+		}
+	}
+
+	bad := []string{
+		"", "tar",
+	}
+	for _, s := range bad {
+		if _, err := ParseFormat(s); err == nil {
+			t.Errorf("expected format to error: %s, got nil", s)
+		}
+	}
+}
+
 func TestNew(t *testing.T) {
 	if _, err := Compressor("invalid", &bytes.Buffer{}); err == nil {
 		t.Error("expected error constructing with invalid compression format string")
@@ -70,7 +95,5 @@ func TestCompressionCycle(t *testing.T) {
 				t.Errorf("compression round trip result mismatch.\nwant: %s\ngot: %s", plainText, result.String())
 			}
 		})
-
 	}
-
 }


### PR DESCRIPTION
properly interpret strings like 'gz' and 'zstd' as gzip & zstandard compression respectively