### PR TITLE
refactor(validate): don't require structure to be valid

### DIFF
--- a/validate/dataset.go
+++ b/validate/dataset.go
@@ -23,12 +23,10 @@ func Dataset(ds *dataset.Dataset) error {
 		log.Debug(err.Error())
 		return err
 	}
-	if ds.Structure == nil {
-		err := fmt.Errorf("structure is required")
-		log.Debug(err.Error())
-		return err
-	} else if err := Structure(ds.Structure); err != nil {
-		return fmt.Errorf("structure: %s", err.Error())
+	if ds.Structure != nil {
+		if err := Structure(ds.Structure); err != nil {
+			return fmt.Errorf("structure: %s", err.Error())
+		}
 	}
 
 	return nil

--- a/validate/dataset_test.go
+++ b/validate/dataset_test.go
@@ -17,11 +17,7 @@ func TestDataset(t *testing.T) {
 	}{
 		{nil, ""},
 		{&dataset.Dataset{}, "commit is required"},
-		// {&dataset.Dataset{Commit: &dataset.Commit{}}, "commit: title is required"},
-		{&dataset.Dataset{Commit: &dataset.Commit{}}, "structure is required"},
-		{&dataset.Dataset{Commit: cm}, "structure is required"},
 		{&dataset.Dataset{Commit: cm, Structure: &dataset.Structure{}}, "structure: format is required"},
-		// {&dataset.Dataset{Commit: cm, Abstract: &dataset.Dataset{Metadata: &dataset.Metadata{}}}, "abstract field is not an abstract dataset. Metadata: nil: <not nil> != <nil>"},
 		{&dataset.Dataset{Commit: cm, Structure: st}, ""},
 	}
 


### PR DESCRIPTION
need to relax this requirement to allow datasets without a structure and body