### PR TITLE
fix(json): Unescape json strings using byte-by-byte inspection

### DIFF
--- a/dsio/csv_test.go
+++ b/dsio/csv_test.go
@@ -347,11 +347,14 @@ a	12	23	"[""foo"",""bar""]"`
 }
 func BenchmarkCSVWriterArrays(b *testing.B) {
 	const NumWrites = 1000
-	st := &dataset.Structure{Format: "csv", Schema: dataset.BaseSchemaObject}
+	st := &dataset.Structure{Format: "csv", Schema: tabular.BaseTabularSchema}
 
 	for n := 0; n < b.N; n++ {
 		buf := &bytes.Buffer{}
-		w, _ := NewCSVWriter(st, buf)
+		w, err := NewCSVWriter(st, buf)
+		if err != nil {
+			b.Fatalf("could not create CSVWriter: %s", err)
+		}
 		for i := 0; i < NumWrites; i++ {
 			// Write an array entry.
 			arrayEntry := Entry{Index: i, Value: "test"}
@@ -362,11 +365,14 @@ func BenchmarkCSVWriterArrays(b *testing.B) {
 
 func BenchmarkCSVWriterObjects(b *testing.B) {
 	const NumWrites = 1000
-	st := &dataset.Structure{Format: "csv", Schema: dataset.BaseSchemaObject}
+	st := &dataset.Structure{Format: "csv", Schema: tabular.BaseTabularSchema}
 
 	for n := 0; n < b.N; n++ {
 		buf := &bytes.Buffer{}
-		w, _ := NewCSVWriter(st, buf)
+		w, err := NewCSVWriter(st, buf)
+		if err != nil {
+			b.Fatalf("could not create CSVWriterObjects: %s", err)
+		}
 		for i := 0; i < NumWrites; i++ {
 			// Write an object entry.
 			objectEntry := Entry{Key: "key", Value: "test"}
@@ -376,14 +382,17 @@ func BenchmarkCSVWriterObjects(b *testing.B) {
 }
 
 func BenchmarkCSVReader(b *testing.B) {
-	st := &dataset.Structure{Format: "csv", Schema: dataset.BaseSchemaArray}
+	st := &dataset.Structure{Format: "csv", Schema: tabular.BaseTabularSchema}
 
 	for n := 0; n < b.N; n++ {
 		file, err := os.Open(testdataFile("../dsio/testdata/movies/body.csv"))
 		if err != nil {
 			b.Errorf("unexpected error: %s", err.Error())
 		}
-		r, _ := NewCSVReader(st, file)
+		r, err := NewCSVReader(st, file)
+		if err != nil {
+			b.Fatalf("could not create CSVReader: %s", err)
+		}
 		for {
 			_, err = r.ReadEntry()
 			if err != nil {

--- a/dsio/json.go
+++ b/dsio/json.go
@@ -339,7 +339,7 @@ func unquoteJSONString(srcBuff []byte) string {
 		s++
 		d++
 	}
-	return string(dstBuff[0:d])
+	return string(dstBuff[:d])
 }
 
 func (r *JSONReader) readString() (string, error) {

--- a/dsio/xlsx_test.go
+++ b/dsio/xlsx_test.go
@@ -130,8 +130,11 @@ func TestXLSXCompression(t *testing.T) {
 	}
 }
 
+/*
+TODO(dustmop): Disabled, testdata/movies/data.xlsx doesn't exist
+
 func BenchmarkXLSXReader(b *testing.B) {
-	st := &dataset.Structure{Format: "xlsx", Schema: dataset.BaseSchemaArray}
+	st := &dataset.Structure{Format: "xlsx", Schema: tabular.BaseTabularSchema}
 
 	for n := 0; n < b.N; n++ {
 		file, err := os.Open("testdata/movies/data.xlsx")
@@ -140,7 +143,7 @@ func BenchmarkXLSXReader(b *testing.B) {
 		}
 		r, err := NewXLSXReader(st, file)
 		if err != nil {
-			b.Errorf("unexpected error: %s", err.Error())
+			b.Fatalf("unexpected error: %s", err.Error())
 		}
 		for {
 			_, err = r.ReadEntry()
@@ -150,3 +153,4 @@ func BenchmarkXLSXReader(b *testing.B) {
 		}
 	}
 }
+*/


### PR DESCRIPTION
Handle all json escape sequences using a byte-by-byte inspection. Also handle escaped hex codes, which are technically out of spec, but often sent in json data. This approach is significantly faster than previous methods.

This benchmark run shows that BenchmarkJSONReader runs approximately 2x as fast.

```
BEFORE

goos: darwin
goarch: amd64
pkg: github.com/qri-io/dataset/dsio
cpu: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
BenchmarkCBORWriterArrays-8    	   10000	    117795 ns/op
BenchmarkCBORWriterObjects-8   	    6321	    192148 ns/op
BenchmarkCBORReader-8          	    2022	    583629 ns/op
BenchmarkCSVWriterArrays-8     	    2220	    525497 ns/op
BenchmarkCSVWriterObjects-8    	    2248	    526928 ns/op
BenchmarkCSVReader-8           	    1894	    620847 ns/op
BenchmarkJSONWriterArrays-8    	    6708	    177715 ns/op
BenchmarkJSONWriterObjects-8   	    4374	    276743 ns/op
BenchmarkJSONReader-8          	     649	   1836256 ns/op
PASS
ok  	github.com/qri-io/dataset/dsio	11.293s

AFTER

goos: darwin
goarch: amd64
pkg: github.com/qri-io/dataset/dsio
cpu: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
BenchmarkCBORWriterArrays-8    	   10000	    119981 ns/op
BenchmarkCBORWriterObjects-8   	    6381	    193160 ns/op
BenchmarkCBORReader-8          	    2031	    581762 ns/op
BenchmarkCSVWriterArrays-8     	    2246	    528192 ns/op
BenchmarkCSVWriterObjects-8    	    2262	    525037 ns/op
BenchmarkCSVReader-8           	    1892	    619852 ns/op
BenchmarkJSONWriterArrays-8    	    6252	    187372 ns/op
BenchmarkJSONWriterObjects-8   	    4257	    286447 ns/op
BenchmarkJSONReader-8          	    1212	    982385 ns/op
PASS
ok  	github.com/qri-io/dataset/dsio	11.239s
```