### PR TITLE
fix(dsio): handle JSON strings properly

### DIFF
--- a/dsio/dsio.go
+++ b/dsio/dsio.go
@@ -143,7 +143,7 @@ func GetTopLevelType(st *dataset.Structure) (string, error) {
 func ReadAll(r EntryReader) (interface{}, error) {
 	tlt, err := GetTopLevelType(r.Structure())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting top level type: %w", err)
 	}
 
 	if tlt == "object" {
@@ -162,7 +162,7 @@ func ReadAllObject(r EntryReader) (map[string]interface{}, error) {
 			if err.Error() == "EOF" {
 				break
 			}
-			return nil, err
+			return nil, fmt.Errorf("row %d: %w", i+1, err)
 		}
 		obj[val.Key] = val.Value
 	}
@@ -179,7 +179,7 @@ func ReadAllArray(r EntryReader) ([]interface{}, error) {
 			if err.Error() == "EOF" {
 				break
 			}
-			return nil, err
+			return nil, fmt.Errorf("entry %d: %w", i+1, err)
 		}
 		array = append(array, val.Value)
 	}

--- a/dsio/json_test.go
+++ b/dsio/json_test.go
@@ -112,6 +112,7 @@ func TestJSONReaderBasicParsing(t *testing.T) {
 		{"{\"a\":\"say \\\"\\u72ac\\\"\"}", objSt, "say \"\xe7\x8a\xac\""},
 		{"{\n  \"a\" : \"b\" }", objSt, "b"},
 		{`{"a": "\/"}`, objSt, "/"},
+		{`{"body":"Template with:\r\n'''\r\n[[ \r\nvar email = (fin._meta.hashbang.match(/\\/([^\\/]+)\\/[^\\/]+$/) || ['',''])[1]\r\nvar activation_code = (fin._meta.hashbang.match(/\\/[^\\/]+\\/([^\\/]+)$/) || ['',''])[1]\r\n]]\r\n\r\n<form id=\"activateform\" ajaxform hashbang=\"blog/admin/forms\" command=\"activate\"\r\n\tvalidator=\"fin.fn.blog.activateValidator\" onSuccess=\"fin.fn.blog.activateSuccess\">\r\n\t\r\n\t<label for=\"email\">Email:</label>\r\n\t<input name=\"email\" type=\"text\" value=\"{{ email }}\"/>\r\n\r\n\t<br /><label for=\"activation_code\">Activation Code:</label>\r\n\t<input name=\"activation_code\" type=\"text\" value=\"{{ activation_code }}\" />\r\n\r\n\t<br /><input type=\"submit\" class=\"btn btn-primary\" value=\"Activate\" />\r\n\t<br /><a class=\"btn btn-inverse\" href=\"/#!/blog/admin/login\">Login</a>\r\n\r\n</form>\r\n'''"}`, objSt, "Template with:\r\n'''\r\n[[ \r\nvar email = (fin._meta.hashbang.match(/\\/([^\\/]+)\\/[^\\/]+$/) || ['',''])[1]\r\nvar activation_code = (fin._meta.hashbang.match(/\\/[^\\/]+\\/([^\\/]+)$/) || ['',''])[1]\r\n]]\r\n\r\n<form id=\"activateform\" ajaxform hashbang=\"blog/admin/forms\" command=\"activate\"\r\n\tvalidator=\"fin.fn.blog.activateValidator\" onSuccess=\"fin.fn.blog.activateSuccess\">\r\n\t\r\n\t<label for=\"email\">Email:</label>\r\n\t<input name=\"email\" type=\"text\" value=\"{{ email }}\"/>\r\n\r\n\t<br /><label for=\"activation_code\">Activation Code:</label>\r\n\t<input name=\"activation_code\" type=\"text\" value=\"{{ activation_code }}\" />\r\n\r\n\t<br /><input type=\"submit\" class=\"btn btn-primary\" value=\"Activate\" />\r\n\t<br /><a class=\"btn btn-inverse\" href=\"/#!/blog/admin/login\">Login</a>\r\n\r\n</form>\r\n'''"},
 	}
 
 	for i, c := range cases {
@@ -119,9 +120,10 @@ func TestJSONReaderBasicParsing(t *testing.T) {
 		ent, err := r.ReadEntry()
 		if err != nil {
 			t.Errorf("case %d error: %s", i, err)
+			continue
 		}
-		if ent.Value != c.expect {
-			t.Errorf("case %d value mismatch: %v <> %v", i, ent.Value, c.expect)
+		if diff := cmp.Diff(c.expect, ent.Value); diff != "" {
+			t.Errorf("result mismatch (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -417,17 +419,17 @@ func TestJSONPrettyWriter(t *testing.T) {
 		{
 			&dataset.Structure{Schema: dataset.BaseSchemaArray},
 			[]Entry{
-				Entry{Value: map[string]string{"a": "hello"}},
-				Entry{Value: map[string]string{"b": "goodbye"}},
+				{Value: map[string]string{"a": "hello"}},
+				{Value: map[string]string{"b": "goodbye"}},
 			},
 			"[\n {\n  \"a\": \"hello\"\n },\n {\n  \"b\": \"goodbye\"\n }\n]",
 		},
 		{
 			&dataset.Structure{Schema: dataset.BaseSchemaObject},
 			[]Entry{
-				Entry{Key: "a", Value: "foo"},
-				Entry{Key: "b", Value: true},
-				Entry{Key: "c", Value: map[string]int{"depth_2": 2}},
+				{Key: "a", Value: "foo"},
+				{Key: "b", Value: true},
+				{Key: "c", Value: map[string]int{"depth_2": 2}},
 			},
 			"{\n \"a\": \"foo\",\n \"b\": true,\n \"c\": {\n  \"depth_2\": 2\n }\n}",
 		},


### PR DESCRIPTION
string parser is choking on complex escape sequences, fix by falling back to `encoding/json` package unmarshaler. This is slower, but works where our current approach fails.

@dustmop seeking your review on this. I'd love a follow up that makes this less bad