### PR TITLE
feat(stepfile): stepfile reads and writes step flat files

### DIFF
--- a/stepfile/stepfile.go
+++ b/stepfile/stepfile.go
@@ -1,0 +1,82 @@
+// Package stepfile provides utilities for reading and writing an ordered set of
+// transform steps to and from a flat file representation
+//
+// A stepfile file consists of one or more steps of input text separated by
+// "---" lines.
+//
+// Example:
+//
+//      "step"
+//      ---
+//      "another step"
+//      ---
+//      "and another step"
+package stepfile
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/qri-io/dataset"
+)
+
+// ReadFile opens a stepfile and returns steps
+func ReadFile(filename string) (steps []*dataset.TransformStep, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Read(f)
+}
+
+// Read consumes a reader into steps
+func Read(r io.Reader) (steps []*dataset.TransformStep, err error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, chunk := range strings.Split(string(data), "\n---\n") {
+		steps = append(steps, &dataset.TransformStep{
+			Script: chunk,
+		})
+	}
+	return steps, nil
+}
+
+// Write prints transform steps as a stepfile to a writer
+func Write(steps []*dataset.TransformStep, w io.Writer) error {
+	for i, step := range steps {
+		if err := writeStepScript(step, w); err != nil {
+			return err
+		}
+		if i != len(steps)-1 {
+			w.Write([]byte("\n---\n"))
+		}
+	}
+	return nil
+}
+
+func writeStepScript(s *dataset.TransformStep, w io.Writer) error {
+	if r, ok := s.Script.(io.Reader); ok {
+		if closer, ok := s.Script.(io.Closer); ok {
+			defer closer.Close()
+		}
+		_, err := io.Copy(w, r)
+		return err
+	}
+
+	switch v := s.Script.(type) {
+	case string:
+		_, err := w.Write([]byte(v))
+		return err
+	case []byte:
+		_, err := w.Write(v)
+		return err
+	}
+	return fmt.Errorf("unrecognized script type: %T", s.Script)
+}

--- a/stepfile/stepfile_test.go
+++ b/stepfile/stepfile_test.go
@@ -1,0 +1,115 @@
+package stepfile
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/qri-io/dataset"
+)
+
+func TestRead(t *testing.T) {
+	cases := []struct {
+		inputFilename  string
+		expectFilename string
+	}{
+		{"steps.txt", "steps.json"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputFilename, func(t *testing.T) {
+			in := filepath.Join("./testdata", c.inputFilename)
+			expect := []*dataset.TransformStep{}
+			f, err := os.Open(filepath.Join("./testdata", c.expectFilename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := json.NewDecoder(f).Decode(&expect); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			got, err := ReadFile(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(expect, got); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("errors", func(t *testing.T) {
+		if _, err := ReadFile("unknown"); err == nil {
+			t.Error("expected error reading unknown file")
+		}
+	})
+}
+
+func TestWrite(t *testing.T) {
+	cases := []struct {
+		inputFilename  string
+		expectFilename string
+	}{
+		{"steps.json", "steps.txt"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputFilename, func(t *testing.T) {
+			data, err := ioutil.ReadFile(filepath.Join("./testdata", c.expectFilename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect := string(data)
+
+			input := []*dataset.TransformStep{}
+			f, err := os.Open(filepath.Join("./testdata", c.inputFilename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := json.NewDecoder(f).Decode(&input); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			buf := &bytes.Buffer{}
+			if err := Write(input, buf); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(expect, buf.String()); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("write from a reader", func(t *testing.T) {
+		steps := []*dataset.TransformStep{
+			{Script: bytes.NewBuffer([]byte("oh hai"))},
+			{Script: []byte("my friend")},
+		}
+		buf := &bytes.Buffer{}
+		if err := Write(steps, buf); err != nil {
+			t.Error(err)
+		}
+		expect := "oh hai\n---\nmy friend"
+		if diff := cmp.Diff(expect, buf.String()); diff != "" {
+			t.Errorf("result mismatch. (-want +got):\n %s", diff)
+		}
+	})
+
+	t.Run("bad scripts", func(t *testing.T) {
+		steps := []*dataset.TransformStep{
+			{Script: 2},
+		}
+		buf := &bytes.Buffer{}
+		if err := Write(steps, buf); err == nil {
+			t.Error("expected error, got none")
+		}
+	})
+}

--- a/stepfile/testdata/steps.json
+++ b/stepfile/testdata/steps.json
@@ -1,0 +1,11 @@
+[
+  {
+    "script": "I am a step"
+  },
+  {
+    "script": "I am another step"
+  },
+  {
+    "script": "I am a third step"
+  }
+]

--- a/stepfile/testdata/steps.txt
+++ b/stepfile/testdata/steps.txt
@@ -1,0 +1,5 @@
+I am a step
+---
+I am another step
+---
+I am a third step


### PR DESCRIPTION
this'll let us read/write transform files broken into steps. Borrows from a "convention" I've seen in a few places, most recently in [Starlark's internal testing package](https://github.com/google/starlark-go/blob/master/internal/chunkedfile/chunkedfile.go).

We can expand this in the future in two ways:
1. `Read()` returns three arguments: the parsed steps, _a struct of line offsets_, and an error. This offset struct would let us print out errors for input files that say things like `error on line 34 (step 2, line 1): missing separator`
2. Support _front matter_ on each step like syntax, title, and description that correspond to fields on `dataset.TransformStep`. The challenge here is picking a syntax for the front matter.

One possible example of front matter in the future: just use python/bash-style comments:

```
# syntax: starlark
# name: setup
# description: load dependencies

load("net/http.star", "http")
---
# syntax: starlark
# name: download
# description: download stuff from the internet

def download(ds, ctx):
  return http.get("foo.com/some.json").json()
```